### PR TITLE
Fix ruff lint: import order and line formatting

### DIFF
--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -32,7 +32,9 @@ def registry_model_profile(model_name: str):
         return None
 
 
-def model_definition_from_registry(model_name: str, selected_items: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
+def model_definition_from_registry(
+    model_name: str, selected_items: Optional[List[str]] = None
+) -> Optional[Dict[str, Any]]:
     """Build a model definition dict from the registry for export.
 
     Returns the legacy-shaped mapping (``general`` + one section per

--- a/src/openbench/gui/pages/page_preview.py
+++ b/src/openbench/gui/pages/page_preview.py
@@ -445,7 +445,9 @@ class PagePreview(BasePage):
                 raise RemoteNamelistSyncError(stderr.strip() or f"mkdir exit code {exit_code}")
 
             with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8") as tmp:
-                _yaml.dump(profile.to_dict(), tmp, default_flow_style=False, allow_unicode=True, sort_keys=False, indent=2)
+                _yaml.dump(
+                    profile.to_dict(), tmp, default_flow_style=False, allow_unicode=True, sort_keys=False, indent=2
+                )
                 tmp_path = tmp.name
             try:
                 remote_path = f"{remote_models_dir}/{model_name}.yaml"

--- a/src/openbench/gui/pages/page_ref_data.py
+++ b/src/openbench/gui/pages/page_ref_data.py
@@ -634,9 +634,7 @@ class PageRefData(BasePage):
         saved_data_root = general_section.get("data_root", "")
         if not saved_data_root:
             eval_items_cfg = self.controller.config.get("evaluation_items", {})
-            saved_data_root = _infer_ref_data_root(
-                general_section, [k for k, v in eval_items_cfg.items() if v]
-            )
+            saved_data_root = _infer_ref_data_root(general_section, [k for k, v in eval_items_cfg.items() if v])
         if saved_data_root:
             self.data_root_input.setText(saved_data_root)
 

--- a/tests/test_gui_scan_alignment_fixes.py
+++ b/tests/test_gui_scan_alignment_fixes.py
@@ -25,7 +25,6 @@ from openbench.gui.config_manager import (
 from openbench.gui.pages import page_sim_data
 from tests.gui_fakes import FakeLineEdit as _Text
 
-
 # ---------------------------------------------------------------------------
 # Bug 1 — scan root inference
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves the CI `ruff check` / `ruff format --check` failures introduced on 5523b09 ("Fix CLI exit, GUI scan, and registry exports").

Changes are formatting-only, no logic:
- `ruff format` line-wrapping in `gui/config_manager.py`, `gui/pages/page_preview.py`, `gui/pages/page_ref_data.py`
- import ordering (I001) in `tests/test_gui_scan_alignment_fixes.py`

Verification:
- `ruff check src/ tests/` → All checks passed
- `ruff format --check src/ tests/` → 355 files already formatted
- full suite: 1521 passed, 5 skipped