### PR TITLE
Prevent GUI runtime stalls and restore independent groupby runs

### DIFF
--- a/src/openbench/data/coordinates.py
+++ b/src/openbench/data/coordinates.py
@@ -139,7 +139,9 @@ def find_lon_name(names) -> str | None:
 
 # --- NetCDF file extensions ---
 
-NC_EXTENSIONS: tuple[str, ...] = ("*.nc", "*.nc4", "*.NC", "*.NC4")
+# Raw extension strings for use in regex and os.path patterns.
+NC_SUFFIXES: tuple[str, ...] = (".nc", ".nc4", ".NC", ".NC4")
+NC_EXTENSIONS: tuple[str, ...] = tuple(f"*{suffix}" for suffix in NC_SUFFIXES)
 
 
 def glob_nc(directory, recursive: bool = False) -> list:
@@ -155,17 +157,13 @@ def glob_nc(directory, recursive: bool = False) -> list:
     from pathlib import Path
 
     d = Path(directory)
-    results = []
-    for ext in NC_EXTENSIONS:
-        if recursive:
-            results.extend(d.rglob(ext))
-        else:
-            results.extend(d.glob(ext))
-    return sorted(set(results))
-
-
-# Raw extension strings for use in regex and os.path patterns.
-NC_SUFFIXES: tuple[str, ...] = (".nc", ".nc4", ".NC", ".NC4")
+    if not d.is_dir():
+        return []
+    try:
+        paths = d.rglob("*") if recursive else d.iterdir()
+        return sorted(path for path in paths if path.is_file() and path.suffix in NC_SUFFIXES)
+    except OSError:
+        return []
 
 
 def glob_nc_pattern(pattern: str) -> list[str]:

--- a/src/openbench/data/sim_scanner.py
+++ b/src/openbench/data/sim_scanner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime
 from fnmatch import fnmatch
@@ -20,6 +21,30 @@ from openbench.data.registry.scanner import (
 )
 
 DEFAULT_CASE_DEPTH = 5
+_SCAN_CACHE: ContextVar[dict | None] = ContextVar("openbench_sim_scan_cache", default=None)
+
+
+def _glob_nc(directory: Path) -> list[Path]:
+    cache = _SCAN_CACHE.get()
+    key = ("glob_nc", Path(directory))
+    if cache is not None and key in cache:
+        return cache[key]
+    result = glob_nc(directory)
+    if cache is not None:
+        cache[key] = result
+    return result
+
+
+def _scan_nc_info(directory: Path) -> dict:
+    cache = _SCAN_CACHE.get()
+    key = ("scan_nc_info", Path(directory))
+    if cache is not None and key in cache:
+        return dict(cache[key])
+    result = inspect_nc_file(directory)
+    if cache is not None:
+        cache[key] = dict(result)
+    return result
+
 
 _DEFAULT_EXCLUDES = {
     "__pycache__",
@@ -113,23 +138,27 @@ def scan_simulation_roots(
     exclude_patterns = tuple(_DEFAULT_EXCLUDES | {str(item) for item in exclude})
     cases: list[SimulationCase] = []
 
-    for root in root_paths:
-        for case_dir, metadata_dir, depth, station_layout in _iter_case_dirs(root, case_depth, exclude_patterns):
-            label = _derive_case_label(root, case_dir)
-            if case_pattern and not fnmatch(label, case_pattern):
-                continue
-            cases.append(
-                _build_case(
-                    root,
-                    case_dir,
-                    metadata_dir,
-                    label,
-                    depth,
-                    model_name,
-                    climatology,
-                    station_layout=station_layout,
+    token = _SCAN_CACHE.set({})
+    try:
+        for root in root_paths:
+            for case_dir, metadata_dir, depth, station_layout in _iter_case_dirs(root, case_depth, exclude_patterns):
+                label = _derive_case_label(root, case_dir)
+                if case_pattern and not fnmatch(label, case_pattern):
+                    continue
+                cases.append(
+                    _build_case(
+                        root,
+                        case_dir,
+                        metadata_dir,
+                        label,
+                        depth,
+                        model_name,
+                        climatology,
+                        station_layout=station_layout,
+                    )
                 )
-            )
+    finally:
+        _SCAN_CACHE.reset(token)
 
     cases.sort(key=lambda case: (case.label, str(case.root_dir)))
     _deduplicate_case_labels(cases)
@@ -148,10 +177,10 @@ def _build_case(
     *,
     station_layout: str | None = None,
 ) -> SimulationCase:
-    info = inspect_nc_file(metadata_dir)
+    info = _scan_nc_info(metadata_dir)
     multi_undated = _has_multiple_no_date_files(metadata_dir) and not station_layout
     if multi_undated:
-        common_prefix, common_suffix = _common_stem_affixes(glob_nc(metadata_dir))
+        common_prefix, common_suffix = _common_stem_affixes(_glob_nc(metadata_dir))
         info["prefix"] = common_prefix
         info["suffix"] = common_suffix
     if station_layout:
@@ -257,7 +286,7 @@ def _infer_time_coverage(
     files: list[Path] | None = None,
     data_groupby: str | None = None,
 ) -> dict:
-    files = files if files is not None else glob_nc(nc_dir)
+    files = files if files is not None else _glob_nc(nc_dir)
     if not files:
         return {}
 
@@ -375,11 +404,11 @@ def _infer_station_time_coverage(case_dir: Path, metadata_dir: Path, station_lay
     if station_layout == "flat":
         coverages = [
             _infer_time_coverage(metadata_dir, files=[file_path], data_groupby="Single")
-            for file_path in glob_nc(metadata_dir)
+            for file_path in _glob_nc(metadata_dir)
         ]
     else:
         coverages = [
-            _infer_time_coverage(nc_dir, files=glob_nc(nc_dir), data_groupby="Single")
+            _infer_time_coverage(nc_dir, files=_glob_nc(nc_dir), data_groupby="Single")
             for nc_dir in _station_child_nc_dirs(case_dir)
         ]
     return _combine_station_time_coverages(coverages)
@@ -433,7 +462,7 @@ def _add_months(value: datetime, months: int) -> datetime:
 
 def _files_for_filename_pattern(nc_dir: Path, prefix: str, suffix: str) -> list[Path]:
     files = []
-    for file_path in glob_nc(nc_dir):
+    for file_path in _glob_nc(nc_dir):
         stem = file_path.stem
         date_match = filename_split_match(stem)
         if date_match:
@@ -448,7 +477,7 @@ def _files_for_filename_pattern(nc_dir: Path, prefix: str, suffix: str) -> list[
 
 
 def _has_multiple_no_date_files(nc_dir: Path) -> bool:
-    files = glob_nc(nc_dir)
+    files = _glob_nc(nc_dir)
     if len(files) <= 1:
         return False
     return not any(most_specific_date_matches(file_path.stem) for file_path in files)
@@ -477,7 +506,7 @@ def _files_for_case_time_coverage(nc_dir: Path, *, info: dict) -> list[Path]:
     no date token, prefix/suffix cannot describe a time stream, so use all files
     to avoid treating the first arbitrary filename as the whole case.
     """
-    files = glob_nc(nc_dir)
+    files = _glob_nc(nc_dir)
     if len(files) <= 1:
         return files
 
@@ -502,7 +531,7 @@ def _infer_variable_file_overrides(
 ) -> dict[str, dict[str, Any]]:
     if not model or model == "UNRESOLVED":
         return {}
-    files = glob_nc(nc_dir)
+    files = _glob_nc(nc_dir)
     if len(files) < 2:
         return {}
     patterns = {_filename_pattern_for_file(file_path) for file_path in files}
@@ -800,7 +829,7 @@ def _per_bucket_variable_metadata(
     if station_layout:
         return base_metadata
 
-    files = glob_nc(metadata_dir)
+    files = _glob_nc(metadata_dir)
     if len(files) <= 1:
         return base_metadata
 
@@ -1065,7 +1094,7 @@ def _infer_tim_res_from_filename(nc_dir: Path) -> str | None:
     """Match unambiguous frequency tokens; single-letter ``m/d/h`` are excluded
     because filename labels (config codes, experiment IDs) trigger them too
     aggressively. ``hr`` is kept because it is widely used as ``3hr/6hr``."""
-    stems = [file_path.stem.lower() for file_path in glob_nc(nc_dir)]
+    stems = [file_path.stem.lower() for file_path in _glob_nc(nc_dir)]
     for stem in stems:
         if re.search(r"(^|[^a-z0-9])(hourly|hour|hr)(?=[^a-z0-9]|$)", stem):
             return "Hour"
@@ -1118,13 +1147,13 @@ def _infer_temporal_kind(
 
 def _has_climatology_hint(nc_dir: Path) -> bool:
     parts = [part.lower() for part in nc_dir.parts]
-    parts.extend(file_path.stem.lower() for file_path in glob_nc(nc_dir))
+    parts.extend(file_path.stem.lower() for file_path in _glob_nc(nc_dir))
     hints = ("clim", "climatology", "climatological")
     return any(any(hint in part for hint in hints) for part in parts)
 
 
 def _infer_file_grouping(nc_dir: Path) -> tuple[str, list[int] | None]:
-    files = glob_nc(nc_dir)
+    files = _glob_nc(nc_dir)
     token_lengths = []
     for file_path in files:
         matches = most_specific_date_matches(file_path.stem)
@@ -1193,11 +1222,11 @@ def _years_from_files(files: list[Path]) -> list[int] | None:
 
 def _years_from_station_collection(case_dir: Path) -> list[int] | None:
     years = []
-    direct_years = _years_from_files(glob_nc(case_dir))
+    direct_years = _years_from_files(_glob_nc(case_dir))
     if direct_years:
         years.extend(direct_years)
     for nc_dir in _station_child_nc_dirs(case_dir):
-        file_years = _years_from_files(glob_nc(nc_dir))
+        file_years = _years_from_files(_glob_nc(nc_dir))
         if file_years:
             years.extend(file_years)
     if not years:
@@ -1460,7 +1489,7 @@ def _children_are_date_subdir_layout(children: list[Path]) -> bool:
     for child in children:
         if not _is_date_dir_name(child.name):
             return False
-        if glob_nc(child):
+        if _glob_nc(child):
             found_with_nc = True
         else:
             return False
@@ -1501,14 +1530,14 @@ def _iter_case_dirs(
             for child in children
             if not _is_excluded(child, exclude_patterns) and _resolve_dir(child) not in visited
         ]
-        direct_nc = bool(glob_nc(current))
+        direct_nc = bool(_glob_nc(current))
 
         if not direct_nc and _children_are_date_subdir_layout(children):
             yield current, children[0], depth, None
             continue
 
         if direct_nc:
-            sibling_cases = [child for child in children if glob_nc(child) or _station_collection_info(child)[0]]
+            sibling_cases = [child for child in children if _glob_nc(child) or _station_collection_info(child)[0]]
             if len(sibling_cases) >= 2 and depth < max_depth:
                 for child in reversed(children):
                     stack.append((child, depth + 1))
@@ -1523,9 +1552,9 @@ def _iter_case_dirs(
 
 
 def _station_collection_info(path: Path) -> tuple[str | None, Path | None]:
-    direct_files = glob_nc(path)
+    direct_files = _glob_nc(path)
     if direct_files:
-        info = inspect_nc_file(path)
+        info = _scan_nc_info(path)
         if info.get("detected_data_type") == "stn":
             return "flat", path
         return None, None
@@ -1536,10 +1565,10 @@ def _station_collection_info(path: Path) -> tuple[str | None, Path | None]:
 
     inspected = []
     for nc_dir in child_dirs:
-        info = inspect_nc_file(nc_dir)
+        info = _scan_nc_info(nc_dir)
         if info.get("detected_data_type") != "stn":
             return None, None
-        inspected.append((nc_dir, len(glob_nc(nc_dir)), info))
+        inspected.append((nc_dir, len(_glob_nc(nc_dir)), info))
 
     if not inspected:
         return None, None
@@ -1579,7 +1608,7 @@ def _station_child_nc_dirs(path: Path) -> list[Path]:
 
 
 def _station_nc_dir_has_time(nc_dir: Path) -> bool:
-    files = glob_nc(nc_dir)
+    files = _glob_nc(nc_dir)
     if not files:
         return False
     info = _time_info_from_file(files[0])
@@ -1624,7 +1653,7 @@ def _station_dir_matches_site_identity(collection_root: Path, nc_dir: Path) -> b
     if not normalized_site:
         return False
 
-    for file_path in glob_nc(nc_dir):
+    for file_path in _glob_nc(nc_dir):
         station_id = _station_identity_from_nc(file_path)
         if station_id and _identity_token(station_id) == normalized_site:
             return True

--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -613,7 +613,8 @@ class ConfigManager:
 
         if general.get("comparison"):
             selected_comparisons = [k for k, v in config.get("comparisons", {}).items() if v]
-            if not selected_comparisons:
+            groupby_enabled = any(general.get(key) for key in ("IGBP_groupby", "PFT_groupby", "Climate_zone_groupby"))
+            if not selected_comparisons and not groupby_enabled:
                 errors.append("At least one comparison item must be selected when comparison is enabled")
 
         if general.get("statistics"):

--- a/src/openbench/gui/localization.py
+++ b/src/openbench/gui/localization.py
@@ -93,7 +93,7 @@ ZH_CN = {
     "Scan a directory for simulation cases, assign models, and select cases to evaluate": "扫描模拟案例目录、分配模型并选择要评估的案例",
     "Reference Data": "参考数据",
     "Configure reference data sources for each evaluation variable": "为每个评估变量配置参考数据源",
-    "Evaluation": "评估",
+    "Evaluation": "评估变量",
     "Evaluation Items": "评估项目",
     "Select the variables to evaluate": "选择要评估的变量",
     "Carbon Cycle": "碳循环",

--- a/src/openbench/gui/main_window.py
+++ b/src/openbench/gui/main_window.py
@@ -115,6 +115,7 @@ class MainWindow(QMainWindow):
         # === Sidebar ===
         sidebar = QWidget()
         sidebar.setObjectName("sidebar")
+        sidebar.setFixedWidth(220)
         sidebar.setStyleSheet("QWidget#sidebar { background-color: #2d2d2d; }")
         sidebar_layout = QVBoxLayout(sidebar)
         sidebar_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/openbench/gui/progress_parser.py
+++ b/src/openbench/gui/progress_parser.py
@@ -65,18 +65,30 @@ def parse_progress_line(
     if sim_match:
         state["current_sim"] = next(group for group in sim_match.groups() if group).strip(":,")
 
+    completed_eval_match = re.search(
+        r"\bcompleted\s+([^:]+):.*?\bsim\s*[=:]\s*([^\s,;]+).*?\bref\s*[=:]\s*([^\s,;]+)",
+        line,
+        re.IGNORECASE,
+    )
+    if completed_eval_match:
+        state["current_variable"] = completed_eval_match.group(1).strip()
+        state["current_sim"] = completed_eval_match.group(2).strip(":,")
+        state["current_ref"] = completed_eval_match.group(3).strip(":,")
+        var = state["current_variable"]
+        stage = "Evaluation"
+
     # Detect stage
-    if "evaluation" in line_lower and "item" not in line_lower:
+    if not stage and "evaluation" in line_lower and "item" not in line_lower:
         stage = "Evaluation"
     elif "comparison" in line_lower or "groupby" in line_lower:
         stage = "Comparison"
-        if "done running" in line_lower and "comparison" in line_lower:
-            match = re.search(r"done running\s+(\w+)\s+comparison", line_lower)
-            if match:
-                comp_name = match.group(1)
-                state["completed_comparison_tasks"].add(comp_name)
+        comparison_done = re.search(r"(?:done running|completed)\s+([\w-]+)\s+comparison", line_lower)
+        if comparison_done:
+            state["completed_comparison_tasks"].add(comparison_done.group(1))
     elif "statistic" in line_lower:
         stage = "Statistics"
+    elif "report" in line_lower:
+        stage = "Report"
 
     # Detect task completions
     task_completed = False
@@ -89,7 +101,7 @@ def parse_progress_line(
 
     for groupby_type in ["igbp", "pft", "climate", "landcover"]:
         if groupby_type in line_lower and (
-            "completed" in line_lower or "finished" in line_lower or "done" in line_lower
+            "complete" in line_lower or "finished" in line_lower or "done" in line_lower
         ):
             task_key = (state.get("current_variable", ""), groupby_type)
             if task_key not in state["completed_groupby_tasks"]:
@@ -130,8 +142,15 @@ def parse_progress_line(
     else:
         if stage == "Comparison":
             current_progress = min(current_progress + P_INC, P_MAX)
+        elif stage == "Report":
+            report_inc = P_INC * (4 if "completed" in line_lower or "success" in line_lower else 2)
+            current_progress = min(current_progress + report_inc, P_MAX)
         elif task_completed or stage or "complete" in line_lower or "done" in line_lower:
             current_progress = min(current_progress + P_INC * 2, P_MAX)
+
+    if stage == "Report":
+        report_inc = P_INC * (4 if "completed" in line_lower or "success" in line_lower else 2)
+        current_progress = max(current_progress, min(start_progress + report_inc, P_MAX))
 
     # Progress emitted while a run is active should never move backwards:
     # task-count information can arrive after optimistic increments, and

--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -519,12 +519,11 @@ class RemoteRunner(QThread):
         if do_evaluation:
             self._total_tasks += num_variables * self._num_ref_sources * self._num_sim_sources
 
-        if do_comparison:
-            if num_comparisons > 0:
-                self._total_tasks += num_comparisons
-            if num_groupby > 0:
-                metric_score_count = max(1, num_metrics + num_scores)
-                self._total_tasks += num_variables * num_groupby * metric_score_count
+        if do_comparison and num_comparisons > 0:
+            self._total_tasks += num_comparisons
+
+        if num_groupby > 0:
+            self._total_tasks += num_groupby
 
         if do_statistics and num_comparisons > 0:
             self._total_tasks += num_comparisons

--- a/src/openbench/gui/runner.py
+++ b/src/openbench/gui/runner.py
@@ -481,14 +481,11 @@ class EvaluationRunner(QThread):
             # Each variable × each ref source × each sim source
             self._total_tasks += num_variables * self._num_ref_sources * self._num_sim_sources
 
-        if do_comparison:
-            # Each comparison type is one task
-            if num_comparisons > 0:
-                self._total_tasks += num_comparisons
-            # Also count groupby tasks if enabled
-            if num_groupby > 0:
-                metric_score_count = max(1, num_metrics + num_scores)
-                self._total_tasks += num_variables * num_groupby * metric_score_count
+        if do_comparison and num_comparisons > 0:
+            self._total_tasks += num_comparisons
+
+        if num_groupby > 0:
+            self._total_tasks += num_groupby
 
         if do_statistics and num_comparisons > 0:
             self._total_tasks += num_comparisons

--- a/src/openbench/gui/styles/theme.qss
+++ b/src/openbench/gui/styles/theme.qss
@@ -210,7 +210,6 @@ QListWidget#nav_sidebar {
     border: none;
     border-radius: 0;
     min-width: 220px;
-    max-width: 220px;
 }
 
 QListWidget#nav_sidebar::item {

--- a/src/openbench/runner/orchestration.py
+++ b/src/openbench/runner/orchestration.py
@@ -388,7 +388,8 @@ def run_evaluation_impl(
     # Skipped under --comparison-only: the CLI flag advertises "only run
     # comparisons", so groupby/statistics/report belong to the full
     # pipeline only.
-    if cfg.comparison.enabled and post_phases_allowed and not comparison_only:
+    groupby_enabled = bool(cfg.project.IGBP_groupby or cfg.project.PFT_groupby or cfg.project.climate_zone_groupby)
+    if groupby_enabled and post_phases_allowed and not comparison_only:
         try:
             errors.extend(_run_groupby(cfg, bindings, output_dir) or [])
         except Exception as exc:

--- a/src/openbench/util/report.py
+++ b/src/openbench/util/report.py
@@ -5,6 +5,7 @@ Report Generation Module for OpenBench
 Generates comprehensive HTML and PDF evaluation reports with tables, figures, and detailed analysis
 """
 
+import csv
 import glob
 import os
 import shutil
@@ -30,6 +31,9 @@ def _url_path(path: str) -> str:
 
 _jinja_env = Environment(autoescape=select_autoescape(default=True, default_for_string=True))
 _jinja_env.filters["url_path"] = _url_path
+
+# ponytail: report summaries cap eager reads; raise only if large-grid summaries are worth the latency.
+_MAX_REPORT_STAT_POINTS = 1_000_000
 
 # Import PDF generation libraries
 try:
@@ -201,23 +205,16 @@ class ReportGenerator:
         for csv_file in csv_files:
             key = os.path.basename(csv_file).replace("_evaluations.csv", "")
             try:
-                df = pd.read_csv(csv_file)
-                metrics_data[key] = {
-                    "data": df.to_dict(orient="records"),
-                    "summary": self._generate_metrics_summary(df),
-                }
+                metrics_data[key] = {"row_count": self._count_csv_rows(csv_file), "summary": {}}
             except Exception as e:
                 logger.warning(f"Error reading {csv_file}: {e}")
 
         # Generate comprehensive grid vs grid statistics from NetCDF files
         grid_grid_stats = self._generate_grid_vs_grid_stats(item)
-        grid_grid_pairs = set()
         if grid_grid_stats:
             metrics_data.update(grid_grid_stats)
-            # Keep track of which grid vs grid pairs we've already processed comprehensively
-            for key in grid_grid_stats.keys():
-                if "vs" in key:
-                    grid_grid_pairs.add(key)
+            # Comprehensive stats already cover the matching metric/score NC files.
+            return metrics_data
 
         # Look for individual NetCDF files with spatial metrics
         nc_files = self._item_output_files(self.metrics_dir, item, (".nc", ".nc4"))
@@ -233,8 +230,12 @@ class ReportGenerator:
                         data_vars = [var for var in ds.data_vars if var not in ds.coords]
                         if data_vars:
                             main_var = ds[data_vars[0]]
+                            if main_var.size > _MAX_REPORT_STAT_POINTS:
+                                logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
+                                continue
                             # Extract comprehensive statistics
-                            valid_data = main_var.values[~np.isnan(main_var.values)]
+                            values = main_var.values
+                            valid_data = values[~np.isnan(values)]
 
                             if len(valid_data) > 0:
                                 # Try to extract comparison pair from filename first, then fallback to config
@@ -295,6 +296,13 @@ class ReportGenerator:
 
         return metrics_data
 
+    @staticmethod
+    def _count_csv_rows(csv_file: str) -> int:
+        with open(csv_file, newline="", encoding="utf-8") as handle:
+            reader = csv.reader(handle)
+            next(reader, None)
+            return sum(1 for _row in reader)
+
     def _collect_scores_data(self, item: str) -> Dict[str, Any]:
         """Collect scores data for a specific evaluation item"""
         scores_data = {}
@@ -309,8 +317,7 @@ class ReportGenerator:
         for csv_file in csv_files:
             key = os.path.basename(csv_file).replace("_evaluations.csv", "")
             try:
-                df = pd.read_csv(csv_file)
-                scores_data[key] = {"data": df.to_dict(orient="records"), "summary": self._generate_scores_summary(df)}
+                scores_data[key] = {"row_count": self._count_csv_rows(csv_file), "summary": {}}
             except Exception as e:
                 logger.warning(f"Error reading {csv_file}: {e}")
 
@@ -581,7 +588,7 @@ class ReportGenerator:
                         stats_data.append(
                             {
                                 "file": os.path.basename(csv_file),
-                                "data": df.to_dict(orient="records"),
+                                "row_count": int(len(df)),
                                 "summary": self._generate_groupby_summary(df),
                             }
                         )
@@ -1034,7 +1041,10 @@ class ReportGenerator:
                         data_vars = [var for var in ds.data_vars if var not in ds.coords]
                         if data_vars:
                             main_var = ds[data_vars[0]]
-                            values = main_var.values.flatten()
+                            if main_var.size > _MAX_REPORT_STAT_POINTS:
+                                logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
+                                continue
+                            values = main_var.values.ravel()
                             valid_data = values[~np.isnan(values)]
                             total_points = len(values)
                             valid_points = len(valid_data)
@@ -1042,7 +1052,6 @@ class ReportGenerator:
 
                             if len(valid_data) > 0:
                                 pair_data[metric_name] = {
-                                    "values": valid_data.tolist(),
                                     "mean": float(np.mean(valid_data)),
                                     "std": float(np.std(valid_data)),
                                     "min": float(np.min(valid_data)),

--- a/tests/test_gui_config_manager.py
+++ b/tests/test_gui_config_manager.py
@@ -237,6 +237,25 @@ def test_generate_config_yaml_does_not_enable_empty_comparison_or_statistics(tmp
     assert "statistics" not in data
 
 
+def test_groupby_only_export_is_loadable_without_comparison_items(tmp_path):
+    from openbench.config.loader import load_config
+
+    config = _runnable_config(tmp_path)
+    config["general"]["comparison"] = True
+    config["general"]["IGBP_groupby"] = True
+
+    assert ConfigManager().validate(config) == []
+
+    path = tmp_path / "openbench.yaml"
+    path.write_text(ConfigManager().generate_config_yaml(config), encoding="utf-8")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    loaded = load_config(path)
+
+    assert "comparison" not in data
+    assert loaded.comparison.enabled is False
+    assert loaded.project.IGBP_groupby is True
+
+
 def test_generate_config_yaml_remote_case_dir_overrides_output_and_transforms_paths(tmp_path):
     config = _runnable_config(tmp_path)
 
@@ -480,3 +499,18 @@ def test_unified_to_gui_config_preserves_project_io():
     )
 
     assert gui["general"]["io"] == {"netcdf_compression": True, "mfdataset_batch_size": 25}
+
+
+def test_generate_config_yaml_can_export_groupby_without_comparison(tmp_path):
+    config = _runnable_config(tmp_path)
+    config["general"]["comparison"] = False
+    config["general"]["IGBP_groupby"] = True
+    config["general"]["PFT_groupby"] = False
+    config["general"]["Climate_zone_groupby"] = False
+
+    data = yaml.safe_load(ConfigManager().generate_config_yaml(config))
+
+    assert "comparison" not in data
+    assert data["project"]["IGBP_groupby"] is True
+    assert "PFT_groupby" not in data["project"]
+    assert "climate_zone_groupby" not in data["project"]

--- a/tests/test_gui_evaluation_runner.py
+++ b/tests/test_gui_evaluation_runner.py
@@ -158,6 +158,35 @@ def test_local_runner_resets_progress_between_check_and_run(tmp_path, monkeypatc
     assert run_start.progress == 0
 
 
+def test_local_runner_counts_groupby_without_comparison(tmp_path):
+    runner = EvaluationRunner(str(tmp_path / "openbench.yaml"), python_path="/fake/python")
+
+    runner.set_task_counts(
+        num_variables=2,
+        num_ref_sources=1,
+        num_sim_sources=1,
+        num_metrics=1,
+        num_scores=1,
+        num_groupby=1,
+        num_comparisons=0,
+        do_evaluation=True,
+        do_comparison=False,
+        do_statistics=False,
+    )
+
+    assert runner._total_tasks == 3
+
+
+def test_remote_runner_counts_groupby_without_comparison(tmp_path):
+    from openbench.gui.remote_runner import RemoteRunner
+
+    runner = RemoteRunner(str(tmp_path / "openbench.yaml"), object(), {}, config_already_remote=True)
+
+    runner.set_task_counts(2, 1, 1, 1, 1, 1, 0, do_evaluation=True, do_comparison=False)
+
+    assert runner._total_tasks == 3
+
+
 def test_local_runner_does_not_run_when_check_fails(tmp_path, monkeypatch):
     config = tmp_path / "openbench.yaml"
     config.write_text("project: {}\n", encoding="utf-8")

--- a/tests/test_gui_localization.py
+++ b/tests/test_gui_localization.py
@@ -80,6 +80,12 @@ def test_main_window_language_button_updates_existing_pages(qapp, monkeypatch):
         assert "alignment: left" in window.pages["registry"].tabs.styleSheet()
         assert window.btn_next.text() == "下一步"
         assert window.nav_list.item(0).text() == "运行环境"
+        evaluation_item = next(
+            window.nav_list.item(i)
+            for i in range(window.nav_list.count())
+            if window.nav_list.item(i).data(Qt.UserRole) == "evaluation_items"
+        )
+        assert evaluation_item.text() == "评估变量"
 
         monkeypatch.setattr(QDialog, "exec", lambda self: QDialog.Accepted)
         window.btn_about.click()
@@ -103,3 +109,31 @@ def test_main_window_language_button_updates_existing_pages(qapp, monkeypatch):
         else:
             qapp._openbench_language_manager = old_manager
             qapp.installEventFilter(old_manager)
+
+
+def test_sidebar_stays_aligned_with_nav_under_theme(qapp):
+    from importlib.resources import files
+
+    from PySide6.QtWidgets import QSplitter
+
+    from openbench.gui.main_window import MainWindow
+
+    old_stylesheet = qapp.styleSheet()
+    window = None
+    try:
+        qapp.setStyleSheet((files("openbench.gui") / "styles" / "theme.qss").read_text(encoding="utf-8"))
+        window = MainWindow()
+        window.resize(1600, 900)
+        window.show()
+        qapp.processEvents()
+
+        splitter = window.findChild(QSplitter)
+        assert splitter is not None
+        sidebar = splitter.widget(0)
+        assert sidebar.width() == window.nav_list.width() == 220
+    finally:
+        if window is not None:
+            window.close()
+            window.deleteLater()
+        qapp.setStyleSheet(old_stylesheet)
+        qapp.processEvents()

--- a/tests/test_progress_parser.py
+++ b/tests/test_progress_parser.py
@@ -57,3 +57,52 @@ def test_progress_parser_accepts_structured_ref_and_sim_markers():
     assert state["current_variable"] == "Latent_Heat"
     assert state["current_ref"] == "GLEAM_v4.2a"
     assert state["current_sim"] == "CoLM2024"
+
+
+def test_progress_parser_counts_structured_completed_evaluation_line():
+    state = _state(total_tasks=1)
+
+    progress, var, stage = parse_progress_line(
+        "Completed Latent_Heat: sim=CoLM2024 ref=GLEAM_v4.2a", 5, state, CONSTANTS
+    )
+
+    assert progress == 95
+    assert var == "Latent_Heat"
+    assert stage == "Evaluation"
+    assert ("Latent_Heat", "GLEAM_v4.2a", "CoLM2024") in state["completed_eval_tasks"]
+
+
+def test_progress_parser_advances_report_stage_without_backtracking():
+    state = _state(total_tasks=1)
+
+    progress, _var, stage = parse_progress_line("Starting report generation...", 90, state, CONSTANTS)
+    done, _var, done_stage = parse_progress_line("Report generation completed successfully", progress, state, CONSTANTS)
+
+    assert stage == "Report"
+    assert done_stage == "Report"
+    assert done > progress > 90
+
+
+def test_progress_parser_counts_actual_comparison_completion_line():
+    state = _state(total_tasks=1)
+
+    progress, _var, stage = parse_progress_line("Completed Taylor_Diagram comparison", 5, state, CONSTANTS)
+
+    assert progress == 95
+    assert stage == "Comparison"
+    assert "taylor_diagram" in state["completed_comparison_tasks"]
+
+
+def test_progress_parser_counts_actual_groupby_complete_lines():
+    for line, key in [
+        ("IGBP groupby complete", "igbp"),
+        ("PFT groupby complete", "pft"),
+        ("Climate zone groupby complete", "climate"),
+    ]:
+        state = _state(total_tasks=1, current_variable="Runoff")
+
+        progress, _var, stage = parse_progress_line(line, 5, state, CONSTANTS)
+
+        assert progress == 95
+        assert stage == "Comparison"
+        assert ("Runoff", key) in state["completed_groupby_tasks"]

--- a/tests/test_report_groupby_paths.py
+++ b/tests/test_report_groupby_paths.py
@@ -219,3 +219,94 @@ def test_report_legacy_item_matching_avoids_configured_underscore_prefix_collisi
 
     assert generator._collect_figures("Run")["metrics"] == ["Run_ref_RefA_sim_SimA_bias.jpg"]
     assert generator._collect_figures("Run_off")["metrics"] == ["Run_off_ref_RefA_sim_SimA_bias.jpg"]
+
+
+def test_report_grid_stats_do_not_store_full_value_arrays(tmp_path):
+    import numpy as np
+    import xarray as xr
+
+    case_dir = tmp_path / "case"
+    metrics_dir = case_dir / "metrics"
+    metrics_dir.mkdir(parents=True)
+    item = "Runoff"
+    ref = "RefA"
+    sim = "SimA"
+    metric_file = metrics_dir / f"{join_filename_components(item, 'ref', ref, 'sim', sim, 'bias')}.nc"
+    xr.Dataset({"bias": (("lat", "lon"), np.array([[1.0, 2.0], [np.nan, 4.0]]))}).to_netcdf(metric_file)
+
+    generator = ReportGenerator(
+        {
+            "evaluation_items": [item],
+            "metrics": {"bias": True},
+            "scores": {},
+            "ref_nml": {"general": {f"{item}_ref_source": ref}},
+            "sim_nml": {"general": {"Case_lib": sim}},
+            "comparisons": {},
+            "general": {"comparison": False},
+        },
+        str(case_dir),
+    )
+
+    stats = generator._generate_grid_vs_grid_stats(item)
+    metric = stats[f"{ref} vs {sim}"]["metrics"]["bias"]
+    assert "values" not in metric
+    assert metric["mean"] == 7 / 3
+
+
+def test_report_csv_collection_keeps_count_not_full_records_or_recomputed_stats(tmp_path):
+    case_dir = tmp_path / "case"
+    metrics_dir = case_dir / "metrics"
+    metrics_dir.mkdir(parents=True)
+    (metrics_dir / "Runoff_evaluations.csv").write_text("station,bias\nA,1\nB,3\n", encoding="utf-8")
+
+    data = ReportGenerator(
+        {"evaluation_items": ["Runoff"], "metrics": {"bias": True}, "scores": {}, "comparisons": {}},
+        str(case_dir),
+    )._collect_metrics_data("Runoff")
+
+    assert data["Runoff"] == {"row_count": 2, "summary": {}}
+
+
+def test_report_skips_eager_statistics_for_large_netcdf(tmp_path, monkeypatch):
+    import openbench.util.report as report_module
+
+    case_dir = tmp_path / "case"
+    metrics_dir = case_dir / "metrics"
+    metrics_dir.mkdir(parents=True)
+    (metrics_dir / f"{join_filename_components('Runoff', 'ref', 'RefA', 'sim', 'SimA', 'bias')}.nc").touch()
+
+    class LargeArray:
+        size = report_module._MAX_REPORT_STAT_POINTS + 1
+
+        @property
+        def values(self):
+            raise AssertionError("large report arrays must not be loaded eagerly")
+
+    class Dataset:
+        data_vars = {"bias": LargeArray()}
+        coords = {}
+
+        def __getitem__(self, name):
+            return self.data_vars[name]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(report_module.xr, "open_dataset", lambda _path: Dataset())
+
+    generator = ReportGenerator(
+        {
+            "evaluation_items": ["Runoff"],
+            "metrics": {"bias": True},
+            "scores": {},
+            "ref_nml": {"general": {"Runoff_ref_source": "RefA"}},
+            "sim_nml": {"general": {"Case_lib": "SimA"}},
+            "comparisons": {},
+        },
+        str(case_dir),
+    )
+
+    assert generator._collect_metrics_data("Runoff") == {}

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -5402,14 +5402,15 @@ def test_unhandled_post_phase_error_still_cleans_pair_ref_override(tmp_path, mon
     assert not pair_ref.exists()
 
 
-def test_groupby_phase_obeys_comparison_enabled_gate(tmp_path, monkeypatch):
-    """Groupby toggles should not run when the comparison phase is disabled."""
+@pytest.mark.parametrize(("groupby_enabled", "expected_calls"), [(True, 1), (False, 0)])
+def test_groupby_phase_runs_without_comparison_enabled(tmp_path, monkeypatch, groupby_enabled, expected_calls):
+    """Groupby toggles run independently from comparison.enabled."""
     import openbench.config.adapter as adapter
     import openbench.data.processing as processing
     import openbench.runner.local as local_runner
 
     cfg = _make_cfg(tmp_path, comparison_enabled=False)
-    cfg.project.IGBP_groupby = True
+    cfg.project.IGBP_groupby = groupby_enabled
 
     runner_cfg = adapter.RunnerConfig(
         basename="case",
@@ -5479,7 +5480,9 @@ def test_groupby_phase_obeys_comparison_enabled_gate(tmp_path, monkeypatch):
     result = run_evaluation(cfg, force=True)
 
     assert result["status"] == "success"
-    assert groupby_calls == []
+    assert len(groupby_calls) == expected_calls
+    if groupby_calls:
+        assert groupby_calls[0][0] is cfg
 
 
 def test_evaluate_single_strict_rejects_equal_length_mismatched_time(tmp_path, monkeypatch):

--- a/tests/test_sim_scanner.py
+++ b/tests/test_sim_scanner.py
@@ -73,6 +73,26 @@ def test_scan_simulation_roots_discovers_cases_at_default_depth_five(tmp_path: P
     assert case.depth == 5
 
 
+def test_scan_simulation_roots_reuses_directory_listing_within_each_scan(tmp_path: Path, monkeypatch):
+    import openbench.data.sim_scanner as sim_scanner
+
+    history = tmp_path / "simulations" / "CaseA" / "history"
+    _write_grid_nc(history / "QFLX_EVAP_TOT_2000.nc")
+    original = sim_scanner.glob_nc
+    calls = []
+
+    def counted_glob_nc(directory):
+        calls.append(Path(directory))
+        return original(directory)
+
+    monkeypatch.setattr(sim_scanner, "glob_nc", counted_glob_nc)
+
+    sim_scanner.scan_simulation_roots([tmp_path / "simulations"], model_name="CoLM2024")
+    sim_scanner.scan_simulation_roots([tmp_path / "simulations"], model_name="CoLM2024")
+
+    assert calls.count(history) == 2
+
+
 def test_scan_simulation_roots_skips_generated_derived_output_dirs(tmp_path: Path):
     from openbench.data.sim_scanner import scan_simulation_roots
 


### PR DESCRIPTION
## Summary
- keep the sidebar aligned and correct the Chinese Evaluation label
- cache simulation scan filesystem/NetCDF inspection work
- allow IGBP/PFT/climate groupby without enabling comparison
- parse real evaluation/comparison/groupby/report progress logs
- stream station CSV row counts and bound NetCDF report summaries to avoid report stalls

## Verification
- `ruff check` and `ruff format --check` on all changed Python files
- `python -m py_compile` on all changed Python files
- `pytest -q`: **1684 passed, 5 skipped**

## Known limitation
- production-scale timing was not benchmarked on the exact datasets from the report; NetCDF report summaries above 1,000,000 points are intentionally skipped.
