### PR TITLE
remap

### DIFF
--- a/openbench/core/comparison/Mod_ClimateZone_Groupby.py
+++ b/openbench/core/comparison/Mod_ClimateZone_Groupby.py
@@ -158,6 +158,7 @@ class CZ_groupby(metrics, scores):
                             if not self._station_warning_shown:
                                 logging.warning(f"warning: station data is not supported for Climate zone class comparison")
                                 self._station_warning_shown = True
+                            continue  # Skip processing for station data
                         else:
                             dir_path = os.path.join(f'{basedir}', 'output', 'metrics', 'CZ_groupby',
                                                     f'{sim_source}___{ref_source}')

--- a/openbench/core/comparison/Mod_Landcover_Groupby.py
+++ b/openbench/core/comparison/Mod_Landcover_Groupby.py
@@ -144,7 +144,7 @@ class LC_groupby(metrics, scores):
                             if not self._igbp_station_warning_shown:
                                 logging.warning(f"warning: station data is not supported for IGBP class comparison")
                                 self._igbp_station_warning_shown = True
-                            pass
+                            continue  # Skip processing for station data
                         else:
                             dir_path = os.path.join(f'{basedir}', 'output', 'metrics', 'IGBP_groupby',
                                                     f'{sim_source}___{ref_source}')
@@ -415,6 +415,7 @@ class LC_groupby(metrics, scores):
                             if not self._pft_station_warning_shown:
                                 logging.warning(f"warning: station data is not supported for PFT class comparison")
                                 self._pft_station_warning_shown = True
+                            continue  # Skip processing for station data
                         else:
                             dir_path = os.path.join(f'{basedir}', 'output', 'metrics', 'PFT_groupby',
                                                     f'{sim_source}___{ref_source}')

--- a/openbench/openbench.py
+++ b/openbench/openbench.py
@@ -418,10 +418,21 @@ def run_evaluation(main_nl, sim_nml, ref_nml, evaluation_items, metric_vars, sco
                 if combination_key not in displayed_combinations:
                     ref_dataset_info = format_dataset_info(ref_source, ref_nml, evaluation_item)
                     sim_dataset_info = format_dataset_info(sim_source, sim_nml, evaluation_item)
-                    ref_type = "Station" if ref_nml[evaluation_item].get(f'{ref_source}_data_type') == 'stn' else "Grid"
-                    sim_type = "Station" if sim_nml[evaluation_item].get(f'{sim_source}_data_type') == 'stn' else "Grid"
-                    print(f"    Reference: {ref_source} ({ref_type})")
-                    print(f"    Simulation: {sim_source} ({sim_type})")
+                    # Get colors for data type highlighting
+                    colors = get_platform_colors()
+                    
+                    ref_data_type = ref_nml[evaluation_item].get(f'{ref_source}_data_type')
+                    sim_data_type = sim_nml[evaluation_item].get(f'{sim_source}_data_type')
+                    
+                    ref_type = "Station" if ref_data_type == 'stn' else "Grid"
+                    sim_type = "Station" if sim_data_type == 'stn' else "Grid"
+                    
+                    # Color code: Station = Orange/Yellow, Grid = Cyan/Blue
+                    ref_color = colors['yellow'] if ref_data_type == 'stn' else colors['cyan']
+                    sim_color = colors['yellow'] if sim_data_type == 'stn' else colors['cyan']
+                    
+                    print(f"    Reference: {ref_source} ({ref_color}{ref_type}{colors['reset']})")
+                    print(f"    Simulation: {sim_source} ({sim_color}{sim_type}{colors['reset']})")
                     displayed_combinations.add(combination_key)
                 
                 process_evaluation(onetimeref, main_nl, sim_nml, ref_nml, metric_vars, score_vars, comparison_vars,


### PR DESCRIPTION
  现在当遇到station data时，系统会：

  1. 显示警告 - 告知用户station data不支持该分析
  2. 跳过处理 - 不再进行不必要的remap操作
  3. 避免CDO调用 - 减少系统资源浪费和错误输出