### PR TITLE
Fix GUI progress, Windows telemetry, and report integrity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
 # is in the base install. The report/migration/statistics/plot extras are kept
 # (empty) for backward compatibility so e.g. `pip install colm-openbench[report]`
 # still resolves and never errors.
-gui = ["PySide6>=6.5.0"]
+gui = ["PySide6>=6.5.0", "psutil>=5.9.0"]
 remote = ["paramiko>=3.0.0", "cryptography>=41.0.0"]
 # PDF reports need xhtml2pdf, which pulls pycairo (requires system cairo to
 # build), so it stays optional to keep the base `pip install` lightweight and

--- a/src/openbench/cli/_register.py
+++ b/src/openbench/cli/_register.py
@@ -150,21 +150,21 @@ def register_reference(
         from openbench.data.registry.scanner import _detect_data_type_from_nc
 
         root_path = Path(root_dir)
-        nc_files = glob_nc(root_path)
-        if not nc_files:
-            try:
+        try:
+            nc_files = glob_nc(root_path)
+            if not nc_files:
                 children = sorted(root_path.iterdir())
-            except OSError as exc:
-                click.secho(
-                    f"  Could not inspect subdirectories for data_type auto-detection ({exc}); using default: grid",
-                    fg="yellow",
-                )
-                children = []
-            for child in children:
-                if child.is_dir():
-                    nc_files = glob_nc(child)
-                    if nc_files:
-                        break
+                for child in children:
+                    if child.is_dir():
+                        nc_files = glob_nc(child)
+                        if nc_files:
+                            break
+        except OSError as exc:
+            click.secho(
+                f"  Could not inspect subdirectories for data_type auto-detection ({exc}); using default: grid",
+                fg="yellow",
+            )
+            nc_files = []
         nc_file = nc_files[0] if nc_files else None
         if nc_file is not None:
             detected = _detect_data_type_from_nc(nc_file)

--- a/src/openbench/data/coordinates.py
+++ b/src/openbench/data/coordinates.py
@@ -162,7 +162,7 @@ def glob_nc(directory, recursive: bool = False) -> list:
     try:
         paths = d.rglob("*") if recursive else d.iterdir()
         return sorted(path for path in paths if path.is_file() and path.suffix in NC_SUFFIXES)
-    except OSError:
+    except FileNotFoundError:
         return []
 
 

--- a/src/openbench/gui/main_window.py
+++ b/src/openbench/gui/main_window.py
@@ -356,6 +356,7 @@ class MainWindow(QMainWindow):
     def _show_about(self):
         """Show OpenBench version, maintainer, and copyright information."""
         dialog = QDialog(self)
+        dialog.setAttribute(Qt.WA_DeleteOnClose, True)
         dialog.setWindowTitle("About OpenBench")
         dialog.setFixedWidth(460)
 

--- a/src/openbench/gui/pages/page_run_monitor.py
+++ b/src/openbench/gui/pages/page_run_monitor.py
@@ -24,6 +24,39 @@ from openbench.gui.remote_runner import RemoteRunner
 logger = logging.getLogger(__name__)
 
 
+def _source_list(value) -> list:
+    if isinstance(value, (list, tuple, set)):
+        return [source for source in value if source]
+    return [value] if value else []
+
+
+def count_evaluation_tasks(config: dict, selected_variables: list[str]) -> int:
+    """Count the per-variable ref/sim pairs that the runner will actually build."""
+    ref_data = config.get("ref_data", {}) or {}
+    sim_data = config.get("sim_data", {}) or {}
+    ref_general = ref_data.get("general", {}) or {}
+    sim_general = sim_data.get("general", {}) or {}
+    ref_configs = ref_data.get("source_configs", {}) or {}
+    sim_configs = sim_data.get("source_configs", {}) or {}
+    fallback_refs = [name for name, path in (ref_data.get("def_nml", {}) or {}).items() if path]
+    fallback_sims = [name for name, path in (sim_data.get("def_nml", {}) or {}).items() if path]
+
+    total = 0
+    for variable in selected_variables:
+        refs = _source_list(ref_general.get(f"{variable}_ref_source"))
+        if not refs:
+            refs = [key.split("::", 1)[1] for key in ref_configs if key.startswith(f"{variable}::")]
+        if not refs:
+            refs = fallback_refs
+
+        sims = _source_list(sim_general.get(f"{variable}_sim_source"))
+        if not sims:
+            sims = list(sim_configs) or fallback_sims
+
+        total += len(set(refs)) * len(set(sims))
+    return total
+
+
 class PageRunMonitor(BasePage):
     """Run and Monitor page."""
 
@@ -167,6 +200,7 @@ class PageRunMonitor(BasePage):
             do_evaluation=general.get("evaluation", True),
             do_comparison=general.get("comparison", False),
             do_statistics=general.get("statistics", False),
+            num_evaluation_tasks=count_evaluation_tasks(config, selected),
         )
 
         # Connect signals - same interface for both runners

--- a/src/openbench/gui/progress_parser.py
+++ b/src/openbench/gui/progress_parser.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 """Shared log-line progress parser for local and remote runners."""
 
+import json
 import re
+
+from openbench.runner.progress_events import GUI_PROGRESS_PREFIX
 
 
 def parse_progress_line(
@@ -31,11 +34,27 @@ def parse_progress_line(
 
     line_lower = line.lower()
 
+    protocol_line = GUI_PROGRESS_PREFIX in line
+    if protocol_line:
+        try:
+            event = json.loads(line.split(GUI_PROGRESS_PREFIX, 1)[1])
+        except (json.JSONDecodeError, TypeError):
+            event = {}
+        if event.get("event") == "evaluation_completed":
+            state["current_variable"] = str(event.get("variable", ""))
+            state["current_sim"] = str(event.get("sim", ""))
+            state["current_ref"] = str(event.get("ref", ""))
+            var = state["current_variable"]
+            stage = "Evaluation"
+
+    natural_line = "" if protocol_line else line
+    natural_line_lower = natural_line.lower()
+
     # Detect variable being processed
-    if "processing" in line_lower or "evaluating" in line_lower:
+    if "processing" in natural_line_lower or "evaluating" in natural_line_lower:
         for keyword in ["Processing", "Evaluating", "processing", "evaluating"]:
-            if keyword in line:
-                parts = line.split(keyword)
+            if keyword in natural_line:
+                parts = natural_line.split(keyword)
                 if len(parts) > 1:
                     remaining = parts[1].strip()
                     if remaining:
@@ -51,7 +70,7 @@ def parse_progress_line(
     # "ReferenceError: ..." as a new reference source.
     ref_match = re.search(
         r"(?:^|[-\s])ref:\s*(\S+)|\bref_source\b\s*[:=]\s*(\S+)|\breference(?:\s+source)?\b\s*[:=]\s*(\S+)",
-        line,
+        natural_line,
         re.IGNORECASE,
     )
     if ref_match:
@@ -59,7 +78,7 @@ def parse_progress_line(
 
     sim_match = re.search(
         r"(?:^|[-\s])sim:\s*(\S+)|\bsim_source\b\s*[:=]\s*(\S+)|\bsimulation(?:\s+source)?\b\s*[:=]\s*(\S+)",
-        line,
+        natural_line,
         re.IGNORECASE,
     )
     if sim_match:
@@ -67,10 +86,10 @@ def parse_progress_line(
 
     completed_eval_match = re.search(
         r"\bcompleted\s+([^:]+):.*?\bsim\s*[=:]\s*([^\s,;]+).*?\bref\s*[=:]\s*([^\s,;]+)",
-        line,
+        natural_line,
         re.IGNORECASE,
     )
-    if completed_eval_match:
+    if completed_eval_match and not stage:
         state["current_variable"] = completed_eval_match.group(1).strip()
         state["current_sim"] = completed_eval_match.group(2).strip(":,")
         state["current_ref"] = completed_eval_match.group(3).strip(":,")
@@ -78,16 +97,16 @@ def parse_progress_line(
         stage = "Evaluation"
 
     # Detect stage
-    if not stage and "evaluation" in line_lower and "item" not in line_lower:
+    if not stage and "evaluation" in natural_line_lower and "item" not in natural_line_lower:
         stage = "Evaluation"
-    elif "comparison" in line_lower or "groupby" in line_lower:
+    elif "comparison" in natural_line_lower or "groupby" in natural_line_lower:
         stage = "Comparison"
-        comparison_done = re.search(r"(?:done running|completed)\s+([\w-]+)\s+comparison", line_lower)
+        comparison_done = re.search(r"(?:done running|completed)\s+([\w-]+)\s+comparison", natural_line_lower)
         if comparison_done:
             state["completed_comparison_tasks"].add(comparison_done.group(1))
-    elif "statistic" in line_lower:
+    elif "statistic" in natural_line_lower:
         stage = "Statistics"
-    elif "report" in line_lower:
+    elif "report" in natural_line_lower:
         stage = "Report"
 
     # Detect task completions
@@ -100,8 +119,8 @@ def parse_progress_line(
             task_completed = True
 
     for groupby_type in ["igbp", "pft", "climate", "landcover"]:
-        if groupby_type in line_lower and (
-            "complete" in line_lower or "finished" in line_lower or "done" in line_lower
+        if groupby_type in natural_line_lower and (
+            "complete" in natural_line_lower or "finished" in natural_line_lower or "done" in natural_line_lower
         ):
             task_key = (state.get("current_variable", ""), groupby_type)
             if task_key not in state["completed_groupby_tasks"]:

--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -33,7 +33,7 @@ def build_remote_run_command(python_path: str, openbench_path: str, config_path:
     q_python = quote_remote_path(python_path or "python3")
     q_openbench = quote_remote_path(openbench_path)
     q_config = shlex.quote(config_path)
-    prefix = f"PYTHONUNBUFFERED=1 {q_python} -u -m openbench"
+    prefix = f"PYTHONUNBUFFERED=1 OPENBENCH_GUI_PROGRESS=1 {q_python} -u -m openbench"
     invocation = f"{prefix} check {q_config} && {prefix} run {q_config}"
     return wrap_with_conda_env(
         f"cd {q_openbench} && {invocation}",
@@ -497,6 +497,7 @@ class RemoteRunner(QThread):
         do_evaluation: bool = True,
         do_comparison: bool = False,
         do_statistics: bool = False,
+        num_evaluation_tasks: int | None = None,
     ):
         """Set detailed task counts for accurate progress calculation.
 
@@ -517,7 +518,9 @@ class RemoteRunner(QThread):
         self._total_tasks = 0
 
         if do_evaluation:
-            self._total_tasks += num_variables * self._num_ref_sources * self._num_sim_sources
+            if num_evaluation_tasks is None:
+                num_evaluation_tasks = num_variables * self._num_ref_sources * self._num_sim_sources
+            self._total_tasks += max(0, int(num_evaluation_tasks))
 
         if do_comparison and num_comparisons > 0:
             self._total_tasks += num_comparisons

--- a/src/openbench/gui/runner.py
+++ b/src/openbench/gui/runner.py
@@ -180,6 +180,7 @@ class EvaluationRunner(QThread):
             env["PYTHONIOENCODING"] = "utf-8"
             # Disable output buffering to ensure real-time log display
             env["PYTHONUNBUFFERED"] = "1"
+            env["OPENBENCH_GUI_PROGRESS"] = "1"
 
             progress = 0
             for index, cmd in enumerate(commands):
@@ -442,6 +443,7 @@ class EvaluationRunner(QThread):
         do_evaluation: bool = True,
         do_comparison: bool = False,
         do_statistics: bool = False,
+        num_evaluation_tasks: int | None = None,
     ):
         """
         Set detailed task counts for accurate progress calculation.
@@ -478,8 +480,9 @@ class EvaluationRunner(QThread):
         self._total_tasks = 0
 
         if do_evaluation:
-            # Each variable × each ref source × each sim source
-            self._total_tasks += num_variables * self._num_ref_sources * self._num_sim_sources
+            if num_evaluation_tasks is None:
+                num_evaluation_tasks = num_variables * self._num_ref_sources * self._num_sim_sources
+            self._total_tasks += max(0, int(num_evaluation_tasks))
 
         if do_comparison and num_comparisons > 0:
             self._total_tasks += num_comparisons

--- a/src/openbench/gui/widgets/progress_dashboard.py
+++ b/src/openbench/gui/widgets/progress_dashboard.py
@@ -217,8 +217,11 @@ class ProgressDashboard(QWidget):
             mem_percent = int(mem.percent)
             self.mem_bar.setValue(mem_percent)
             self.mem_label.setText(f"{mem_percent}%")
-        except ImportError:
-            pass
+        except (ImportError, AttributeError, OSError):
+            self.cpu_bar.setValue(0)
+            self.mem_bar.setValue(0)
+            self.cpu_label.setText("N/A")
+            self.mem_label.setText("N/A")
 
     def start_monitoring(self):
         """Start resource monitoring."""

--- a/src/openbench/runner/cache_state.py
+++ b/src/openbench/runner/cache_state.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from openbench.runner.cache import EvaluationCache
+from openbench.runner.progress_events import emit_gui_task_completion
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,7 @@ def cached_task_result(task: dict[str, Any]) -> dict[str, Any] | None:
             task["sim_source"],
             task["ref_source"],
         )
-        return {
+        result = {
             "variable": task["var_name"],
             "sim": task["sim_source"],
             "ref": task["ref_source"],
@@ -48,6 +49,8 @@ def cached_task_result(task: dict[str, Any]) -> dict[str, Any] | None:
             "config_hash": config_hash,
             "skipped": True,
         }
+        emit_gui_task_completion(result)
+        return result
 
     logger.warning(
         "Cache stale (output missing or unreadable), re-evaluating %s: sim=%s ref=%s",

--- a/src/openbench/runner/evaluation_dispatch.py
+++ b/src/openbench/runner/evaluation_dispatch.py
@@ -8,6 +8,8 @@ import sys
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any
 
+from openbench.runner.progress_events import emit_gui_task_completion
+
 logger = logging.getLogger(__name__)
 
 
@@ -88,22 +90,30 @@ def evaluate_ready_tasks(
     evaluate_group = _local_attr("_evaluate_task_group", evaluate_task_group)
     executor_cls = _local_attr("ProcessPoolExecutor", ProcessPoolExecutor)
 
+    def serial_results(tasks):
+        results = []
+        for task in tasks:
+            result = evaluate_single(task)
+            emit_gui_task_completion(result)
+            results.append(result)
+        return results
+
     workers = worker_count(num_cores, len(ready_tasks))
     if dask_distributed:
         logger.info("Task-level process parallelism disabled while dask.distributed is active")
-        return [evaluate_single(task) for task in ready_tasks]
+        return serial_results(ready_tasks)
     if only_drawing or workers <= 1 or not parallel_safe(ready_tasks):
-        return [evaluate_single(task) for task in ready_tasks]
+        return serial_results(ready_tasks)
 
     if unified_mask:
         # Preprocessing already applied the shared mask. Keep tasks that share
         # a flat ref serial, but allow different refs to evaluate in parallel.
         if not all(task.get("ref_preprocessed") for task in ready_tasks):
-            return [evaluate_single(task) for task in ready_tasks]
+            return serial_results(ready_tasks)
         groups = group_tasks(ready_tasks)
         group_workers = worker_count(num_cores, len(groups))
         if group_workers <= 1 or len(groups) <= 1:
-            return [evaluate_single(task) for task in ready_tasks]
+            return serial_results(ready_tasks)
         cores_per_worker = max(1, _core_budget(num_cores) // group_workers)
         groups = [[{**task, "num_cores_override": cores_per_worker} for task in group] for group in groups]
         logger.info(
@@ -114,7 +124,12 @@ def evaluate_ready_tasks(
         )
         with executor_cls(max_workers=group_workers) as executor:
             grouped_results = executor.map(evaluate_group, groups)
-        return [result for group in grouped_results for result in group]
+            results = []
+            for group in grouped_results:
+                for result in group:
+                    emit_gui_task_completion(result)
+                    results.append(result)
+        return results
 
     cores_per_worker = max(1, _core_budget(num_cores) // workers)
     budgeted_tasks = [{**task, "num_cores_override": cores_per_worker} for task in ready_tasks]
@@ -125,4 +140,8 @@ def evaluate_ready_tasks(
         cores_per_worker,
     )
     with executor_cls(max_workers=workers) as executor:
-        return list(executor.map(evaluate_single, budgeted_tasks))
+        results = []
+        for result in executor.map(evaluate_single, budgeted_tasks):
+            emit_gui_task_completion(result)
+            results.append(result)
+        return results

--- a/src/openbench/runner/progress_events.py
+++ b/src/openbench/runner/progress_events.py
@@ -1,12 +1,22 @@
 """Machine-readable task progress emitted only for GUI-launched runs."""
 
+import json
 import os
+
+GUI_PROGRESS_PREFIX = "OPENBENCH_PROGRESS "
 
 
 def emit_gui_task_completion(result: dict) -> None:
-    if os.environ.get("OPENBENCH_GUI_PROGRESS") != "1":
+    if os.environ.get("OPENBENCH_GUI_PROGRESS") != "1" or result.get("status") not in {"success", "skipped"}:
         return
-    print(
-        f"Completed {result['variable']}: sim={result['sim']} ref={result['ref']}",
-        flush=True,
+    payload = json.dumps(
+        {
+            "event": "evaluation_completed",
+            "variable": result["variable"],
+            "sim": result["sim"],
+            "ref": result["ref"],
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
     )
+    print(f"{GUI_PROGRESS_PREFIX}{payload}", flush=True)

--- a/src/openbench/runner/progress_events.py
+++ b/src/openbench/runner/progress_events.py
@@ -1,0 +1,12 @@
+"""Machine-readable task progress emitted only for GUI-launched runs."""
+
+import os
+
+
+def emit_gui_task_completion(result: dict) -> None:
+    if os.environ.get("OPENBENCH_GUI_PROGRESS") != "1":
+        return
+    print(
+        f"Completed {result['variable']}: sim={result['sim']} ref={result['ref']}",
+        flush=True,
+    )

--- a/src/openbench/util/report.py
+++ b/src/openbench/util/report.py
@@ -5,7 +5,6 @@ Report Generation Module for OpenBench
 Generates comprehensive HTML and PDF evaluation reports with tables, figures, and detailed analysis
 """
 
-import csv
 import glob
 import os
 import shutil
@@ -205,7 +204,8 @@ class ReportGenerator:
         for csv_file in csv_files:
             key = os.path.basename(csv_file).replace("_evaluations.csv", "")
             try:
-                metrics_data[key] = {"row_count": self._count_csv_rows(csv_file), "summary": {}}
+                row_count, summary = self._summarize_csv(csv_file)
+                metrics_data[key] = {"row_count": row_count, "summary": summary}
             except Exception as e:
                 logger.warning(f"Error reading {csv_file}: {e}")
 
@@ -232,6 +232,12 @@ class ReportGenerator:
                             main_var = ds[data_vars[0]]
                             if main_var.size > _MAX_REPORT_STAT_POINTS:
                                 logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
+                                metrics_data[key] = {
+                                    "summary": {},
+                                    "summary_omitted": True,
+                                    "total_points": int(main_var.size),
+                                    "file": os.path.basename(nc_file),
+                                }
                                 continue
                             # Extract comprehensive statistics
                             values = main_var.values
@@ -297,11 +303,63 @@ class ReportGenerator:
         return metrics_data
 
     @staticmethod
-    def _count_csv_rows(csv_file: str) -> int:
-        with open(csv_file, newline="", encoding="utf-8") as handle:
-            reader = csv.reader(handle)
-            next(reader, None)
-            return sum(1 for _row in reader)
+    def _summarize_csv(csv_file: str, chunksize: int = 100_000) -> tuple[int, Dict[str, Any]]:
+        """Return row count and numeric summaries without retaining the full CSV."""
+        excluded = {
+            "sim_lon",
+            "sim_lat",
+            "ref_lon",
+            "ref_lat",
+            "sim_syear",
+            "sim_eyear",
+            "ref_syear",
+            "ref_eyear",
+        }
+        row_count = 0
+        states: Dict[str, Dict[str, float | int]] = {}
+
+        for chunk in pd.read_csv(csv_file, chunksize=chunksize):
+            row_count += len(chunk)
+            for column in chunk.columns:
+                if column in excluded:
+                    continue
+                values = pd.to_numeric(chunk[column], errors="coerce").dropna().to_numpy(dtype=float)
+                if not len(values):
+                    continue
+
+                chunk_count = int(len(values))
+                chunk_mean = float(np.mean(values))
+                chunk_m2 = float(np.sum((values - chunk_mean) ** 2))
+                state = states.setdefault(
+                    column,
+                    {
+                        "count": 0,
+                        "mean": 0.0,
+                        "m2": 0.0,
+                        "min": float("inf"),
+                        "max": float("-inf"),
+                    },
+                )
+                old_count = int(state["count"])
+                new_count = old_count + chunk_count
+                delta = chunk_mean - float(state["mean"])
+                state["mean"] = float(state["mean"]) + delta * chunk_count / new_count
+                state["m2"] = float(state["m2"]) + chunk_m2 + delta * delta * old_count * chunk_count / new_count
+                state["count"] = new_count
+                state["min"] = min(float(state["min"]), float(np.min(values)))
+                state["max"] = max(float(state["max"]), float(np.max(values)))
+
+        summary = {}
+        for column, state in states.items():
+            count = int(state["count"])
+            summary[column] = {
+                "mean": float(state["mean"]),
+                "std": float(np.sqrt(float(state["m2"]) / (count - 1))) if count > 1 else np.nan,
+                "min": float(state["min"]),
+                "max": float(state["max"]),
+                "count": count,
+            }
+        return row_count, summary
 
     def _collect_scores_data(self, item: str) -> Dict[str, Any]:
         """Collect scores data for a specific evaluation item"""
@@ -317,7 +375,8 @@ class ReportGenerator:
         for csv_file in csv_files:
             key = os.path.basename(csv_file).replace("_evaluations.csv", "")
             try:
-                scores_data[key] = {"row_count": self._count_csv_rows(csv_file), "summary": {}}
+                row_count, summary = self._summarize_csv(csv_file)
+                scores_data[key] = {"row_count": row_count, "summary": summary}
             except Exception as e:
                 logger.warning(f"Error reading {csv_file}: {e}")
 
@@ -1043,6 +1102,11 @@ class ReportGenerator:
                             main_var = ds[data_vars[0]]
                             if main_var.size > _MAX_REPORT_STAT_POINTS:
                                 logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
+                                pair_data[metric_name] = {
+                                    "summary_omitted": True,
+                                    "total_points": int(main_var.size),
+                                    "file": os.path.basename(nc_file),
+                                }
                                 continue
                             values = main_var.values.ravel()
                             valid_data = values[~np.isnan(values)]
@@ -1063,52 +1127,15 @@ class ReportGenerator:
                 except Exception as e:
                     logger.warning(f"Error reading {nc_file}: {e}")
 
-            # Try to estimate correlation if not present but other metrics are available
-            # Check if 'correlation' is an enabled metric
-            if "correlation" in self.enabled_metrics and "correlation" not in pair_data:
-                # Simple heuristic estimation based on available metrics
-                estimated_corr = 0.5  # Default moderate correlation
-
-                # Check for KGESS if it's enabled
-                if "KGESS" in self.enabled_metrics and "KGESS" in pair_data:
-                    kgess_mean = pair_data["KGESS"]["mean"]
-                    # KGESS ranges from -inf to 1, with 1 being perfect
-                    # Correlation ranges from -1 to 1, estimate conservatively
-                    estimated_corr = max(0.0, min(1.0, kgess_mean * 0.9))
-                # Check for Overall_Score if it's enabled
-                elif "Overall_Score" in self.enabled_scores and "Overall_Score" in pair_data:
-                    # Use Overall_Score as a proxy for correlation
-                    overall_mean = pair_data["Overall_Score"]["mean"]
-                    estimated_corr = max(0.0, min(1.0, overall_mean))
-                # Check for RMSE if enabled and try to estimate from it
-                elif "RMSE" in self.enabled_metrics and "RMSE" in pair_data:
-                    # For RMSE, lower is better, so inverse relationship
-                    # This is a rough estimate - actual implementation might vary
-                    rmse_mean = pair_data["RMSE"]["mean"]
-                    if rmse_mean > 0:
-                        # Arbitrary conversion - needs domain knowledge
-                        estimated_corr = max(0.0, min(1.0, 1.0 / (1.0 + rmse_mean)))
-
-                pair_data["correlation"] = {
-                    "values": [estimated_corr],
-                    "mean": estimated_corr,
-                    "std": 0.1,  # Assume some uncertainty
-                    "min": max(0.0, estimated_corr - 0.1),
-                    "max": min(1.0, estimated_corr + 0.1),
-                    "median": estimated_corr,
-                    "coverage": 100.0,
-                    "estimated": True,
-                    "estimation_source": "heuristic",
-                }
-
             if len(pair_data) > 2:  # More than just the year entries
                 # Calculate average data coverage across all metrics
                 coverages = [
                     metric_info.get("coverage", 0.0)
-                    for metric_info in pair_data.values()
+                    for metric_name, metric_info in pair_data.items()
+                    if metric_name not in {"use_syear", "use_eyear"}
                     if isinstance(metric_info, dict) and "coverage" in metric_info
                 ]
-                avg_coverage = np.mean(coverages) if coverages else 100.0
+                avg_coverage = float(np.mean(coverages)) if coverages else None
 
                 # Get comparison pair from configuration
                 comparison_pair = self._get_comparison_pair_from_config(item, ref_source, sim_source)
@@ -1118,7 +1145,7 @@ class ReportGenerator:
                     "comparison_pair": comparison_pair,
                     "station_format": True,  # Flag to use station-like display
                     "metrics": pair_data,
-                    "data_coverage": float(avg_coverage),
+                    "data_coverage": avg_coverage,
                 }
 
                 logger.info(f"Generated comprehensive stats for {comparison_pair}")
@@ -1565,7 +1592,7 @@ class ReportGenerator:
             <p>This report presents the comprehensive evaluation results from OpenBench Land Surface Model benchmarking system.</p>
             
             <div style="text-align: center; margin: 20px 0;">
-                {% if overall_summary.grand_average %}
+                {% if overall_summary.grand_average is defined %}
                 <div class="metric-card">
                     <div class="metric-value">{{ "%.3f"|format(overall_summary.grand_average) }}</div>
                     <div class="metric-label">Overall Average Score</div>
@@ -1630,6 +1657,11 @@ class ReportGenerator:
                     {% endif %}
                 {% endfor %}
             </div>
+            {% elif metric_data.summary_omitted %}
+            <h4>{{ metric_key }}</h4>
+            <div class="summary-box">
+                <p>Summary omitted for {{ metric_data.total_points }} points to avoid excessive memory use. Raw result: {{ metric_data.file }}</p>
+            </div>
             {% elif metric_data.station_format %}
             <!-- Grid vs Grid comprehensive statistics (station format) -->
             <h4>{{ metric_data.comparison_pair }}</h4>
@@ -1640,13 +1672,17 @@ class ReportGenerator:
                 <p><strong>{{ metric_name }}:</strong> {{ "%.0f"|format(metric_values.mean) }}</p>
                 {% endif %}
                 {% else %}
+                {% if metric_values.summary_omitted %}
+                <p><strong>{{ metric_name }}:</strong> Summary omitted for {{ metric_values.total_points }} points to avoid excessive memory use. Raw result: {{ metric_values.file }}</p>
+                {% else %}
                 <p><strong>{{ metric_name }}:</strong> 
                    Mean = {{ "%.4f"|format(metric_values.mean) }}, 
                    Std = {{ "%.4f"|format(metric_values.std) }}, 
                    Median = {{ "%.4f"|format(metric_values.median) }}, 
-                   Range = [{{ "%.4f"|format(metric_values.min) }}, {{ "%.4f"|format(metric_values.max) }}], 
-                   Data Coverage = {{ "%.1f"|format(metric_data.data_coverage) }}%
+                   Range = [{{ "%.4f"|format(metric_values.min) }}, {{ "%.4f"|format(metric_values.max) }}]
+                   {% if metric_data.data_coverage is not none %}, Data Coverage = {{ "%.1f"|format(metric_data.data_coverage) }}%{% endif %}
                 </p>
+                {% endif %}
                 {% endif %}
                 {% endfor %}
             </div>

--- a/src/openbench/util/report.py
+++ b/src/openbench/util/report.py
@@ -9,6 +9,7 @@ import glob
 import os
 import shutil
 from datetime import datetime
+from itertools import product
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote, unquote
 
@@ -31,7 +32,8 @@ def _url_path(path: str) -> str:
 _jinja_env = Environment(autoescape=select_autoescape(default=True, default_for_string=True))
 _jinja_env.filters["url_path"] = _url_path
 
-# ponytail: report summaries cap eager reads; raise only if large-grid summaries are worth the latency.
+# Report statistics read at most this many values per chunk. Exact medians are
+# retained only when the complete result fits within the same bound.
 _MAX_REPORT_STAT_POINTS = 1_000_000
 
 # Import PDF generation libraries
@@ -230,20 +232,9 @@ class ReportGenerator:
                         data_vars = [var for var in ds.data_vars if var not in ds.coords]
                         if data_vars:
                             main_var = ds[data_vars[0]]
-                            if main_var.size > _MAX_REPORT_STAT_POINTS:
-                                logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
-                                metrics_data[key] = {
-                                    "summary": {},
-                                    "summary_omitted": True,
-                                    "total_points": int(main_var.size),
-                                    "file": os.path.basename(nc_file),
-                                }
-                                continue
-                            # Extract comprehensive statistics
-                            values = main_var.values
-                            valid_data = values[~np.isnan(values)]
+                            stats = self._summarize_data_array(main_var)
 
-                            if len(valid_data) > 0:
+                            if stats:
                                 # Try to extract comparison pair from filename first, then fallback to config
                                 comparison_pair = self._extract_comparison_pair(key)
 
@@ -280,17 +271,27 @@ class ReportGenerator:
                                     except Exception as e:
                                         logger.warning(f"Error extracting sources from filename {key}: {e}")
 
+                                metric_type = self._extract_metric_type(key)
                                 metrics_data[key] = {
-                                    "global_mean": float(np.mean(valid_data)),
-                                    "global_std": float(np.std(valid_data)),
-                                    "global_min": float(np.min(valid_data)),
-                                    "global_max": float(np.max(valid_data)),
-                                    "global_median": float(np.median(valid_data)),
-                                    "valid_points": int(len(valid_data)),
-                                    "total_points": int(main_var.size),
-                                    "data_coverage": float(len(valid_data) / main_var.size * 100),
+                                    "summary": {
+                                        metric_type: {
+                                            "mean": stats["mean"],
+                                            "std": stats["std"],
+                                            "min": stats["min"],
+                                            "max": stats["max"],
+                                        }
+                                    },
+                                    "global_mean": stats["mean"],
+                                    "global_std": stats["std"],
+                                    "global_min": stats["min"],
+                                    "global_max": stats["max"],
+                                    "global_median": stats["median"],
+                                    "median_omitted": stats["median_omitted"],
+                                    "valid_points": stats["valid_points"],
+                                    "total_points": stats["total_points"],
+                                    "data_coverage": stats["coverage"],
                                     "shape": str(main_var.dims),
-                                    "metric_type": self._extract_metric_type(key),
+                                    "metric_type": metric_type,
                                     "comparison_pair": comparison_pair,
                                 }
                             else:
@@ -301,6 +302,68 @@ class ReportGenerator:
                     logger.warning(f"Error reading {nc_file}: {e}")
 
         return metrics_data
+
+    @staticmethod
+    def _summarize_data_array(main_var: xr.DataArray, max_points: Optional[int] = None) -> Optional[Dict[str, Any]]:
+        """Calculate exact bounded-memory statistics, omitting only large-array medians."""
+        max_points = max_points or _MAX_REPORT_STAT_POINTS
+        total_points = int(main_var.size)
+        if total_points == 0:
+            return None
+
+        remaining = max_points
+        chunk_sizes = []
+        for size in reversed(main_var.shape):
+            chunk_size = min(int(size), remaining)
+            chunk_sizes.append(max(1, chunk_size))
+            remaining = max(1, remaining // max(1, chunk_size))
+        chunk_sizes.reverse()
+
+        count = 0
+        mean = 0.0
+        m2 = 0.0
+        minimum = float("inf")
+        maximum = float("-inf")
+        median_parts = [] if total_points <= max_points else None
+
+        ranges = [range(0, int(size), chunk) for size, chunk in zip(main_var.shape, chunk_sizes)]
+        for starts in product(*ranges):
+            indexers = {
+                dim: slice(start, min(start + chunk, int(size)))
+                for dim, size, chunk, start in zip(main_var.dims, main_var.shape, chunk_sizes, starts)
+            }
+            values = np.asarray(main_var.isel(indexers).values).ravel()
+            valid = values[~np.isnan(values)]
+            if not len(valid):
+                continue
+
+            chunk_count = int(len(valid))
+            chunk_mean = float(np.mean(valid))
+            chunk_m2 = float(np.sum((valid - chunk_mean) ** 2))
+            new_count = count + chunk_count
+            delta = chunk_mean - mean
+            mean += delta * chunk_count / new_count
+            m2 += chunk_m2 + delta * delta * count * chunk_count / new_count
+            count = new_count
+            minimum = min(minimum, float(np.min(valid)))
+            maximum = max(maximum, float(np.max(valid)))
+            if median_parts is not None:
+                median_parts.append(valid)
+
+        if not count:
+            return None
+
+        return {
+            "mean": mean,
+            "std": float(np.sqrt(m2 / count)),
+            "min": minimum,
+            "max": maximum,
+            "median": float(np.median(np.concatenate(median_parts))) if median_parts is not None else None,
+            "median_omitted": median_parts is None,
+            "coverage": count / total_points * 100,
+            "valid_points": count,
+            "total_points": total_points,
+        }
 
     @staticmethod
     def _summarize_csv(csv_file: str, chunksize: int = 100_000) -> tuple[int, Dict[str, Any]]:
@@ -1100,29 +1163,9 @@ class ReportGenerator:
                         data_vars = [var for var in ds.data_vars if var not in ds.coords]
                         if data_vars:
                             main_var = ds[data_vars[0]]
-                            if main_var.size > _MAX_REPORT_STAT_POINTS:
-                                logger.info("Skipping report summary for large NetCDF file: %s", nc_file)
-                                pair_data[metric_name] = {
-                                    "summary_omitted": True,
-                                    "total_points": int(main_var.size),
-                                    "file": os.path.basename(nc_file),
-                                }
-                                continue
-                            values = main_var.values.ravel()
-                            valid_data = values[~np.isnan(values)]
-                            total_points = len(values)
-                            valid_points = len(valid_data)
-                            coverage = (valid_points / total_points * 100) if total_points > 0 else 0.0
-
-                            if len(valid_data) > 0:
-                                pair_data[metric_name] = {
-                                    "mean": float(np.mean(valid_data)),
-                                    "std": float(np.std(valid_data)),
-                                    "min": float(np.min(valid_data)),
-                                    "max": float(np.max(valid_data)),
-                                    "median": float(np.median(valid_data)),
-                                    "coverage": float(coverage),
-                                }
+                            stats = self._summarize_data_array(main_var)
+                            if stats:
+                                pair_data[metric_name] = stats
 
                 except Exception as e:
                     logger.warning(f"Error reading {nc_file}: {e}")
@@ -1656,11 +1699,9 @@ class ReportGenerator:
                     {% endif %}
                     {% endif %}
                 {% endfor %}
-            </div>
-            {% elif metric_data.summary_omitted %}
-            <h4>{{ metric_key }}</h4>
-            <div class="summary-box">
-                <p>Summary omitted for {{ metric_data.total_points }} points to avoid excessive memory use. Raw result: {{ metric_data.file }}</p>
+                {% if metric_data.median_omitted %}
+                <p>Median omitted for large result; all other statistics were calculated from the complete dataset.</p>
+                {% endif %}
             </div>
             {% elif metric_data.station_format %}
             <!-- Grid vs Grid comprehensive statistics (station format) -->
@@ -1672,17 +1713,13 @@ class ReportGenerator:
                 <p><strong>{{ metric_name }}:</strong> {{ "%.0f"|format(metric_values.mean) }}</p>
                 {% endif %}
                 {% else %}
-                {% if metric_values.summary_omitted %}
-                <p><strong>{{ metric_name }}:</strong> Summary omitted for {{ metric_values.total_points }} points to avoid excessive memory use. Raw result: {{ metric_values.file }}</p>
-                {% else %}
                 <p><strong>{{ metric_name }}:</strong> 
                    Mean = {{ "%.4f"|format(metric_values.mean) }}, 
                    Std = {{ "%.4f"|format(metric_values.std) }}, 
-                   Median = {{ "%.4f"|format(metric_values.median) }}, 
+                   Median = {% if metric_values.median is not none %}{{ "%.4f"|format(metric_values.median) }}{% else %}omitted for large result{% endif %},
                    Range = [{{ "%.4f"|format(metric_values.min) }}, {{ "%.4f"|format(metric_values.max) }}]
                    {% if metric_data.data_coverage is not none %}, Data Coverage = {{ "%.1f"|format(metric_data.data_coverage) }}%{% endif %}
                 </p>
-                {% endif %}
                 {% endif %}
                 {% endfor %}
             </div>

--- a/tests/test_audit_bugfixes.py
+++ b/tests/test_audit_bugfixes.py
@@ -163,6 +163,20 @@ def test_glob_nc_matches_uppercase_extensions(tmp_path):
     assert nc_exists(str(tmp_path / "CASE.nc")) == str(upper)
 
 
+def test_glob_nc_does_not_hide_permission_errors(tmp_path, monkeypatch):
+    from pathlib import Path
+
+    from openbench.data.coordinates import glob_nc
+
+    def denied(_path):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "iterdir", denied)
+
+    with pytest.raises(PermissionError, match="denied"):
+        glob_nc(tmp_path)
+
+
 def test_ubkge_uses_two_component_unbiased_form():
     from openbench.core.metrics import metrics
 

--- a/tests/test_gui_evaluation_runner.py
+++ b/tests/test_gui_evaluation_runner.py
@@ -125,10 +125,12 @@ def test_local_runner_checks_before_run(tmp_path, monkeypatch):
     runner = EvaluationRunner(str(config), python_path="/fake/python")
     monkeypatch.setattr(runner, "_find_python_interpreter", lambda: "/fake/python")
     commands = []
+    environments = []
     processes = iter([FakeProcess(["Ready to run\n"], 0), FakeProcess(["Evaluation complete\n"], 0)])
 
     def fake_popen(command, **kwargs):
         commands.append(command)
+        environments.append(kwargs["env"])
         return next(processes)
 
     monkeypatch.setattr("openbench.gui.runner.subprocess.Popen", fake_popen)
@@ -138,6 +140,7 @@ def test_local_runner_checks_before_run(tmp_path, monkeypatch):
     runner.run()
 
     assert [command[3] for command in commands] == ["check", "run"]
+    assert all(env["OPENBENCH_GUI_PROGRESS"] == "1" for env in environments)
     assert finished[-1][0] is True
 
 
@@ -175,6 +178,23 @@ def test_local_runner_counts_groupby_without_comparison(tmp_path):
     )
 
     assert runner._total_tasks == 3
+
+
+def test_local_runner_uses_exact_evaluation_task_count(tmp_path):
+    runner = EvaluationRunner(str(tmp_path / "openbench.yaml"), python_path="/fake/python")
+
+    runner.set_task_counts(
+        num_variables=2,
+        num_ref_sources=2,
+        num_sim_sources=2,
+        num_metrics=1,
+        num_scores=1,
+        num_groupby=0,
+        num_comparisons=0,
+        num_evaluation_tasks=2,
+    )
+
+    assert runner._total_tasks == 2
 
 
 def test_remote_runner_counts_groupby_without_comparison(tmp_path):

--- a/tests/test_gui_localization.py
+++ b/tests/test_gui_localization.py
@@ -90,6 +90,7 @@ def test_main_window_language_button_updates_existing_pages(qapp, monkeypatch):
         monkeypatch.setattr(QDialog, "exec", lambda self: QDialog.Accepted)
         window.btn_about.click()
         about = next(dialog for dialog in window.findChildren(QDialog) if dialog.windowTitle() == "关于 OpenBench")
+        assert about.testAttribute(Qt.WA_DeleteOnClose)
         about_text = "\n".join(label.text() for label in about.findChildren(QLabel))
         assert "版权所有：CoLM陆面模式开发团队，中山大学大气科学学院" in about_text
         assert "开发与维护\nCoLM陆面模式开发团队" in about_text

--- a/tests/test_gui_remote_scanner_workflow.py
+++ b/tests/test_gui_remote_scanner_workflow.py
@@ -207,8 +207,12 @@ def test_remote_run_command_expands_tilde_paths():
     # '~/OpenBench' is the documented remote default; a shlex-quoted literal
     # tilde would make both cd and the interpreter path fail remotely.
     assert 'cd "$HOME"/OpenBench && ' in cmd
+    assert "OPENBENCH_GUI_PROGRESS=1" in cmd
     assert '"$HOME"/miniconda3/envs/ob/bin/python -u -m openbench check' in cmd
-    assert '&& PYTHONUNBUFFERED=1 "$HOME"/miniconda3/envs/ob/bin/python -u -m openbench run' in cmd
+    assert (
+        "&& PYTHONUNBUFFERED=1 OPENBENCH_GUI_PROGRESS=1 "
+        '"$HOME"/miniconda3/envs/ob/bin/python -u -m openbench run' in cmd
+    )
     assert "'~/" not in cmd
 
 

--- a/tests/test_progress_dashboard.py
+++ b/tests/test_progress_dashboard.py
@@ -1,3 +1,4 @@
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -41,6 +42,30 @@ def test_completed_task_status_can_advance_progress_when_higher(qapp):
 
     assert dashboard.progress_bar.value() == 50
     assert dashboard.progress_label.text() == "50%"
+
+
+def test_resource_usage_updates_from_psutil(qapp, monkeypatch):
+    fake_psutil = SimpleNamespace(
+        cpu_percent=lambda: 37.9,
+        virtual_memory=lambda: SimpleNamespace(percent=62.1),
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    dashboard = ProgressDashboard()
+
+    dashboard._update_resource_usage()
+
+    assert dashboard.cpu_label.text() == "37%"
+    assert dashboard.mem_label.text() == "62%"
+
+
+def test_resource_usage_shows_unavailable_when_psutil_is_missing(qapp, monkeypatch):
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    dashboard = ProgressDashboard()
+
+    dashboard._update_resource_usage()
+
+    assert dashboard.cpu_label.text() == "N/A"
+    assert dashboard.mem_label.text() == "N/A"
 
 
 def _validation_progress_probe():

--- a/tests/test_progress_parser.py
+++ b/tests/test_progress_parser.py
@@ -1,3 +1,4 @@
+from openbench.gui.pages.page_run_monitor import count_evaluation_tasks
 from openbench.gui.progress_parser import parse_progress_line
 
 
@@ -106,3 +107,22 @@ def test_progress_parser_counts_actual_groupby_complete_lines():
         assert progress == 95
         assert stage == "Comparison"
         assert ("Runoff", key) in state["completed_groupby_tasks"]
+
+
+def test_evaluation_task_count_uses_each_variables_bound_sources():
+    config = {
+        "ref_data": {
+            "general": {
+                "Runoff_ref_source": "RefA",
+                "GPP_ref_source": "RefB",
+            }
+        },
+        "sim_data": {
+            "general": {
+                "Runoff_sim_source": ["SimA"],
+                "GPP_sim_source": ["SimB"],
+            }
+        },
+    }
+
+    assert count_evaluation_tasks(config, ["Runoff", "GPP"]) == 2

--- a/tests/test_progress_parser.py
+++ b/tests/test_progress_parser.py
@@ -126,3 +126,19 @@ def test_evaluation_task_count_uses_each_variables_bound_sources():
     }
 
     assert count_evaluation_tasks(config, ["Runoff", "GPP"]) == 2
+
+
+def test_progress_parser_preserves_spaces_in_structured_source_names():
+    state = _state(total_tasks=1)
+    progress, variable, stage = parse_progress_line(
+        'OPENBENCH_PROGRESS {"event":"evaluation_completed","variable":"Runoff Basin","sim":"ERA5 Land",'
+        '"ref":"GLDAS Comparison 2"}',
+        5,
+        state,
+        CONSTANTS,
+    )
+
+    assert progress == 95
+    assert variable == "Runoff Basin"
+    assert stage == "Evaluation"
+    assert ("Runoff Basin", "GLDAS Comparison 2", "ERA5 Land") in state["completed_eval_tasks"]

--- a/tests/test_report_groupby_paths.py
+++ b/tests/test_report_groupby_paths.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from openbench.util.filenames import (
     groupby_class_netcdf_filename,
     groupby_pair_dirname,
@@ -253,21 +255,47 @@ def test_report_grid_stats_do_not_store_full_value_arrays(tmp_path):
     assert metric["mean"] == 7 / 3
 
 
-def test_report_csv_collection_keeps_count_not_full_records_or_recomputed_stats(tmp_path):
+def test_report_csv_collection_streams_summary_without_full_records(tmp_path):
     case_dir = tmp_path / "case"
     metrics_dir = case_dir / "metrics"
+    scores_dir = case_dir / "scores"
     metrics_dir.mkdir(parents=True)
+    scores_dir.mkdir(parents=True)
     (metrics_dir / "Runoff_evaluations.csv").write_text("station,bias\nA,1\nB,3\n", encoding="utf-8")
+    (scores_dir / "Runoff_evaluations.csv").write_text("station,Overall_Score\nA,0\nB,0\n", encoding="utf-8")
 
-    data = ReportGenerator(
-        {"evaluation_items": ["Runoff"], "metrics": {"bias": True}, "scores": {}, "comparisons": {}},
+    generator = ReportGenerator(
+        {
+            "evaluation_items": ["Runoff"],
+            "metrics": {"bias": True},
+            "scores": {"Overall_Score": True},
+            "comparisons": {},
+        },
         str(case_dir),
-    )._collect_metrics_data("Runoff")
+    )
+    data = generator._collect_metrics_data("Runoff")
 
-    assert data["Runoff"] == {"row_count": 2, "summary": {}}
+    assert data["Runoff"]["row_count"] == 2
+    assert "data" not in data["Runoff"]
+    assert data["Runoff"]["summary"]["bias"] == {
+        "mean": 2.0,
+        "std": 2**0.5,
+        "min": 1.0,
+        "max": 3.0,
+        "count": 2,
+    }
+    assert generator._summarize_csv(str(metrics_dir / "Runoff_evaluations.csv"), chunksize=1) == (
+        2,
+        data["Runoff"]["summary"],
+    )
+    report_data = generator._collect_report_data()
+    assert report_data["overall_summary"]["grand_average"] == 0.0
+    html = Path(generator._generate_html_report(report_data, "csv_summary")).read_text(encoding="utf-8")
+    assert "Overall Average Score" in html
+    assert "0.000" in html
 
 
-def test_report_skips_eager_statistics_for_large_netcdf(tmp_path, monkeypatch):
+def test_report_marks_large_netcdf_summary_as_omitted(tmp_path, monkeypatch):
     import openbench.util.report as report_module
 
     case_dir = tmp_path / "case"
@@ -309,4 +337,58 @@ def test_report_skips_eager_statistics_for_large_netcdf(tmp_path, monkeypatch):
         str(case_dir),
     )
 
-    assert generator._collect_metrics_data("Runoff") == {}
+    data = generator._collect_metrics_data("Runoff")
+    metric = data["RefA vs SimA"]["metrics"]["bias"]
+    assert metric["summary_omitted"] is True
+    assert metric["total_points"] == report_module._MAX_REPORT_STAT_POINTS + 1
+
+
+def test_report_does_not_invent_correlation_when_large_real_result_is_omitted(tmp_path, monkeypatch):
+    import openbench.util.report as report_module
+
+    case_dir = tmp_path / "case"
+    metrics_dir = case_dir / "metrics"
+    metrics_dir.mkdir(parents=True)
+    correlation_file = metrics_dir / join_filename_components("Runoff", "ref", "RefA", "sim", "SimA", "correlation")
+    correlation_file.with_suffix(".nc").touch()
+
+    class LargeArray:
+        size = report_module._MAX_REPORT_STAT_POINTS + 1
+
+        @property
+        def values(self):
+            raise AssertionError("large report arrays must not be loaded eagerly")
+
+    class Dataset:
+        data_vars = {"correlation": LargeArray()}
+        coords = {}
+
+        def __getitem__(self, name):
+            return self.data_vars[name]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    monkeypatch.setattr(report_module.xr, "open_dataset", lambda _path: Dataset())
+
+    generator = ReportGenerator(
+        {
+            "evaluation_items": ["Runoff"],
+            "metrics": {"correlation": True},
+            "scores": {},
+            "ref_nml": {"general": {"Runoff_ref_source": "RefA"}},
+            "sim_nml": {"general": {"Case_lib": "SimA"}},
+            "comparisons": {},
+        },
+        str(case_dir),
+    )
+
+    metric = generator._generate_grid_vs_grid_stats("Runoff")["RefA vs SimA"]["metrics"]["correlation"]
+    assert metric == {
+        "summary_omitted": True,
+        "total_points": report_module._MAX_REPORT_STAT_POINTS + 1,
+        "file": correlation_file.with_suffix(".nc").name,
+    }

--- a/tests/test_report_groupby_paths.py
+++ b/tests/test_report_groupby_paths.py
@@ -295,35 +295,18 @@ def test_report_csv_collection_streams_summary_without_full_records(tmp_path):
     assert "0.000" in html
 
 
-def test_report_marks_large_netcdf_summary_as_omitted(tmp_path, monkeypatch):
+def test_report_streams_large_netcdf_statistics(tmp_path, monkeypatch):
+    import numpy as np
+    import xarray as xr
+
     import openbench.util.report as report_module
 
     case_dir = tmp_path / "case"
     metrics_dir = case_dir / "metrics"
     metrics_dir.mkdir(parents=True)
-    (metrics_dir / f"{join_filename_components('Runoff', 'ref', 'RefA', 'sim', 'SimA', 'bias')}.nc").touch()
-
-    class LargeArray:
-        size = report_module._MAX_REPORT_STAT_POINTS + 1
-
-        @property
-        def values(self):
-            raise AssertionError("large report arrays must not be loaded eagerly")
-
-    class Dataset:
-        data_vars = {"bias": LargeArray()}
-        coords = {}
-
-        def __getitem__(self, name):
-            return self.data_vars[name]
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(report_module.xr, "open_dataset", lambda _path: Dataset())
+    metric_file = metrics_dir / f"{join_filename_components('Runoff', 'ref', 'RefA', 'sim', 'SimA', 'bias')}.nc"
+    xr.Dataset({"bias": (("lat", "lon"), np.array([[1.0, 2.0], [np.nan, 4.0]]))}).to_netcdf(metric_file)
+    monkeypatch.setattr(report_module, "_MAX_REPORT_STAT_POINTS", 2)
 
     generator = ReportGenerator(
         {
@@ -339,40 +322,68 @@ def test_report_marks_large_netcdf_summary_as_omitted(tmp_path, monkeypatch):
 
     data = generator._collect_metrics_data("Runoff")
     metric = data["RefA vs SimA"]["metrics"]["bias"]
-    assert metric["summary_omitted"] is True
-    assert metric["total_points"] == report_module._MAX_REPORT_STAT_POINTS + 1
+    assert metric["mean"] == 7 / 3
+    assert metric["std"] == np.std([1.0, 2.0, 4.0])
+    assert metric["min"] == 1.0
+    assert metric["max"] == 4.0
+    assert metric["coverage"] == 75.0
+    assert metric["median"] is None
+    assert metric["median_omitted"] is True
+
+    report_data = generator._collect_report_data()
+    html = Path(generator._generate_html_report(report_data, "large_nc")).read_text(encoding="utf-8")
+    assert "Mean = 2.3333" in html
+    assert "Median = omitted for large result" in html
+    assert "Summary omitted" not in html
 
 
-def test_report_does_not_invent_correlation_when_large_real_result_is_omitted(tmp_path, monkeypatch):
+def test_report_netcdf_summary_never_reads_more_than_chunk_limit():
+    import numpy as np
+
+    class LoadedChunk:
+        def __init__(self, values):
+            self.values = values
+
+    class ChunkedArray:
+        dims = ("lat", "lon")
+
+        def __init__(self):
+            self.data = np.arange(12, dtype=float).reshape(3, 4)
+            self.shape = self.data.shape
+            self.size = self.data.size
+            self.chunk_sizes = []
+
+        @property
+        def values(self):
+            raise AssertionError("the complete array must not be loaded eagerly")
+
+        def isel(self, indexers):
+            chunk = self.data[tuple(indexers[dim] for dim in self.dims)]
+            self.chunk_sizes.append(chunk.size)
+            return LoadedChunk(chunk)
+
+    values = ChunkedArray()
+    stats = ReportGenerator._summarize_data_array(values, max_points=5)
+
+    assert max(values.chunk_sizes) <= 5
+    assert stats["mean"] == 5.5
+    assert stats["median"] is None
+
+
+def test_report_does_not_invent_correlation_for_large_real_result(tmp_path, monkeypatch):
+    import numpy as np
+    import xarray as xr
+
     import openbench.util.report as report_module
 
     case_dir = tmp_path / "case"
     metrics_dir = case_dir / "metrics"
     metrics_dir.mkdir(parents=True)
     correlation_file = metrics_dir / join_filename_components("Runoff", "ref", "RefA", "sim", "SimA", "correlation")
-    correlation_file.with_suffix(".nc").touch()
-
-    class LargeArray:
-        size = report_module._MAX_REPORT_STAT_POINTS + 1
-
-        @property
-        def values(self):
-            raise AssertionError("large report arrays must not be loaded eagerly")
-
-    class Dataset:
-        data_vars = {"correlation": LargeArray()}
-        coords = {}
-
-        def __getitem__(self, name):
-            return self.data_vars[name]
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_args):
-            return False
-
-    monkeypatch.setattr(report_module.xr, "open_dataset", lambda _path: Dataset())
+    xr.Dataset({"correlation": (("lat", "lon"), np.array([[0.1, 0.2], [np.nan, 0.9]]))}).to_netcdf(
+        correlation_file.with_suffix(".nc")
+    )
+    monkeypatch.setattr(report_module, "_MAX_REPORT_STAT_POINTS", 2)
 
     generator = ReportGenerator(
         {
@@ -387,8 +398,7 @@ def test_report_does_not_invent_correlation_when_large_real_result_is_omitted(tm
     )
 
     metric = generator._generate_grid_vs_grid_stats("Runoff")["RefA vs SimA"]["metrics"]["correlation"]
-    assert metric == {
-        "summary_omitted": True,
-        "total_points": report_module._MAX_REPORT_STAT_POINTS + 1,
-        "file": correlation_file.with_suffix(".nc").name,
-    }
+    assert metric["mean"] == 0.4
+    assert metric["coverage"] == 75.0
+    assert metric["median"] is None
+    assert metric["median_omitted"] is True

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -291,6 +291,22 @@ def test_ready_tasks_stay_serial_for_unified_mask_or_only_drawing(monkeypatch):
     assert evaluated == ["SimA", "SimA", "SimA", "SimA", "SimA", "SimA"]
 
 
+def test_ready_tasks_emit_gui_progress_markers(monkeypatch, capsys):
+    import openbench.runner.local as local_runner
+
+    task = {"var_name": "Runoff", "sim_source": "SimA", "ref_source": "RefA"}
+    monkeypatch.setenv("OPENBENCH_GUI_PROGRESS", "1")
+    monkeypatch.setattr(
+        local_runner,
+        "_evaluate_single",
+        lambda _task: {"variable": "Runoff", "sim": "SimA", "ref": "RefA", "status": "success"},
+    )
+
+    local_runner._evaluate_ready_tasks([task], num_cores=1, unified_mask=False, only_drawing=False)
+
+    assert "Completed Runoff: sim=SimA ref=RefA" in capsys.readouterr().out
+
+
 def test_ready_tasks_parallelize_unified_mask_across_ref_groups(monkeypatch):
     """Unified-mask tasks can parallelize across refs after preprocessing is complete."""
     import openbench.runner.local as local_runner

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -304,7 +304,26 @@ def test_ready_tasks_emit_gui_progress_markers(monkeypatch, capsys):
 
     local_runner._evaluate_ready_tasks([task], num_cores=1, unified_mask=False, only_drawing=False)
 
-    assert "Completed Runoff: sim=SimA ref=RefA" in capsys.readouterr().out
+    assert (
+        'OPENBENCH_PROGRESS {"event":"evaluation_completed","variable":"Runoff","sim":"SimA","ref":"RefA"}'
+        in capsys.readouterr().out
+    )
+
+
+def test_failed_tasks_do_not_emit_gui_progress_markers(monkeypatch, capsys):
+    import openbench.runner.local as local_runner
+
+    task = {"var_name": "Runoff", "sim_source": "SimA", "ref_source": "RefA"}
+    monkeypatch.setenv("OPENBENCH_GUI_PROGRESS", "1")
+    monkeypatch.setattr(
+        local_runner,
+        "_evaluate_single",
+        lambda _task: {"variable": "Runoff", "sim": "SimA", "ref": "RefA", "status": "error"},
+    )
+
+    local_runner._evaluate_ready_tasks([task], num_cores=1, unified_mask=False, only_drawing=False)
+
+    assert "OPENBENCH_PROGRESS" not in capsys.readouterr().out
 
 
 def test_ready_tasks_parallelize_unified_mask_across_ref_groups(monkeypatch):


### PR DESCRIPTION
## Summary
- emit exact, Windows-safe GUI progress events and count per-variable task pairs
- restore memory-bounded CSV summaries and remove fabricated correlation estimates
- retain explicit markers for oversized NetCDF summaries instead of silently dropping results
- declare psutil for GUI installs, surface unavailable telemetry, and clean up About dialogs
- propagate filesystem permission errors while preserving explicit CLI fallback warnings

## Scope
Legacy reference aliases are intentionally unchanged per maintainer direction.

## Verification
- 1691 passed, 5 skipped
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m compileall -q src
- built wheel metadata contains psutil for gui/all extras

## Platform gap
Physical Windows GUI was not available locally; the Windows CI matrix is the platform verification.