### PR TITLE
Release normal build 3.0.0b12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.0b12] - 2026-08-18
+
+Beta release over 3.0.0b11 for reliable generated station configuration.
+
+### Fixed
+- `openbench init` and `openbench sim scan` now write absolute station
+  `fulllist` paths so generated YAML works from any current directory.
+
 ## [3.0.0b11] - 2026-08-13
 
 Beta release over 3.0.0b10 for GUI dataset discovery, registry coverage, and

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ conda install -c conda-forge colm-openbench
 mamba install -c conda-forge colm-openbench   # or the faster mamba
 ```
 
-> **Note:** the current release is a Beta pre-release (`3.0.0b11`) and is **not on
+> **Note:** the current release is a Beta pre-release (`3.0.0b12`) and is **not on
 > conda-forge yet**. Until it is, use one of the two paths below.
 
 If your platform does not have wheels for geospatial dependencies such as

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b11" %}
+{% set version = "3.0.0b12" %}
 
 package:
   name: {{ name|lower }}

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b11"
+__version__ = "3.0.0b12"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"

--- a/src/openbench/cli/init_cmd.py
+++ b/src/openbench/cli/init_cmd.py
@@ -695,7 +695,7 @@ def _scan_simulation_config(
         )
     if project_years is not None:
         _warn_simulation_case_year_coverage(result.cases, project_years)
-    return _simulation_yaml(result, sim_path=output)["simulation"]
+    return _simulation_yaml(result)["simulation"]
 
 
 def _prompt_manual_simulations(mgr) -> dict:

--- a/src/openbench/cli/sim.py
+++ b/src/openbench/cli/sim.py
@@ -203,7 +203,7 @@ def scan(
             )
             click.secho(f"Wrote draft model profile {catalog_path}", fg="green", bold=True)
 
-        _atomic_yaml_write(sim_path, _simulation_yaml(result, sim_path=sim_path))
+        _atomic_yaml_write(sim_path, _simulation_yaml(result))
         _atomic_yaml_write(report_path, _report_yaml(result, case_depth=case_depth))
 
     finally:
@@ -559,8 +559,8 @@ def _apply_temporal_kind_candidate(case) -> None:
     case.provenance["tim_res"] = "climatology"
 
 
-def _simulation_yaml(result, *, sim_path: Path | None = None) -> dict:
-    entries = {case.label: _case_simulation_entry(case, sim_path=sim_path) for case in result.cases}
+def _simulation_yaml(result) -> dict:
+    entries = {case.label: _case_simulation_entry(case) for case in result.cases}
     defaults = _common_defaults(entries)
     if defaults:
         for entry in entries.values():
@@ -570,22 +570,13 @@ def _simulation_yaml(result, *, sim_path: Path | None = None) -> dict:
     return {"simulation": entries}
 
 
-def _portable_artifact_path(path: Path | None, sim_path: Path | None) -> str | None:
+def _absolute_artifact_path(path: Path | None) -> str | None:
     if path is None:
         return None
-    target = Path(path)
-    if sim_path is not None:
-        try:
-            base = Path(sim_path).expanduser().resolve().parent
-            rel = Path(os.path.relpath(target.expanduser().resolve(), start=base)).as_posix()
-            if not rel.startswith(".."):
-                return rel
-        except (OSError, ValueError):
-            pass
-    return str(target)
+    return str(Path(path).expanduser().resolve())
 
 
-def _case_simulation_entry(case, *, sim_path: Path | None = None) -> dict:
+def _case_simulation_entry(case) -> dict:
     entry = {
         "model": case.model,
         "root_dir": str(case.root_dir),
@@ -605,7 +596,7 @@ def _case_simulation_entry(case, *, sim_path: Path | None = None) -> dict:
     if getattr(case, "variable_overrides", None):
         entry["variables"] = case.variable_overrides
     if getattr(case, "fulllist", None):
-        entry["fulllist"] = _portable_artifact_path(case.fulllist, sim_path)
+        entry["fulllist"] = _absolute_artifact_path(case.fulllist)
     return entry
 
 

--- a/tests/test_cli_sim_scan.py
+++ b/tests/test_cli_sim_scan.py
@@ -117,6 +117,7 @@ def test_sim_scan_station_collection_writes_fulllist_and_merged_station_files(
     assert "suffix" not in entry
 
     fulllist = Path(entry["fulllist"])
+    assert fulllist.is_absolute()
     assert fulllist.exists()
     rows = pd.read_csv(fulllist)
     assert sorted(rows["ID"]) == ["US-AAA", "US-BBB"]
@@ -162,8 +163,7 @@ def test_sim_scan_default_station_output_follows_explicit_output_parent(
     sim_data = yaml.safe_load(output_path.read_text(encoding="utf-8"))
     raw_fulllist = sim_data["simulation"]["CaseA"]["fulllist"]
     fulllist = Path(raw_fulllist)
-    if not fulllist.is_absolute():
-        fulllist = (output_path.parent / fulllist).resolve()
+    assert fulllist.is_absolute()
     assert fulllist.parent.parent == output_dir / "foo_sim_station_lists"
     assert not list(cwd.glob("openbench_sim_scan_station_lists_*"))
 

--- a/tests/test_cli_stubs.py
+++ b/tests/test_cli_stubs.py
@@ -4460,7 +4460,7 @@ def test_scan_simulation_config_prompts_for_model_when_auto_inference_is_unresol
     assert simulation["Case01"]["model"] == "CoLM"
 
 
-def test_scan_simulation_config_writes_portable_station_fulllist(tmp_path, monkeypatch):
+def test_scan_simulation_config_writes_absolute_station_fulllist(tmp_path, monkeypatch):
     import openbench.cli.init_cmd as init_module
     import openbench.data.sim_scanner as sim_scanner
     from openbench.data.sim_scanner import SimulationCase, SimulationScanResult
@@ -4503,7 +4503,8 @@ def test_scan_simulation_config_writes_portable_station_fulllist(tmp_path, monke
     )
 
     assert materialize_calls == [(tmp_path / "configs" / "openbench_sim_station_lists", {"allow_partial": False})]
-    assert simulation["Case01"]["fulllist"] == "openbench_sim_station_lists/Case01/Case01_stations.csv"
+    expected = tmp_path / "configs" / "openbench_sim_station_lists" / "Case01" / "Case01_stations.csv"
+    assert simulation["Case01"]["fulllist"] == str(expected)
 
 
 def test_scan_simulation_config_aborts_on_partial_station_materialization(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

- write generated station `fulllist` paths as absolute paths in both `openbench init` and `openbench sim scan`
- bump the normal package, README, changelog, and conda metadata to `3.0.0b12`

## Why

The previous relative artifact path could fail when the generated YAML was executed from a different current directory.

## Release scope

This is the normal build for PyPI. The uncertainty-aware implementation remains isolated on `feature/uncertainty-aware-evaluation` and is not included in these artifacts.

## Validation

- `pytest -q` — 1625 passed, 5 skipped
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m compileall -q src tests`
- isolated sdist/wheel build and Twine 7 check
- wheel import smoke test
- archive audit confirming uncertainty-only modules are absent
