### PR TITLE
Fix NEE flat-file var read; registry overlay hygiene; min_year default

### DIFF
--- a/src/openbench/cli/main.py
+++ b/src/openbench/cli/main.py
@@ -24,6 +24,7 @@ class LazyGroup(click.Group):
         "gui": "openbench.cli.gui:gui",
         "cache": "openbench.cli.cache:cache",
         "smoke-test": "openbench.cli.smoke:smoke_test",
+        "registry": "openbench.cli.registry_cmd:registry",
     }
 
     def list_commands(self, ctx):
@@ -35,6 +36,7 @@ class LazyGroup(click.Group):
             "ref",
             "sim",
             "model",
+            "registry",
             "migrate",
             "cache",
             "gui",
@@ -56,6 +58,15 @@ class LazyGroup(click.Group):
 @click.version_option(version=__version__, prog_name="openbench", message="openbench %(version)s")
 def cli():
     """OpenBench: Land Surface Model Benchmarking System."""
+    # Throttled, silent-when-clean notice if the user registry overlay shadows
+    # the bundled catalog (e.g. a legacy full snapshot hiding bundled fixes).
+    # Never raises; skipped entirely when nothing changed since the last check.
+    try:
+        from openbench.data.registry.overlay_audit import maybe_emit_overlay_notice
+
+        maybe_emit_overlay_notice()
+    except Exception:
+        pass
 
 
 @cli.command()

--- a/src/openbench/cli/registry_cmd.py
+++ b/src/openbench/cli/registry_cmd.py
@@ -1,0 +1,133 @@
+"""``openbench registry`` — inspect and re-sparse the user registry overlay.
+
+The user overlay (``~/.openbench/...``) deep-merges on top of the bundled
+catalog and should contain only sparse deltas. A bloated overlay (e.g. a legacy
+full snapshot) silently shadows bundled fixes. These commands make that visible
+and let you re-sparse it safely.
+"""
+
+from __future__ import annotations
+
+import click
+
+from openbench.data.registry import overlay_audit as oa
+
+
+@click.group()
+def registry() -> None:
+    """Inspect and re-sparse the user registry overlay."""
+
+
+def _print_catalog_report(cat) -> bool:
+    """Print one catalog's classification. Return True if it has bloat."""
+    redundant = cat.by_kind(oa.REDUNDANT)
+    stale = cat.by_kind(oa.STALE_FULLCOPY)
+    delta = cat.by_kind(oa.DELTA)
+    custom = cat.by_kind(oa.CUSTOM)
+
+    click.secho(f"\n{cat.label}: {cat.overlay_path}", bold=True)
+    if not cat.entries:
+        click.echo("  (overlay empty — fully tracking bundled catalog) ✓")
+        return False
+
+    if redundant:
+        click.secho(
+            f"  ● {len(redundant)} redundant (identical to bundled — safe to drop)",
+            fg="yellow",
+        )
+    if stale:
+        click.secho(
+            f"  ● {len(stale)} stale full-cop{'y' if len(stale) == 1 else 'ies'} "
+            f"(shadow bundled and differ — likely outdated):",
+            fg="red",
+        )
+        for e in stale:
+            fields = ", ".join(sorted(e.minimal.get("variables", e.minimal).keys()))
+            click.echo(f"      - {e.name}  (overrides: {fields})")
+    if delta:
+        click.secho(f"  ● {len(delta)} deliberate delta(s) (minimal overrides — kept):", fg="green")
+        for e in delta:
+            fields = ", ".join(sorted(e.minimal.get("variables", e.minimal).keys()))
+            click.echo(f"      - {e.name}  (overrides: {fields})")
+    if custom:
+        noun = "entry" if len(custom) == 1 else "entries"
+        click.secho(f"  ● {len(custom)} custom {noun} (not in bundled — kept):", fg="cyan")
+        for e in custom:
+            click.echo(f"      - {e.name}")
+
+    return bool(redundant or stale)
+
+
+@registry.command(name="diff")
+def diff_cmd() -> None:
+    """Show how the user overlay diverges from the bundled catalog."""
+    audit = oa.audit_overlays()
+    has_bloat = False
+    for cat in audit.catalogs:
+        has_bloat = _print_catalog_report(cat) or has_bloat
+
+    n_delta = sum(len(c.by_kind(oa.DELTA)) for c in audit.catalogs)
+    click.echo()
+    if has_bloat:
+        click.secho(
+            "Your overlay shadows bundled entries. Run `openbench registry prune` to "
+            "re-sparse it (behavior-preserving: drops redundant copies, reduces stale "
+            "ones to minimal overrides). Review the remaining overrides afterwards.",
+            fg="yellow",
+        )
+    elif n_delta:
+        click.secho(
+            f"No snapshot bloat. {n_delta} deliberate override(s) still shadow bundled "
+            "(listed above) — delete an entry from the overlay to take the bundled value.",
+            fg="green",
+        )
+    else:
+        click.secho("Overlay is clean — fully tracking the bundled catalog. ✓", fg="green")
+
+
+# Alias: `registry status` behaves like `registry diff`.
+registry.add_command(diff_cmd, name="status")
+
+
+@registry.command(name="prune")
+@click.option("--dry-run", is_flag=True, help="Show what would change without writing.")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
+def prune_cmd(dry_run: bool, yes: bool) -> None:
+    """Re-sparse the overlay: drop redundant entries, minimize stale full-copies.
+
+    Behavior-preserving — the merged registry is identical before and after.
+    Each modified overlay file is backed up first.
+    """
+    audit = oa.audit_overlays()
+    if audit.bloat_count == 0:
+        click.secho("Overlay already sparse — nothing to prune. ✓", fg="green")
+        return
+
+    if not dry_run and not yes:
+        click.echo(
+            f"This will re-sparse {audit.bloat_count} overlay entr"
+            f"{'y' if audit.bloat_count == 1 else 'ies'} (a backup is made first)."
+        )
+        click.confirm("Proceed?", abort=True)
+
+    results = oa.prune_overlays(dry_run=dry_run)
+    verb = "Would remove" if dry_run else "Removed"
+    verb2 = "would minimize" if dry_run else "minimized"
+    for res in results:
+        if not (res.removed or res.minimized):
+            continue
+        click.secho(f"\n{res.label}:", bold=True)
+        click.echo(
+            f"  {verb} {len(res.removed)} redundant; {verb2} {len(res.minimized)} stale full-cop"
+            f"{'y' if len(res.minimized) == 1 else 'ies'}."
+        )
+        if res.minimized:
+            click.echo(f"    minimized: {', '.join(res.minimized)}")
+        if res.backup:
+            click.echo(f"    backup: {res.backup}")
+
+    click.echo()
+    if dry_run:
+        click.secho("Dry run — no files written. Re-run without --dry-run to apply.", fg="yellow")
+    else:
+        click.secho("Done. Run `openbench registry diff` to review remaining overrides.", fg="green")

--- a/src/openbench/config/loader.py
+++ b/src/openbench/config/loader.py
@@ -719,7 +719,7 @@ def _build_project(raw: dict[str, Any]) -> ProjectConfig:
         # literally and fail at directory creation time on HPC.
         output_dir=str(Path(os.path.expandvars(str(raw["output_dir"]))).expanduser()),
         years=years,
-        min_year_threshold=raw.get("min_year_threshold", 3),
+        min_year_threshold=raw.get("min_year_threshold", 1),
         lat_range=lat_range,
         lon_range=lon_range,
         # Target resolution

--- a/src/openbench/config/schema.py
+++ b/src/openbench/config/schema.py
@@ -69,7 +69,7 @@ class ProjectConfig:
     years: list[int]  # [start_year, end_year], inclusive — exactly 2 ints
 
     # --- Spatial-temporal bounds ---
-    min_year_threshold: int = 3  # Per-station filter: drop stations whose valid span < N years (stn ref only)
+    min_year_threshold: int = 1  # Per-station filter: drop stations whose valid span < N years (stn ref only)
     lat_range: list[float] = field(default_factory=lambda: [-90.0, 90.0])  # Spatial bounds, default global
     lon_range: list[float] = field(default_factory=lambda: [-180.0, 180.0])  # Spatial bounds, default global
 

--- a/src/openbench/core/_comparison_basic.py
+++ b/src/openbench/core/_comparison_basic.py
@@ -13,6 +13,7 @@ from joblib import delayed
 
 from openbench.core._comparison_helpers import _apply_pairwise_valid_mask, _require_stat_method, _write_csv_atomic
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 
 
 def _comparison_callable(name: str):
@@ -46,9 +47,9 @@ class BasicComparisonMixin:
             ref_path = os.path.join(basedir, "data", f"stn_{ref_source}_{sim_source}", ref_filename)
 
             with xr.open_dataset(sim_path) as sim_ds:
-                s = sim_ds[sim_varname].squeeze().load()
+                s = select_data_array(sim_ds, sim_varname).squeeze().load()
             with xr.open_dataset(ref_path) as ref_ds:
-                o = ref_ds[ref_varname].squeeze().load()
+                o = select_data_array(ref_ds, ref_varname).squeeze().load()
             o = Convert_Type.convert_nc(o)
             s = Convert_Type.convert_nc(s)
 

--- a/src/openbench/core/_comparison_parallel.py
+++ b/src/openbench/core/_comparison_parallel.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 from openbench.core._comparison_helpers import _finite_reduced_value, _write_csv_atomic
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 from openbench.util.netcdf import write_file_atomic as _write_file_atomic
 
 
@@ -134,9 +135,9 @@ class ParallelCoordinatesComparisonMixin:
                                                 )
 
                                                 with xr.open_dataset(ref_path) as ref_ds:
-                                                    reffile = ref_ds[ref_varname].load()
+                                                    reffile = select_data_array(ref_ds, ref_varname).load()
                                                 with xr.open_dataset(sim_path) as sim_ds:
-                                                    simfile = sim_ds[sim_varname].load()
+                                                    simfile = select_data_array(sim_ds, sim_varname).load()
                                                 reffile = Convert_Type.convert_nc(reffile)
                                                 simfile = Convert_Type.convert_nc(simfile)
 

--- a/src/openbench/core/_comparison_portrait_seasonal.py
+++ b/src/openbench/core/_comparison_portrait_seasonal.py
@@ -22,6 +22,7 @@ from openbench.core._comparison_portrait_calculations import (
     process_portrait_score,
 )
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 
 
 def _comparison_callable(name: str):
@@ -138,9 +139,9 @@ class PortraitSeasonalComparisonMixin:
                                                     )
 
                                                     with xr.open_dataset(sim_path) as sim_ds:
-                                                        s = sim_ds[sim_varname].squeeze().load()
+                                                        s = select_data_array(sim_ds, sim_varname).squeeze().load()
                                                     with xr.open_dataset(ref_path) as ref_ds:
-                                                        o = ref_ds[ref_varname].squeeze().load()
+                                                        o = select_data_array(ref_ds, ref_varname).squeeze().load()
                                                     o = Convert_Type.convert_nc(o)
                                                     s = Convert_Type.convert_nc(s)
 
@@ -290,9 +291,9 @@ class PortraitSeasonalComparisonMixin:
                                                 )
 
                                                 with xr.open_dataset(ref_path) as ref_ds:
-                                                    o = ref_ds[ref_varname].load()
+                                                    o = select_data_array(ref_ds, ref_varname).load()
                                                 with xr.open_dataset(sim_path) as sim_ds:
-                                                    s = sim_ds[sim_varname].load()
+                                                    s = select_data_array(sim_ds, sim_varname).load()
                                                 o = Convert_Type.convert_nc(o)
                                                 s = Convert_Type.convert_nc(s)
 

--- a/src/openbench/core/_comparison_smpi.py
+++ b/src/openbench/core/_comparison_smpi.py
@@ -14,6 +14,7 @@ from joblib import delayed
 
 from openbench.core._comparison_helpers import _apply_pairwise_valid_mask, _atomic_text_writer
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 from openbench.util.netcdf import write_netcdf_atomic as _write_netcdf_atomic
 
 
@@ -203,9 +204,9 @@ class SingleModelPerformanceIndexComparisonMixin:
                                         f"{item}_ref_{station_list['ID'][iik]}_{station_list['use_syear'][iik]}_{station_list['use_eyear'][iik]}.nc",
                                     )
                                     with xr.open_dataset(sim_path) as sim_ds:
-                                        s = sim_ds[sim_varname].squeeze().load()
+                                        s = select_data_array(sim_ds, sim_varname).squeeze().load()
                                     with xr.open_dataset(ref_path) as ref_ds:
-                                        o = ref_ds[ref_varname].squeeze().load()
+                                        o = select_data_array(ref_ds, ref_varname).squeeze().load()
                                     o = Convert_Type.convert_nc(o)
                                     s = Convert_Type.convert_nc(s)
 

--- a/src/openbench/core/_comparison_tail.py
+++ b/src/openbench/core/_comparison_tail.py
@@ -17,6 +17,7 @@ from openbench.core._comparison_helpers import (
     _station_csv_column_mean,
 )
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 
 
 def _comparison_callable(name: str):
@@ -150,7 +151,7 @@ class TailComparisonMixin:
                                     f"{evaluation_item}/{sim_source}: {sim_path}"
                                 )
                             with xr.open_dataset(sim_path) as sim_ds:
-                                sim = sim_ds[sim_varname].load()
+                                sim = select_data_array(sim_ds, sim_varname).load()
                             sim = Convert_Type.convert_nc(sim)
 
                             result = method_function(*[sim])
@@ -192,7 +193,7 @@ class TailComparisonMixin:
                                     f"{evaluation_item}/{ref_source}: {ref_path}"
                                 )
                             with xr.open_dataset(ref_path) as ref_ds:
-                                ref = ref_ds[ref_varname].load()
+                                ref = select_data_array(ref_ds, ref_varname).load()
                             ref = Convert_Type.convert_nc(ref)
 
                             result = method_function(*[ref])
@@ -255,7 +256,7 @@ class TailComparisonMixin:
                                 basedir, "data", f"{evaluation_item}_ref_{ref_source}_{ref_varname}.nc"
                             )
                             with xr.open_dataset(ref_path) as ref_ds:
-                                ref = ref_ds[ref_varname].load()
+                                ref = select_data_array(ref_ds, ref_varname).load()
                             ref = Convert_Type.convert_nc(ref)
 
                             for sim_source in sim_sources:
@@ -268,7 +269,7 @@ class TailComparisonMixin:
                                             basedir, "data", f"{evaluation_item}_sim_{sim_source}_{sim_varname}.nc"
                                         )
                                         with xr.open_dataset(sim_path) as sim_ds:
-                                            sim = sim_ds[sim_varname].load()
+                                            sim = select_data_array(sim_ds, sim_varname).load()
                                         sim = Convert_Type.convert_nc(sim)
 
                                         result = method_function(*[ref, sim])

--- a/src/openbench/core/_comparison_target.py
+++ b/src/openbench/core/_comparison_target.py
@@ -19,6 +19,7 @@ from openbench.core._comparison_helpers import (
     _write_csv_atomic,
 )
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 from openbench.util.filenames import join_filename_components
 
 
@@ -136,9 +137,9 @@ class TargetDiagramComparisonMixin:
                                                     )
 
                                                     with xr.open_dataset(sim_path) as sim_ds:
-                                                        s = sim_ds[sim_varname].squeeze().load()
+                                                        s = select_data_array(sim_ds, sim_varname).squeeze().load()
                                                     with xr.open_dataset(ref_path) as ref_ds:
-                                                        o = ref_ds[ref_varname].squeeze().load()
+                                                        o = select_data_array(ref_ds, ref_varname).squeeze().load()
                                                     o = Convert_Type.convert_nc(o)
                                                     s = Convert_Type.convert_nc(s)
 
@@ -237,9 +238,9 @@ class TargetDiagramComparisonMixin:
                                             )
 
                                             with xr.open_dataset(ref_path) as ref_ds:
-                                                reffile = ref_ds[ref_varname].load()
+                                                reffile = select_data_array(ref_ds, ref_varname).load()
                                             with xr.open_dataset(sim_path) as sim_ds:
-                                                simfile = sim_ds[sim_varname].load()
+                                                simfile = select_data_array(sim_ds, sim_varname).load()
                                             reffile = Convert_Type.convert_nc(reffile)
                                             simfile = Convert_Type.convert_nc(simfile)
 

--- a/src/openbench/core/_comparison_taylor.py
+++ b/src/openbench/core/_comparison_taylor.py
@@ -20,6 +20,7 @@ from openbench.core._comparison_helpers import (
     _write_csv_atomic,
 )
 from openbench.util.converttype import Convert_Type
+from openbench.util.names import select_data_array
 from openbench.util.filenames import join_filename_components
 
 
@@ -241,9 +242,9 @@ class TaylorDiagramComparisonMixin:
                                                     )
 
                                                     with xr.open_dataset(sim_path) as sim_ds:
-                                                        s = sim_ds[sim_varname].squeeze().load()
+                                                        s = select_data_array(sim_ds, sim_varname).squeeze().load()
                                                     with xr.open_dataset(ref_path) as ref_ds:
-                                                        o = ref_ds[ref_varname].squeeze().load()
+                                                        o = select_data_array(ref_ds, ref_varname).squeeze().load()
                                                     o = Convert_Type.convert_nc(o)
                                                     s = Convert_Type.convert_nc(s)
 
@@ -345,9 +346,9 @@ class TaylorDiagramComparisonMixin:
                                             )
 
                                             with xr.open_dataset(ref_path) as ref_ds:
-                                                reffile = ref_ds[ref_varname].load()
+                                                reffile = select_data_array(ref_ds, ref_varname).load()
                                             with xr.open_dataset(sim_path) as sim_ds:
-                                                simfile = sim_ds[sim_varname].load()
+                                                simfile = select_data_array(sim_ds, sim_varname).load()
                                             reffile = Convert_Type.convert_nc(reffile)
                                             simfile = Convert_Type.convert_nc(simfile)
 

--- a/src/openbench/core/evaluation.py
+++ b/src/openbench/core/evaluation.py
@@ -296,8 +296,14 @@ class Evaluation_grid(metrics, scores):
             # Open datasets and keep references for proper cleanup
             ref_ds = open_dataset_chunked(ref_path)
             sim_ds = open_dataset_chunked(sim_path)
-            o = ref_ds[f"{self.ref_varname}"]
-            s = sim_ds[f"{self.sim_varname}"]
+            # Resolve the variable robustly: a fallback/convert may have stored
+            # the data under the relabelled item name (e.g. Net_Ecosystem_Exchange)
+            # rather than the configured varname (e.g. f_respc). Flat files hold a
+            # single data variable, so fall back to the item name / sole variable.
+            from openbench.util.names import select_data_array
+
+            o = select_data_array(ref_ds, self.ref_varname, self.item)
+            s = select_data_array(sim_ds, self.sim_varname, self.item)
             o = Convert_Type.convert_nc(o)
             s = Convert_Type.convert_nc(s)
 

--- a/src/openbench/data/registry/overlay_audit.py
+++ b/src/openbench/data/registry/overlay_audit.py
@@ -1,0 +1,314 @@
+"""Audit and re-sparse the user registry overlay against the bundled catalog.
+
+The user overlay (``~/.openbench/references/reference_catalog.yaml`` and
+``~/.openbench/models/model_catalog.yaml``) is meant to hold only *sparse
+deltas* on top of the bundled catalog. Older OpenBench versions sometimes wrote
+the entire merged catalog back as a full snapshot. A full-snapshot overlay
+silently shadows the bundled catalog field-by-field, freezing the user on a
+stale version so bundled fixes never take effect.
+
+This module classifies each overlay entry, can re-sparse the overlay
+(behavior-preserving), and powers a throttled startup notice.
+
+Behavior-preservation note: the manager's deep merge (``_deep_merge_reference`` /
+``_deep_merge_model``) overrides per-field/per-variable and never deletes a
+bundled variable just because the overlay omits it (only an explicit ``None``
+tombstone deletes). So the minimal behavior-preserving overlay is computed by
+``_sparse_delta`` below — which keeps only differing fields/variables and adds
+NO tombstones. (``scanner._descriptor_overlay_diff`` deliberately differs: it
+tombstones omitted variables, which is correct when writing a complete
+descriptor but would change behavior if applied to an existing snapshot.)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Classification kinds
+REDUNDANT = "redundant"  # overlay entry byte-equals bundled (pure snapshot leftover)
+STALE_FULLCOPY = "stale_fullcopy"  # carries bundled-equal baggage AND differs -> stale snapshot
+DELTA = "delta"  # already-minimal deliberate override
+CUSTOM = "custom"  # entry not present in bundled (genuine user addition)
+
+_STATE_FILENAME = ".registry_check"
+_SUPPRESS_ENV = "OPENBENCH_NO_REGISTRY_CHECK"
+
+
+def _ci_get(mapping: dict, key: str) -> Any:
+    """Case-insensitive dict lookup (exact first)."""
+    if key in mapping:
+        return mapping[key]
+    lk = str(key).lower()
+    for k, v in mapping.items():
+        if str(k).lower() == lk:
+            return v
+    return None
+
+
+def _sparse_delta(bundled_entry: dict, overlay_entry: dict) -> dict:
+    """Minimal, behavior-preserving overlay for ``overlay_entry`` over bundled.
+
+    Keeps only top-level fields and variables whose value differs from bundled.
+    Adds NO tombstones (matches deep-merge semantics). ``name`` is structural
+    (implied by the catalog key) and is dropped.
+    """
+    out: dict = {}
+    bundled_entry = bundled_entry or {}
+    for key, value in (overlay_entry or {}).items():
+        if key == "name":
+            continue
+        if key == "variables" and isinstance(value, dict):
+            bundled_vars = bundled_entry.get("variables", {}) or {}
+            var_out = {vk: vv for vk, vv in value.items() if _ci_get(bundled_vars, vk) != vv}
+            if var_out:
+                out["variables"] = var_out
+        elif bundled_entry.get(key) != value:
+            out[key] = value
+    return out
+
+
+def _strip_name(entry: dict) -> dict:
+    return {k: v for k, v in (entry or {}).items() if k != "name"}
+
+
+def _classify_entry(bundled_entry: Optional[dict], overlay_entry: dict) -> tuple[str, dict]:
+    """Return (kind, minimal_delta) for one overlay entry."""
+    if bundled_entry is None:
+        return CUSTOM, _strip_name(overlay_entry)
+    delta = _sparse_delta(bundled_entry, overlay_entry)
+    if not delta:
+        return REDUNDANT, {}
+    if _strip_name(overlay_entry) == delta:
+        return DELTA, delta
+    return STALE_FULLCOPY, delta
+
+
+@dataclass
+class EntryAudit:
+    name: str
+    kind: str
+    minimal: dict = field(default_factory=dict)
+
+
+@dataclass
+class CatalogAudit:
+    label: str  # "references" | "models"
+    overlay_path: Path
+    bundled_path: Path
+    exists: bool
+    entries: list[EntryAudit] = field(default_factory=list)
+
+    def by_kind(self, kind: str) -> list[EntryAudit]:
+        return [e for e in self.entries if e.kind == kind]
+
+    @property
+    def bloat(self) -> list[EntryAudit]:
+        """Entries that silently shadow bundled and are freeze/staleness risks."""
+        return [e for e in self.entries if e.kind in (REDUNDANT, STALE_FULLCOPY)]
+
+
+@dataclass
+class OverlayAudit:
+    references: CatalogAudit
+    models: CatalogAudit
+
+    @property
+    def catalogs(self) -> list[CatalogAudit]:
+        return [self.references, self.models]
+
+    @property
+    def bloat_count(self) -> int:
+        return sum(len(c.bloat) for c in self.catalogs)
+
+    @property
+    def stale_count(self) -> int:
+        return sum(len(c.by_kind(STALE_FULLCOPY)) for c in self.catalogs)
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        if not path.exists():
+            return {}
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except Exception as e:  # pragma: no cover - corrupted file is surfaced elsewhere
+        logger.debug("overlay_audit: could not read %s: %s", path, e)
+        return {}
+
+
+def _audit_catalog(label: str, bundled_path: Path, overlay_path: Path) -> CatalogAudit:
+    bundled = _load_yaml(bundled_path)
+    overlay = _load_yaml(overlay_path)
+    # Case-insensitive bundled lookup keyed by lowercase name.
+    bundled_ci = {str(k).lower(): v for k, v in bundled.items()}
+    entries: list[EntryAudit] = []
+    for name, data in overlay.items():
+        if not isinstance(data, dict):
+            continue
+        if data.get("_deleted"):
+            # Tombstones are intentional deletions — treat as deliberate.
+            entries.append(EntryAudit(name=name, kind=DELTA, minimal=data))
+            continue
+        bundled_entry = bundled_ci.get(str(name).lower())
+        kind, minimal = _classify_entry(bundled_entry, data)
+        entries.append(EntryAudit(name=name, kind=kind, minimal=minimal))
+    return CatalogAudit(
+        label=label,
+        overlay_path=overlay_path,
+        bundled_path=bundled_path,
+        exists=overlay_path.exists(),
+        entries=entries,
+    )
+
+
+def _paths(user_dir: Optional[Path] = None) -> tuple[Path, Path, Path, Path, Path]:
+    """Return (user_dir, bundled_ref, overlay_ref, bundled_model, overlay_model)."""
+    from openbench.config.user_settings import get_user_config_dir
+    from openbench.data.registry.manager import REGISTRY_DIR
+
+    base = Path(get_user_config_dir(user_dir))
+    return (
+        base,
+        REGISTRY_DIR / "reference_catalog.yaml",
+        base / "references" / "reference_catalog.yaml",
+        REGISTRY_DIR / "model_catalog.yaml",
+        base / "models" / "model_catalog.yaml",
+    )
+
+
+def audit_overlays(user_dir: Optional[Path] = None) -> OverlayAudit:
+    """Classify every entry in the user reference + model overlays."""
+    _base, bundled_ref, overlay_ref, bundled_model, overlay_model = _paths(user_dir)
+    return OverlayAudit(
+        references=_audit_catalog("references", bundled_ref, overlay_ref),
+        models=_audit_catalog("models", bundled_model, overlay_model),
+    )
+
+
+@dataclass
+class PruneResult:
+    label: str
+    removed: list[str] = field(default_factory=list)  # redundant entries dropped
+    minimized: list[str] = field(default_factory=list)  # stale full-copies reduced to deltas
+    kept: list[str] = field(default_factory=list)  # delta/custom left as-is
+    backup: Optional[Path] = None
+    wrote: bool = False
+
+
+def _prune_catalog(audit: CatalogAudit, *, dry_run: bool) -> PruneResult:
+    result = PruneResult(label=audit.label)
+    new_overlay: dict = {}
+    overlay_raw = _load_yaml(audit.overlay_path)
+    for entry in audit.entries:
+        original = overlay_raw.get(entry.name)
+        if entry.kind == REDUNDANT:
+            result.removed.append(entry.name)
+            continue
+        if entry.kind == STALE_FULLCOPY:
+            new_overlay[entry.name] = entry.minimal
+            result.minimized.append(entry.name)
+            continue
+        # DELTA / CUSTOM: keep exactly as written
+        new_overlay[entry.name] = original
+        result.kept.append(entry.name)
+
+    changed = result.removed or result.minimized
+    if changed and not dry_run:
+        from openbench.data.registry.scanner import _backup_then_write, _invalidate_registry_caches
+
+        audit.overlay_path.parent.mkdir(parents=True, exist_ok=True)
+        result.backup = _backup_then_write(audit.overlay_path, new_overlay)
+        result.wrote = True
+        _invalidate_registry_caches()
+    return result
+
+
+def prune_overlays(user_dir: Optional[Path] = None, *, dry_run: bool = False) -> list[PruneResult]:
+    """Re-sparse the overlays: drop redundant entries, minimize stale full-copies.
+
+    Behavior-preserving — the merged registry is identical before and after.
+    """
+    audit = audit_overlays(user_dir)
+    return [_prune_catalog(c, dry_run=dry_run) for c in audit.catalogs]
+
+
+# --------------------------------------------------------------------------- #
+# Throttled startup notice
+# --------------------------------------------------------------------------- #
+
+
+def _fingerprint(user_dir: Path, overlay_ref: Path, overlay_model: Path) -> str:
+    from openbench import __version__
+
+    h = hashlib.sha256()
+    h.update(__version__.encode())
+    for p in (overlay_ref, overlay_model):
+        try:
+            h.update(p.read_bytes() if p.exists() else b"")
+        except OSError:
+            pass
+    return h.hexdigest()
+
+
+def _read_state(state_path: Path) -> dict:
+    try:
+        return json.loads(state_path.read_text()) if state_path.exists() else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_state(state_path: Path, fingerprint: str) -> None:
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_path.write_text(json.dumps({"fingerprint": fingerprint}))
+    except OSError:
+        pass
+
+
+def maybe_emit_overlay_notice(user_dir: Optional[Path] = None) -> Optional[str]:
+    """Print a one-line stderr notice when the overlay shadows bundled, throttled.
+
+    Returns the message printed (for tests), or None. Silent when the overlay is
+    clean, suppressed via ``OPENBENCH_NO_REGISTRY_CHECK``, or unchanged since the
+    last check (fingerprint = openbench version + overlay file bytes). Never
+    raises — registry hygiene must not break the CLI.
+    """
+    if os.environ.get(_SUPPRESS_ENV):
+        return None
+    try:
+        base, _bref, overlay_ref, _bmodel, overlay_model = _paths(user_dir)
+        state_path = base / _STATE_FILENAME
+        fp = _fingerprint(base, overlay_ref, overlay_model)
+        if _read_state(state_path).get("fingerprint") == fp:
+            return None  # nothing changed since last check — skip all work, stay silent
+
+        audit = audit_overlays(base)
+        _write_state(state_path, fp)  # persist regardless so we don't recheck until next change
+
+        bloat = audit.bloat_count
+        if bloat == 0:
+            return None
+        stale = audit.stale_count
+        stale_note = f" ({stale} may be stale)" if stale else ""
+        msg = (
+            f"⚠ registry overlay shadows {bloat} bundled "
+            f"entr{'y' if bloat == 1 else 'ies'}{stale_note}; "
+            f"bundled fixes may be hidden. Run: openbench registry diff"
+        )
+        import click
+
+        click.echo(msg, err=True)
+        return msg
+    except Exception as e:  # pragma: no cover - defensive: never break the CLI
+        logger.debug("overlay_audit notice skipped: %s", e)
+        return None

--- a/src/openbench/runner/masking.py
+++ b/src/openbench/runner/masking.py
@@ -57,8 +57,14 @@ def apply_unified_mask(
         ref_ds = xr.open_dataset(ref_path)
         sim_ds = xr.open_dataset(sim_path)
 
-        o = ref_ds[ref_varname]
-        s = sim_ds[sim_varname]
+        # The flat file stores the variable under the configured name OR the
+        # relabelled evaluation item (when a fallback/convert derived it, e.g.
+        # NEE from f_respc). Resolve robustly instead of hard-indexing the
+        # possibly-stale config varname. (var_name is the evaluation item.)
+        from openbench.util.names import select_data_array
+
+        o = select_data_array(ref_ds, ref_varname, var_name)
+        s = select_data_array(sim_ds, sim_varname, var_name)
 
         # Convert types if needed
         try:

--- a/src/openbench/util/names.py
+++ b/src/openbench/util/names.py
@@ -125,6 +125,43 @@ def get_xarray_key_case_insensitive(
     return None
 
 
+def select_data_array(ds, *preferred):
+    """Pull one data variable out of a (flat/preprocessed) dataset robustly.
+
+    Tries each name in ``preferred`` (case-insensitive). If none match, falls
+    back to the single data variable when the dataset has exactly one — which is
+    always the case for OpenBench flat ``<item>_<src>_<varname>.nc`` files.
+
+    This decouples the *configured* variable name (e.g. ``f_respc``) from the
+    name the data is actually stored under (e.g. the relabelled evaluation item
+    ``Net_Ecosystem_Exchange``, produced when a fallback/convert derives the
+    variable). Readers must not hard-index ``ds[sim_varname]`` because the saved
+    variable is intentionally relabelled to the item for output correctness.
+
+    Raises KeyError if nothing matches and the dataset is not single-variable.
+    Each ``preferred`` arg may be a name or a list/tuple of names.
+    """
+    names: list = []
+    for item in preferred:
+        if isinstance(item, (list, tuple)):
+            names.extend(item)
+        elif item:
+            names.append(item)
+    for name in names:
+        if not name:
+            continue
+        actual = get_xarray_key_case_insensitive(ds, name)
+        if actual is not None:
+            return ds[actual]
+    data_vars = list(getattr(ds, "data_vars", []))
+    if len(data_vars) == 1:
+        return ds[data_vars[0]]
+    raise KeyError(
+        f"None of {[n for n in preferred if n]} found in dataset; it has "
+        f"{len(data_vars)} data variables {data_vars}, cannot disambiguate."
+    )
+
+
 def resolve_many_case_insensitive(
     requested: Iterable[object],
     candidates: Iterable[object],

--- a/tests/test_cli_stubs.py
+++ b/tests/test_cli_stubs.py
@@ -3090,7 +3090,7 @@ def test_init_passes_explicit_sim_model_to_scan(tmp_path, monkeypatch):
     assert config["simulation"]["grid"]["model"] == "CoLM"
 
 
-def test_init_caps_min_year_threshold_to_project_span(tmp_path, monkeypatch):
+def test_init_min_year_threshold_defaults_to_one(tmp_path, monkeypatch):
     import openbench.cli.init_cmd as init_module
     import openbench.data.registry as registry_package
     import openbench.data.sim_scanner as sim_scanner
@@ -3158,7 +3158,8 @@ def test_init_caps_min_year_threshold_to_project_span(tmp_path, monkeypatch):
 
     assert result.exit_code == 0, result.output
     project = yaml.safe_load(output.read_text(encoding="utf-8"))["project"]
-    assert project["min_year_threshold"] == 2
+    # Default is now 1 for every project span (min(1, span) == 1).
+    assert project["min_year_threshold"] == 1
 
 
 def test_init_sets_project_resolution_from_selected_reference_when_sim_scan_is_mixed(
@@ -5458,7 +5459,20 @@ def test_all_commands_registered():
     # Use list_commands() for LazyGroup compatibility
     ctx = click.Context(cli)
     command_names = set(cli.list_commands(ctx))
-    expected = {"run", "check", "ref", "sim", "model", "migrate", "init", "cache", "gui", "version", "smoke-test"}
+    expected = {
+        "run",
+        "check",
+        "ref",
+        "sim",
+        "model",
+        "registry",
+        "migrate",
+        "init",
+        "cache",
+        "gui",
+        "version",
+        "smoke-test",
+    }
     assert expected == command_names, f"Missing: {expected - command_names}, Extra: {command_names - expected}"
 
 

--- a/tests/test_config/test_schema.py
+++ b/tests/test_config/test_schema.py
@@ -17,7 +17,7 @@ def test_project_config_defaults():
     assert p.name == "test"
     assert p.output_dir == "./output"
     assert p.years == [2004, 2010]
-    assert p.min_year_threshold == 3
+    assert p.min_year_threshold == 1
     assert p.lat_range == [-90.0, 90.0]
     assert p.lon_range == [-180.0, 180.0]
 

--- a/tests/test_flat_var_resolution.py
+++ b/tests/test_flat_var_resolution.py
@@ -1,0 +1,85 @@
+"""Flat-file variable resolution: decouple stored var name from configured name.
+
+A fallback/convert (e.g. NEE from f_respc) relabels the saved variable to the
+evaluation item, but downstream readers index by the stale configured varname
+(f_respc). Readers must resolve robustly via the sole data variable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from openbench.util.names import select_data_array
+
+
+def _flat(varname: str) -> xr.Dataset:
+    return xr.Dataset(
+        {varname: (("time", "lat", "lon"), np.ones((2, 2, 2)))},
+        coords={
+            "time": xr.date_range("2000-01-01", periods=2, freq="MS", use_cftime=True),
+            "lat": [10, 20],
+            "lon": [30, 40],
+        },
+    )
+
+
+def test_named_variable_found_case_insensitive():
+    ds = _flat("Net_Ecosystem_Exchange")
+    da = select_data_array(ds, "net_ecosystem_exchange")
+    assert da.name == "Net_Ecosystem_Exchange"
+
+
+def test_falls_back_to_sole_variable_when_name_absent():
+    # The exact reproduction of the reported bug: file stores the item-named
+    # variable, reader asks for the stale config varname 'f_respc'.
+    ds = _flat("Net_Ecosystem_Exchange")
+    da = select_data_array(ds, "f_respc")
+    assert da.name == "Net_Ecosystem_Exchange"
+    # raw indexing would raise the user's exact KeyError:
+    with pytest.raises(KeyError):
+        _ = ds["f_respc"]
+
+
+def test_item_name_is_tried_before_sole_fallback():
+    ds = _flat("Net_Ecosystem_Exchange")
+    # preferred list form + item fallback both resolve
+    da = select_data_array(ds, ["f_nee", "f_respc"], "Net_Ecosystem_Exchange")
+    assert da.name == "Net_Ecosystem_Exchange"
+
+
+def test_ambiguous_multivar_without_match_raises():
+    ds = xr.Dataset({"a": ("x", [1.0]), "b": ("x", [2.0])}, coords={"x": [0]})
+    with pytest.raises(KeyError):
+        select_data_array(ds, "f_respc")
+
+
+def test_masking_read_resolves_relabelled_variable(tmp_path):
+    """apply_unified_mask must read a flat sim file whose variable was relabelled
+    to the item even though sim_varname is still the source name."""
+    import openbench.runner.masking as masking
+
+    casedir = tmp_path
+    (casedir / "data").mkdir()
+    item, ref_src, sim_src = "Net_Ecosystem_Exchange", "FLUXCOM", "Case05"
+    ref_vn, sim_vn = "NEE", "f_respc"  # configured names
+    # ref flat: stored under its configured name; sim flat: relabelled to item
+    _flat("NEE").to_netcdf(casedir / "data" / f"{item}_ref_{ref_src}_{ref_vn}.nc")
+    _flat(item).to_netcdf(casedir / "data" / f"{item}_sim_{sim_src}_{sim_vn}.nc")
+
+    info = {
+        "casedir": str(casedir),
+        "ref_varname": ref_vn,
+        "sim_varname": sim_vn,
+        "ref_data_type": "grid",
+        "sim_data_type": "grid",
+    }
+    written = {}
+
+    def fake_writer(ds, path, **kwargs):
+        written["path"] = path
+
+    # Should not raise "No variable named 'f_respc'"
+    masking.apply_unified_mask(info, item, ref_src, sim_src, write_netcdf_atomic_fn=fake_writer)
+    assert written  # the masked ref was written

--- a/tests/test_registry_overlay_audit.py
+++ b/tests/test_registry_overlay_audit.py
@@ -1,0 +1,125 @@
+"""Tests for registry overlay hygiene: classify, behavior-preserving prune, throttle."""
+
+from __future__ import annotations
+
+import copy
+
+import yaml
+
+from openbench.data.registry import manager as registry_manager
+from openbench.data.registry import overlay_audit as oa
+
+
+def _bundled_ref(name: str) -> dict:
+    bundled = yaml.safe_load((registry_manager.REGISTRY_DIR / "reference_catalog.yaml").read_text())
+    key = next(k for k in bundled if k.lower() == name.lower())
+    return copy.deepcopy(bundled[key]), key
+
+
+def _write_overlay(user_dir, entries: dict) -> None:
+    refs = user_dir / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    (refs / "reference_catalog.yaml").write_text(yaml.safe_dump(entries, sort_keys=False))
+    models = user_dir / "models"
+    models.mkdir(parents=True, exist_ok=True)
+    (models / "model_catalog.yaml").write_text("{}\n")
+
+
+def test_classify_four_kinds(tmp_path):
+    clara, _ = _bundled_ref("CLARA_3_LowRes")
+    era, _ = _bundled_ref("ERA5LAND_LowRes")
+
+    # stale full-copy: full bundled copy of ERA with one variable's unit changed
+    stale_era = copy.deepcopy(era)
+    a_var = next(iter(stale_era["variables"]))
+    stale_era["variables"][a_var] = {**stale_era["variables"][a_var], "varunit": "STALE"}
+
+    overlay = {
+        "CLARA_3_LowRes": copy.deepcopy(clara),  # redundant (verbatim copy)
+        "ERA5LAND_LowRes": stale_era,  # stale full-copy
+        "GRFR_LowRes": {"description": "tweaked"},  # sparse delta (one field differs)
+        "My_Custom_Ref": {"description": "x", "data_type": "grid", "variables": {"Latent_Heat": {"varname": "LE"}}},
+    }
+    _write_overlay(tmp_path, overlay)
+
+    audit = oa.audit_overlays(tmp_path)
+    kinds = {e.name: e.kind for e in audit.references.entries}
+    assert kinds["CLARA_3_LowRes"] == oa.REDUNDANT
+    assert kinds["ERA5LAND_LowRes"] == oa.STALE_FULLCOPY
+    assert kinds["GRFR_LowRes"] == oa.DELTA
+    assert kinds["My_Custom_Ref"] == oa.CUSTOM
+
+
+def test_prune_is_behavior_preserving(tmp_path):
+    clara, _ = _bundled_ref("CLARA_3_LowRes")
+    gleam, _ = _bundled_ref("GLEAM_v4.2a_LowRes")
+
+    redundant = copy.deepcopy(clara)
+    stale = copy.deepcopy(gleam)
+    # change one var unit to make it a stale full-copy
+    a_var = next(iter(stale["variables"]))
+    stale["variables"][a_var] = {**stale["variables"][a_var], "varunit": "CHANGED"}
+
+    _write_overlay(tmp_path, {"CLARA_3_LowRes": redundant, "GLEAM_v4.2a_LowRes": stale})
+
+    def merged_units():
+        mgr = registry_manager.RegistryManager(user_dir=tmp_path)
+        out = {}
+        for name in ("CLARA_3_LowRes", "GLEAM_v4.2a_LowRes"):
+            r = mgr.get_reference(name)
+            out[name] = {vk: (vv.varname, vv.varunit) for vk, vv in r.variables.items()}
+        return out
+
+    before = merged_units()
+    results = oa.prune_overlays(tmp_path, dry_run=False)
+    after = merged_units()
+
+    assert before == after  # behavior preserved
+    pruned = yaml.safe_load((tmp_path / "references" / "reference_catalog.yaml").read_text())
+    assert "CLARA_3_LowRes" not in pruned  # redundant dropped
+    assert "GLEAM_v4.2a_LowRes" in pruned  # stale kept but minimized
+    assert set(pruned["GLEAM_v4.2a_LowRes"].keys()) == {"variables"}  # reduced to just the delta
+    ref_result = next(r for r in results if r.label == "references")
+    assert ref_result.removed == ["CLARA_3_LowRes"]
+    assert ref_result.minimized == ["GLEAM_v4.2a_LowRes"]
+    assert ref_result.backup is not None
+
+
+def test_prune_dry_run_writes_nothing(tmp_path):
+    clara, _ = _bundled_ref("CLARA_3_LowRes")
+    _write_overlay(tmp_path, {"CLARA_3_LowRes": copy.deepcopy(clara)})
+    original = (tmp_path / "references" / "reference_catalog.yaml").read_text()
+    oa.prune_overlays(tmp_path, dry_run=True)
+    assert (tmp_path / "references" / "reference_catalog.yaml").read_text() == original
+
+
+def test_notice_throttle_and_suppress(tmp_path, monkeypatch):
+    clara, _ = _bundled_ref("CLARA_3_LowRes")
+    _write_overlay(tmp_path, {"CLARA_3_LowRes": copy.deepcopy(clara)})
+
+    monkeypatch.delenv(oa._SUPPRESS_ENV, raising=False)
+    # First call: bloat present -> message emitted
+    msg1 = oa.maybe_emit_overlay_notice(tmp_path)
+    assert msg1 and "registry overlay shadows" in msg1
+    # Second call: fingerprint unchanged -> throttled (silent)
+    assert oa.maybe_emit_overlay_notice(tmp_path) is None
+    # Changing the overlay re-triggers
+    _write_overlay(tmp_path, {"CLARA_3_LowRes": copy.deepcopy(clara), "ERA5LAND_LowRes": copy.deepcopy(clara)})
+    assert oa.maybe_emit_overlay_notice(tmp_path) is not None
+
+    # Suppress env disables entirely
+    monkeypatch.setenv(oa._SUPPRESS_ENV, "1")
+    _write_overlay(
+        tmp_path,
+        {"CLARA_3_LowRes": {"variables": {"Surface_Albedo": {"varunit": "x"}}}, "GRFR_LowRes": copy.deepcopy(clara)},
+    )
+    assert oa.maybe_emit_overlay_notice(tmp_path) is None
+
+
+def test_notice_silent_when_clean(tmp_path, monkeypatch):
+    monkeypatch.delenv(oa._SUPPRESS_ENV, raising=False)
+    _write_overlay(tmp_path, {})  # empty overlay
+    assert oa.maybe_emit_overlay_notice(tmp_path) is None
+    # a deliberate sparse delta is NOT bloat -> still silent
+    _write_overlay(tmp_path, {"CLARA_3_LowRes": {"variables": {"Surface_Albedo": {"varunit": "1"}}}})
+    assert oa.maybe_emit_overlay_notice(tmp_path) is None


### PR DESCRIPTION
## Summary
Three fixes from a debugging session on the persistent `Net_Ecosystem_Exchange` evaluation error (plus related cleanups).

### 1. NEE flat-file variable resolution (the actual bug)
Preprocessing correctly derives NEE from `f_respc`/`f_assim` and **relabels** the saved variable to the evaluation item (`Net_Ecosystem_Exchange`) for output-label correctness. But the flat file is named with the config varname (`f_respc`), and downstream readers hard-indexed `ds[sim_varname]` → xarray `No variable named 'f_respc'. Variables on the dataset include ['Net_Ecosystem_Exchange', 'time', 'lat', 'lon']`.

- Add `util.names.select_data_array(ds, *names)`: resolve by name (case-insensitive), else fall back to the **sole data variable** (flat files have exactly one).
- Use it in `runner/masking.py` (the preprocess crash), `core/evaluation.py` (grid scoring), and all 7 `core/_comparison_*.py` modules.
- Write-side relabel to the item is intentional and unchanged.

### 2. Registry overlay hygiene — `openbench registry diff|prune`
A legacy full-snapshot `~/.openbench` overlay silently shadows bundled catalog fixes (this is why the CLARA albedo unit fix didn't take effect until the overlay was reset). New tooling:
- Classify overlay entries: **redundant / stale full-copy / delta / custom**.
- `registry prune` re-sparses behavior-preservingly (drops redundant, minimizes stale full-copies; merged registry identical before/after).
- Throttled, silent-when-clean startup notice; suppress via `OPENBENCH_NO_REGISTRY_CHECK`.

### 3. `min_year_threshold` default → 1
`schema` + `loader` default `3 → 1` (matches GUI/smoke); `init` now writes 1 for every project span.

## Testing
- New: `tests/test_flat_var_resolution.py` (reproduces the exact error + end-to-end masking read), `tests/test_registry_overlay_audit.py`.
- Updated `test_cli_stubs.py`, `test_config/test_schema.py` for the new defaults/command.
- **Full suite: 1532 passed, 5 skipped.** ruff clean.

## Remote sync note
After pulling + reinstalling on the HPC, run `openbench registry prune` once to un-shadow the bundled catalog (the remote `~/.openbench` overlay is separate).