### PR TITLE
[codex] Release 3.0.0b14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.0.0b14] - 2026-08-22
+
+Beta release over 3.0.0b13 for actionable GUI preflight diagnostics.
+
+### Fixed
+- GUI configuration-check failures now include the complete CLI check output,
+  so validation details are not hidden by the final summary lines.
+
 ## [3.0.0b13] - 2026-08-22
 
 Beta release over 3.0.0b12 for safer configuration, registration, and GUI

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ conda install -c conda-forge colm-openbench
 mamba install -c conda-forge colm-openbench   # or the faster mamba
 ```
 
-> **Note:** the current release is a Beta pre-release (`3.0.0b13`) and is **not on
+> **Note:** the current release is a Beta pre-release (`3.0.0b14`) and is **not on
 > conda-forge yet**. Until it is, use one of the two paths below.
 
 If your platform does not have wheels for geospatial dependencies such as

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b13" %}
+{% set version = "3.0.0b14" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: f2ada6c0018ed3b2f61393087020d222467fac5ad3597a58cef8273b75275e30
+  sha256: 9c12511f54ef6e48d2c8120860d056cb7998f833fa42228d68c2875deae42be9
 
 build:
   noarch: python

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b13"
+__version__ = "3.0.0b14"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"


### PR DESCRIPTION
## What changed

- bump OpenBench to `3.0.0b14`
- document the GUI configuration-check diagnostic fix
- update the conda recipe to the verified sdist SHA-256

## Why

GUI preflight failures previously retained only the final five CLI output lines, which could hide the concrete validation error behind the generic configuration summary.

## User impact

GUI users now receive the complete CLI check output when preflight fails, including specific errors such as non-overlapping data years.

## Validation

- `ruff check .`
- `ruff format --check src tests`
- `pytest -q` — 1665 passed, 5 skipped
- `python -m build`
- `python -m twine check dist/*`
- `pytest tests/test_build_artifacts.py -q` — 8 passed
- wheel and sdist metadata both report `3.0.0b14`
- conda SHA-256 matches the verified sdist
