### PR TITLE
[codex] Release 3.0.0b13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [3.0.0b13] - 2026-08-22
+
+Beta release over 3.0.0b12 for safer configuration, registration, and GUI
+workflows.
+
+### Added
+- Chinese/English GUI switching with immediate page retranslation.
+- Back navigation throughout interactive CLI setup and registration wizards.
+
+### Changed
+- GUI evaluations now run the same CLI preflight check before execution.
+- Reference rescans distinguish new and registered datasets, default to new
+  entries, and enrich only explicitly selected registered datasets.
+- CLI registration accepts quoted whitespace-containing units in named
+  `key=value` variable specifications and provides actionable shell guidance.
+
+### Fixed
+- CLI and GUI preflight reject evaluations whose configured years do not
+  overlap the available data period.
+- Reference rescans preserve manual catalog corrections and keep remote refresh
+  work responsive and narrowly targeted.
+- Multi-step CLI back navigation retains previously entered values across
+  variables and empty intermediate steps.
+- Cross-platform CI behavior for paths, generated artifacts, and GUI tests.
+
 ## [3.0.0b12] - 2026-08-18
 
 Beta release over 3.0.0b11 for reliable generated station configuration.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ conda install -c conda-forge colm-openbench
 mamba install -c conda-forge colm-openbench   # or the faster mamba
 ```
 
-> **Note:** the current release is a Beta pre-release (`3.0.0b12`) and is **not on
+> **Note:** the current release is a Beta pre-release (`3.0.0b13`) and is **not on
 > conda-forge yet**. Until it is, use one of the two paths below.
 
 If your platform does not have wheels for geospatial dependencies such as

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b12" %}
+{% set version = "3.0.0b13" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: 5b83a941b71b2fb74d4983972acbd35e131502dcdf49f2c5461dcc52c327c02d
+  sha256: f2ada6c0018ed3b2f61393087020d222467fac5ad3597a58cef8273b75275e30
 
 build:
   noarch: python

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b12"
+__version__ = "3.0.0b13"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"


### PR DESCRIPTION
## What changed

- bump OpenBench to `3.0.0b13`
- document the GUI localization, CLI back navigation, safer reference rescans, registration parsing, and temporal preflight fixes shipped since `3.0.0b12`
- update the conda recipe to the final sdist SHA-256

## Why

The fixes already verified on `main` need a new immutable package version before they can be installed from PyPI.

## User impact

Users receive the new CLI/GUI safeguards through a normal `pip install --pre --upgrade colm-openbench` update.

## Validation

- `ruff check .`
- `ruff format --check src tests`
- `pytest -q` — 1665 passed, 5 skipped
- `python -m build`
- `python -m twine check dist/*`
- `pytest tests/test_build_artifacts.py -q` — 8 passed
- wheel and sdist metadata both report `3.0.0b13`
- conda SHA-256 matches the final sdist
