### PR TITLE
Fix reference workflow correctness and scaling

### DIFF
--- a/src/openbench/config/adapter.py
+++ b/src/openbench/config/adapter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from openbench.config.schema import OpenBenchConfig, is_simple_project_name
@@ -114,8 +114,10 @@ class RunnerBindings:
 
             # Both ref_source and sim_source can be str or list[str] (v2.x compat)
             ref_sources_list = [ref_source] if isinstance(ref_source, str) else list(ref_source)
+            ref_sources_list = list(dict.fromkeys(ref_sources_list))
             if isinstance(sim_sources, str):
                 sim_sources = [sim_sources]
+            sim_sources = list(dict.fromkeys(sim_sources))
 
             # Cartesian product: every (sim, ref) pair becomes a task
             for ref_s in ref_sources_list:
@@ -141,9 +143,11 @@ class RunnerBindings:
                 continue
 
             ref_sources_list = [ref_source] if isinstance(ref_source, str) else list(ref_source)
+            ref_sources_list = list(dict.fromkeys(ref_sources_list))
             sim_sources = sim_general.get(f"{var_name}_sim_source", [])
             if isinstance(sim_sources, str):
                 sim_sources = [sim_sources]
+            sim_sources = list(dict.fromkeys(sim_sources))
 
             for ref_s in ref_sources_list:
                 ref_dtype = self.namelists.reference.get(var_name, {}).get(f"{ref_s}_data_type")
@@ -534,6 +538,81 @@ class StatisticsContext:
     statistic_fig: dict[str, Any]
 
 
+
+_UNSAFE_SOURCE_CHARS = set('<>:"/\\|?*')
+_WINDOWS_RESERVED_SOURCE_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def _assert_path_safe_label(label: object, kind: str) -> None:
+    text = str(label)
+    stripped = text.strip()
+    if (
+        text != stripped
+        or any(ch in _UNSAFE_SOURCE_CHARS or ord(ch) < 32 for ch in text)
+        or text.endswith(".")
+        or text.split(".", 1)[0].upper() in _WINDOWS_RESERVED_SOURCE_NAMES
+    ):
+        from openbench.config.loader import ConfigError
+
+        raise ConfigError(f"{kind} must be path-safe for generated output filenames: {text!r}")
+
+
+def _iter_reference_source_names(cfg: OpenBenchConfig):
+    for value in cfg.reference.sources.values():
+        if isinstance(value, str):
+            yield value
+        else:
+            yield from value
+
+
+def _source_override(cfg: OpenBenchConfig, source_name: str) -> dict[str, Any]:
+    overrides = getattr(cfg.reference, "overrides", {}) or {}
+    for key, value in overrides.items():
+        if str(key).lower() == str(source_name).lower():
+            return value if isinstance(value, dict) else {}
+    return {}
+
+
+def _apply_reference_override(ref_ds, var_map, var_name: str, override: dict[str, Any]):
+    """Apply reference.overrides without mutating registry objects."""
+    if not override:
+        return ref_ds, var_map
+    ds_fields = {k: v for k, v in override.items() if k != "variables" and hasattr(ref_ds, k)}
+    if ds_fields:
+        ref_ds = replace(ref_ds, **ds_fields)
+    var_overrides = override.get("variables") if isinstance(override.get("variables"), dict) else {}
+    var_override = {}
+    for key, value in var_overrides.items():
+        if str(key).lower() == str(var_name).lower() and isinstance(value, dict):
+            var_override = value
+            break
+    if var_override and var_map is not None:
+        var_fields = {k: v for k, v in var_override.items() if hasattr(var_map, k)}
+        if var_fields:
+            var_map = replace(var_map, **var_fields)
+    return ref_ds, var_map
+
+
+def _fallbacks_to_dicts(var_map) -> list[dict[str, Any]]:
+    fallbacks = getattr(var_map, "fallbacks", None) or []
+    result = []
+    for fb in fallbacks:
+        item = {"varname": fb.varname}
+        if getattr(fb, "varunit", ""):
+            item["varunit"] = fb.varunit
+        if getattr(fb, "convert", ""):
+            item["convert"] = fb.convert
+        result.append(item)
+    return result
+
+
 def _resolve_varname(profile_var, root_dir: str | None = None) -> tuple[str, str, str]:
     """Resolve a variable name from profile, handling fallbacks.
 
@@ -640,23 +719,7 @@ def _find_nc_dir(ref_dir: str, data_root: str, sub_dir: str | None) -> str:
                 logger.info("NC files found in subdirectory: %s", child_path)
                 return child_path
 
-    # Strategy 2: fall back from MidRes/HigRes to LowRes
-    if data_root and sub_dir:
-        for res in ("MidRes", "HigRes"):
-            if res in data_root:
-                lowres_root = data_root.replace(res, "LowRes", 1)
-                lowres_dir = os.path.join(lowres_root, sub_dir)
-                if os.path.isdir(lowres_dir) and glob_nc(lowres_dir):
-                    logger.info("Falling back to LowRes: %s", lowres_dir)
-                    return lowres_dir
-                # Also check subdirectories of LowRes
-                if os.path.isdir(lowres_dir):
-                    for child in sorted(os.listdir(lowres_dir)):
-                        child_path = os.path.join(lowres_dir, child)
-                        if os.path.isdir(child_path) and glob_nc(child_path):
-                            logger.info("Falling back to LowRes subdirectory: %s", child_path)
-                            return child_path
-                break
+    # Do not silently substitute a different requested resolution.
 
     return ref_dir
 
@@ -670,6 +733,10 @@ def build_runner_config(cfg: OpenBenchConfig) -> RunnerConfig:
     basename = str(cfg.project.name)
     if not is_simple_project_name(basename):
         raise ConfigError("project.name must be a simple directory name, not a path.")
+    for label in cfg.simulation:
+        _assert_path_safe_label(label, "simulation label")
+    for source_name in _iter_reference_source_names(cfg):
+        _assert_path_safe_label(source_name, "reference source")
 
     try:
         registry = get_registry()
@@ -897,6 +964,8 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
             continue
 
         resolved_name = r.resolved_name
+        if resolved_name:
+            _assert_path_safe_label(resolved_name, "resolved reference source")
         # Accumulate ref source names per variable (str when single, list when multi)
         _ref_source_lists.setdefault(var_name, []).append(resolved_name)
         if resolved_name != r.source_name:
@@ -906,6 +975,9 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
 
         ref_ds = r.ref_ds
         var_map = r.var_map
+        source_override = _source_override(cfg, r.source_name) or _source_override(cfg, resolved_name)
+        if r.status == "ok":
+            ref_ds, var_map = _apply_reference_override(ref_ds, var_map, var_name, source_override)
 
         if r.status == "ok":
             # Construct directory: station data uses its own root_dir;
@@ -913,7 +985,12 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
             if ref_ds.data_type == "stn":
                 data_root = ref_ds.root_dir or cfg.reference.data_root or ""
             else:
-                data_root = cfg.reference.data_root or ref_ds.root_dir or ""
+                data_root = (
+                    (source_override.get("root_dir") if source_override else None)
+                    or cfg.reference.data_root
+                    or ref_ds.root_dir
+                    or ""
+                )
             if not data_root:
                 logger.warning(
                     "No data_root or root_dir for reference %s variable %s. "
@@ -929,9 +1006,18 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
             if ref_dir and ref_ds.data_type != "stn":
                 ref_dir = _find_nc_dir(ref_dir, data_root, var_map.sub_dir)
 
+            ref_varname, ref_varunit, ref_convert = _resolve_varname(var_map, ref_dir)
             section[f"{prefix}_data_type"] = ref_ds.data_type
-            section[f"{prefix}_varname"] = var_map.varname
-            section[f"{prefix}_varunit"] = var_map.varunit
+            section[f"{prefix}_varname"] = ref_varname
+            section[f"{prefix}_varunit"] = ref_varunit
+            if ref_convert:
+                section[f"{prefix}_convert"] = ref_convert
+                setattr(r, "convert_expr", ref_convert)
+            fallback_dicts = _fallbacks_to_dicts(var_map)
+            if fallback_dicts:
+                section[f"{prefix}_fallbacks"] = fallback_dicts
+            if getattr(var_map, "prefix_fallback", None):
+                section[f"{prefix}_prefix_fallback"] = var_map.prefix_fallback
             section[f"{prefix}_data_groupby"] = ref_ds.data_groupby
             section[f"{prefix}_tim_res"] = ref_ds.tim_res
             section[f"{prefix}_grid_res"] = ref_ds.grid_res

--- a/src/openbench/config/loader.py
+++ b/src/openbench/config/loader.py
@@ -800,13 +800,15 @@ def _build_config(raw: dict[str, Any]) -> OpenBenchConfig:
             raw_reference["data_root"] = old_data_root
     canonical_reference = (
         _canonicalize_variable_mapping_keys(
-            {k: v for k, v in raw_reference.items() if k != "data_root"},
+            {k: v for k, v in raw_reference.items() if k not in {"data_root", "overrides"}},
             evaluation_lookup,
             path="reference",
         )
         or {}
     )
     raw_reference = {"data_root": raw_reference.get("data_root"), **canonical_reference}
+    if "overrides" in raw.get("reference", {}):
+        raw_reference["overrides"] = raw["reference"]["overrides"]
     if raw_reference.get("data_root") is None:
         raw_reference.pop("data_root", None)
     reference = _build_reference(raw_reference)
@@ -952,6 +954,57 @@ def _build_evaluation(raw: dict[str, Any]) -> EvaluationConfig:
     return EvaluationConfig(variables=variables)
 
 
+
+_UNSAFE_SOURCE_CHARS = set('<>:"/\\|?*')
+_WINDOWS_RESERVED_SOURCE_NAMES = {
+    "CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))
+}
+
+
+def _validate_path_safe_source_name(source: str, path: str) -> str:
+    text = source.strip()
+    if not text:
+        raise ConfigError(f"{path} must not be empty")
+    if source != text or (
+        any(ch in _UNSAFE_SOURCE_CHARS or ord(ch) < 32 for ch in text)
+        or text.endswith((".",))
+        or text.split(".", 1)[0].upper() in _WINDOWS_RESERVED_SOURCE_NAMES
+    ):
+        raise ConfigError(f"{path} must be a path-safe source name")
+    return text
+
+
+def _validate_reference_overrides(raw: Any) -> dict[str, dict[str, Any]]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ConfigError("reference.overrides must be a mapping")
+    allowed_dataset = {
+        "root_dir",
+        "data_type",
+        "tim_res",
+        "data_groupby",
+        "timezone",
+        "years",
+        "grid_res",
+        "fulllist",
+        "variables",
+    }
+    result: dict[str, dict[str, Any]] = {}
+    for source, override in raw.items():
+        safe_source = _validate_path_safe_source_name(str(source), f"reference.overrides.{source}")
+        if not isinstance(override, dict):
+            raise ConfigError(f"reference.overrides.{source} must be a mapping")
+        _reject_unknown_keys(override, allowed_dataset, f"reference.overrides.{source}")
+        if "root_dir" in override:
+            _validated_required_string(override["root_dir"], f"reference.overrides.{source}.root_dir")
+        variables = override.get("variables")
+        if variables is not None:
+            _validated_variables_mapping(variables, f"reference.overrides.{source}.variables")
+        result[safe_source] = dict(override)
+    return result
+
+
 def _build_reference(raw: Any) -> ReferenceConfig:
     """Build ReferenceConfig: extract data_root, treat rest as variable→source mappings.
 
@@ -964,6 +1017,7 @@ def _build_reference(raw: Any) -> ReferenceConfig:
 
     raw_copy = dict(raw)
     data_root = raw_copy.pop("data_root", None)
+    overrides = _validate_reference_overrides(raw_copy.pop("overrides", None))
     if data_root is not None:
         if not isinstance(data_root, str):
             raise ConfigError(f"reference.data_root must be a string, got {type(data_root).__name__}")
@@ -977,31 +1031,32 @@ def _build_reference(raw: Any) -> ReferenceConfig:
         if isinstance(value, str):
             # Auto-split comma-separated strings (legacy NML form)
             if "," in value:
-                parts = [s.strip() for s in value.split(",") if s.strip()]
+                parts = [_validate_path_safe_source_name(s, f"reference.{key}") for s in value.split(",") if s.strip()]
                 if not parts:
                     raise ConfigError(f"reference.{key} must include at least one source name")
+                if len(set(map(str.lower, parts))) != len(parts):
+                    raise ConfigError(f"reference.{key} contains duplicate reference source")
                 sources[key] = parts if len(parts) > 1 else parts[0]
             else:
-                source = value.strip()
-                if not source:
-                    raise ConfigError(f"reference.{key} must not be empty")
-                sources[key] = source
+                sources[key] = _validate_path_safe_source_name(value, f"reference.{key}")
         elif isinstance(value, list):
             for i, item in enumerate(value):
                 if not isinstance(item, str):
                     raise ConfigError(f"reference.{key}[{i}] must be a string (source name), got {type(item).__name__}")
-                if not item.strip():
-                    raise ConfigError(f"reference.{key}[{i}] must not be empty")
+                _validate_path_safe_source_name(item, f"reference.{key}[{i}]")
             if not value:
                 raise ConfigError(f"reference.{key} must not be an empty list")
             # Single-item list collapses to plain string for downstream simplicity
-            sources[key] = value[0].strip() if len(value) == 1 else [item.strip() for item in value]
+            clean = [_validate_path_safe_source_name(item, f"reference.{key}[{i}]") for i, item in enumerate(value)]
+            if len(set(map(str.lower, clean))) != len(clean):
+                raise ConfigError(f"reference.{key} contains duplicate reference source")
+            sources[key] = clean[0] if len(clean) == 1 else clean
         else:
             raise ConfigError(
                 f"reference.{key} must be a string or list of strings (source name), got {type(value).__name__}"
             )
 
-    return ReferenceConfig(data_root=data_root, sources=sources)
+    return ReferenceConfig(data_root=data_root, sources=sources, overrides=overrides)
 
 
 def _build_simulation(raw: dict[str, Any]) -> dict[str, SimulationEntry]:
@@ -1022,6 +1077,7 @@ def _build_simulation(raw: dict[str, Any]) -> dict[str, SimulationEntry]:
     result = {}
 
     for label, entry in raw_copy.items():
+        _validate_path_safe_source_name(str(label), f"simulation.{label}")
         if not isinstance(entry, dict):
             raise ConfigError(f"simulation.{label} must be a mapping")
         _reject_unknown_keys(entry, _SIMULATION_KEYS, f"simulation.{label}")

--- a/src/openbench/config/migration.py
+++ b/src/openbench/config/migration.py
@@ -236,31 +236,18 @@ def migrate_config(main_config_path: str | Path, output_path: str | Path) -> dic
 
     # Case-insensitive lookup: ref_per_source_root keys are lower-cased
     # because f90nml lower-cases all namelist identifiers.
-    used_roots = [ref_per_source_root[s.lower()] for s in used_source_names if s.lower() in ref_per_source_root]
-    if used_roots:
-        # commonpath raises ValueError if mixing absolute/relative or empty
+    used_root_map = {s: ref_per_source_root[s.lower()] for s in used_source_names if s.lower() in ref_per_source_root}
+    if used_root_map:
+        # Preserve exact per-source roots. A common data_root alone can make
+        # multiple legacy refs resolve to the first child directory.
+        filtered_ref["overrides"] = {source: {"root_dir": root} for source, root in sorted(used_root_map.items())}
+        used_roots = list(used_root_map.values())
         try:
             common = os.path.commonpath(used_roots)
         except ValueError:
             common = ""
-        # Reject trivially-empty / root-only prefixes
-        if common and common not in ("/", "."):
+        if common and common not in ("/", ".") and len(set(used_roots)) == 1:
             filtered_ref["data_root"] = common
-            if len(set(used_roots)) > 1:
-                logger.info(
-                    "Migration: reference paths share common prefix %s; "
-                    "writing as reference.data_root. Per-source roots were: %s",
-                    common,
-                    ref_per_source_root,
-                )
-        else:
-            logger.warning(
-                "Migration: legacy reference root_dir paths have no usable "
-                "common prefix; reference.data_root left unset. Migrated "
-                "config will resolve via registry root_dir, which may not "
-                "match your data layout. Legacy per-source roots: %s",
-                {s: ref_per_source_root[s.lower()] for s in used_source_names if s.lower() in ref_per_source_root},
-            )
 
     new_config: dict[str, Any] = {
         "project": {

--- a/src/openbench/config/resolver.py
+++ b/src/openbench/config/resolver.py
@@ -361,6 +361,16 @@ def resolve_all_references(
             source_names = [source_value]
         else:
             source_names = list(source_value)
+        seen_sources: set[str] = set()
+        for source_name in source_names:
+            norm_source = str(source_name).lower()
+            if norm_source in seen_sources:
+                message = f"Variable '{var_name}' contains duplicate reference source '{source_name}'."
+                if strict:
+                    errors.append(message)
+                    continue
+                raise ConfigError(message)
+            seen_sources.add(norm_source)
 
         for source_name in source_names:
             ctx: TargetResolutionContext | None = base_ctx

--- a/src/openbench/config/schema.py
+++ b/src/openbench/config/schema.py
@@ -143,6 +143,8 @@ class ReferenceConfig:
     data_root: Optional[str] = None  # Root directory for reference datasets
     # Variable -> source name (str) or list (multi-ref).
     sources: dict[str, "str | list[str]"] = field(default_factory=dict)
+    # Optional per-source overrides, keyed by source name.
+    overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/openbench/data/_processing_selection.py
+++ b/src/openbench/data/_processing_selection.py
@@ -12,6 +12,7 @@ from typing import List
 import xarray as xr
 
 from openbench.data.time_utils import decode_nonstandard_time
+from openbench.data.coordinates import NC_SUFFIXES, glob_nc_pattern
 from openbench.util.converttype import Convert_Type
 from openbench.util.names import get_mapping_key_case_insensitive, get_xarray_key_case_insensitive
 
@@ -94,48 +95,60 @@ class SelectionMixin:
                     fallback_found = False
                     try:
                         source = getattr(self, f"{datasource}_source", "")
-                        model = getattr(self, f"{source}_model", source)
-                        from openbench.data.registry.manager import get_registry
+                        runtime_fallbacks = getattr(self, f"{source}_fallbacks", None) or []
+                        primary_unit = getattr(self, f"{datasource}_varunit", "")
+                        for fb in runtime_fallbacks:
+                            fb_var = fb.get("varname") if isinstance(fb, dict) else getattr(fb, "varname", "")
+                            actual_fb_var = get_xarray_key_case_insensitive(ds, fb_var) if fb_var else None
+                            if actual_fb_var is not None:
+                                logging.warning("Variable '%s' not found, using fallback '%s'", target_var, actual_fb_var)
+                                target_var = actual_fb_var
+                                actual_target_var = actual_fb_var
+                                setattr(self, f"{datasource}_varname", [target_var])
+                                fb_convert = fb.get("convert", "") if isinstance(fb, dict) else getattr(fb, "convert", "")
+                                fb_unit = fb.get("varunit", "") if isinstance(fb, dict) else getattr(fb, "varunit", "")
+                                if fb_convert:
+                                    setattr(self, f"_fb_convert_{datasource}", fb_convert)
+                                    setattr(self, f"{datasource}_varunit", primary_unit or fb_unit)
+                                elif fb_unit:
+                                    setattr(self, f"{datasource}_varunit", fb_unit)
+                                fallback_found = True
+                                break
 
-                        mgr = get_registry()
-                        profile = mgr.get_model(model)
-                        item = getattr(self, "item", "")
-                        profile_key = get_mapping_key_case_insensitive(profile.variables, item) if profile else None
-                        if profile and profile_key is not None:
-                            var_mapping = profile.variables[profile_key]
-                            # Try fallbacks
-                            if var_mapping.fallbacks:
-                                for fb in var_mapping.fallbacks:
-                                    actual_fb_var = get_xarray_key_case_insensitive(ds, fb.varname)
-                                    if actual_fb_var is not None:
-                                        logging.warning(
-                                            "Variable '%s' not found, using fallback '%s'",
-                                            target_var,
-                                            actual_fb_var,
-                                        )
-                                        target_var = actual_fb_var
-                                        actual_target_var = actual_fb_var
-                                        setattr(self, f"{datasource}_varname", [target_var])
-                                        # A convert expression transforms the fallback
-                                        # variable into the PRIMARY variable's unit (same
-                                        # contract as
-                                        # config.adapter._resolve_varname_from_profile), so
-                                        # the primary varunit must drive downstream unit
-                                        # conversion. Setting fb.varunit here would let
-                                        # process_units re-apply the conversion the
-                                        # expression already did (e.g. mol→gC ×12.011),
-                                        # inflating NEE/GPP fallbacks by ~12×.
-                                        if fb.convert:
-                                            setattr(self, f"_fb_convert_{datasource}", fb.convert)
-                                            setattr(
-                                                self,
-                                                f"{datasource}_varunit",
-                                                var_mapping.varunit or fb.varunit,
+                        if not fallback_found:
+                            model = getattr(self, f"{source}_model", source)
+                            from openbench.data.registry.manager import get_registry
+
+                            mgr = get_registry()
+                            profile = mgr.get_model(model)
+                            item = getattr(self, "item", "")
+                            profile_key = get_mapping_key_case_insensitive(profile.variables, item) if profile else None
+                            if profile and profile_key is not None:
+                                var_mapping = profile.variables[profile_key]
+                                # Try fallbacks
+                                if var_mapping.fallbacks:
+                                    for fb in var_mapping.fallbacks:
+                                        actual_fb_var = get_xarray_key_case_insensitive(ds, fb.varname)
+                                        if actual_fb_var is not None:
+                                            logging.warning(
+                                                "Variable '%s' not found, using fallback '%s'",
+                                                target_var,
+                                                actual_fb_var,
                                             )
-                                        elif fb.varunit:
-                                            setattr(self, f"{datasource}_varunit", fb.varunit)
-                                        fallback_found = True
-                                        break
+                                            target_var = actual_fb_var
+                                            actual_target_var = actual_fb_var
+                                            setattr(self, f"{datasource}_varname", [target_var])
+                                            if fb.convert:
+                                                setattr(self, f"_fb_convert_{datasource}", fb.convert)
+                                                setattr(
+                                                    self,
+                                                    f"{datasource}_varunit",
+                                                    var_mapping.varunit or fb.varunit,
+                                                )
+                                            elif fb.varunit:
+                                                setattr(self, f"{datasource}_varunit", fb.varunit)
+                                            fallback_found = True
+                                            break
                     except Exception as e:
                         logging.debug("Fallback lookup failed: %s", e)
 
@@ -279,6 +292,10 @@ class SelectionMixin:
 
         try:
             source = getattr(self, f"{datasource}_source", "")
+            for fb in getattr(self, f"{source}_fallbacks", None) or []:
+                fb_var = fb.get("varname") if isinstance(fb, dict) else getattr(fb, "varname", "")
+                if fb_var:
+                    candidates.append(str(fb_var))
             model = getattr(self, f"{source}_model", source)
             from openbench.data.registry.manager import get_registry
 
@@ -312,8 +329,8 @@ class SelectionMixin:
             try:
                 with _xr().open_dataset(file_path, decode_times=False) as ds:
                     inspected = True
-                    available = set(ds.variables)
-                    if any(name in available for name in varnames):
+                    available = {str(name).lower() for name in ds.variables}
+                    if any(str(name).lower() in available for name in varnames):
                         return True
             except Exception as exc:
                 logging.debug("Could not inspect variables in %s: %s", file_path, exc)
@@ -343,7 +360,7 @@ class SelectionMixin:
         candidate_varnames = self._candidate_varnames_for_file_lookup(varname, datasource)
         first_existing_path = None
         for try_prefix in self._prefixes_for_variable_lookup(prefix, datasource, candidate_varnames):
-            for ext in (".nc", ".nc4"):
+            for ext in NC_SUFFIXES:
                 path = os.path.join(dirx, f"{try_prefix}{suffix}{ext}")
                 if os.path.exists(path):
                     if first_existing_path is None:
@@ -385,34 +402,18 @@ class SelectionMixin:
             # entirely. The intentional wildcard is between {year} and {suffix}.
             escaped_prefix = glob.escape(try_prefix)
             escaped_suffix = glob.escape(suffix)
-            # Try primary path (.nc and .nc4)
-            var_files = cached_glob(
-                os.path.join(dirx, f"{escaped_prefix}{year}*{escaped_suffix}.nc"),
-                force_refresh=True,
-            )
-            if not var_files:
-                var_files = cached_glob(
-                    os.path.join(dirx, f"{escaped_prefix}{year}*{escaped_suffix}.nc4"),
-                    force_refresh=True,
-                )
+            # Try primary path with .nc/.nc4 and upper-case variants.
+            var_files = glob_nc_pattern(os.path.join(dirx, f"{escaped_prefix}{year}*{escaped_suffix}.nc"))
             # Try subdirectory path
             if not var_files:
-                var_files = cached_glob(
-                    os.path.join(dirx, str(year), f"{escaped_prefix}{year}*{escaped_suffix}.nc"),
-                    force_refresh=True,
-                )
-            if not var_files:
-                var_files = cached_glob(
-                    os.path.join(dirx, str(year), f"{escaped_prefix}{year}*{escaped_suffix}.nc4"),
-                    force_refresh=True,
-                )
+                var_files = glob_nc_pattern(os.path.join(dirx, str(year), f"{escaped_prefix}{year}*{escaped_suffix}.nc"))
 
             # Filter: only keep files where part between prefix+year and suffix has no letters
             if var_files:
                 filtered = []
                 prefix_escaped = re.escape(try_prefix)
                 suffix_escaped = re.escape(suffix) if suffix else ""
-                pattern = re.compile(rf"^{prefix_escaped}{year}[^a-zA-Z]*{suffix_escaped}\.nc4?$")
+                pattern = re.compile(rf"^{prefix_escaped}{year}[^a-zA-Z]*{suffix_escaped}\.nc4?$", re.IGNORECASE)
                 for f in var_files:
                     if pattern.match(os.path.basename(f)):
                         filtered.append(f)

--- a/src/openbench/data/_processing_station_core.py
+++ b/src/openbench/data/_processing_station_core.py
@@ -136,13 +136,29 @@ class StationProcessingCoreMixin:
                     source_name = getattr(self, f"{source_key}_model")
                 except AttributeError:
                     source_name = source_key
-                # Same priority: compute → filter → direct
+                # Same priority: runtime fallback → compute → filter → direct
+                runtime_fallback_used = False
+                for fb in getattr(self, f"{source_key}_fallbacks", None) or []:
+                    fb_var = fb.get("varname") if isinstance(fb, dict) else getattr(fb, "varname", "")
+                    actual_fb_var = get_xarray_key_case_insensitive(stn_data, fb_var) if fb_var else None
+                    if actual_fb_var is not None:
+                        current_var_list = [actual_fb_var]
+                        ds = stn_data[actual_fb_var]
+                        fb_convert = fb.get("convert", "") if isinstance(fb, dict) else getattr(fb, "convert", "")
+                        fb_unit = fb.get("varunit", "") if isinstance(fb, dict) else getattr(fb, "varunit", "")
+                        if fb_convert:
+                            setattr(self, f"_fb_convert_{datasource}", fb_convert)
+                        elif fb_unit:
+                            setattr(self, f"{datasource}_varunit", fb_unit)
+                        runtime_fallback_used = True
+                        break
+
                 # Priority 1: compute
-                computed = self._try_compute_from_profile(source_name, stn_data, datasource)
+                computed = None if runtime_fallback_used else self._try_compute_from_profile(source_name, stn_data, datasource)
                 if computed is not None:
                     current_var_list = [getattr(self, "item", current_var_list[0])]
                     ds = computed
-                else:
+                elif not runtime_fallback_used:
                     # Priority 2: filter (station filters handle CaMA allocation etc.)
                     try:
                         from openbench.data.custom import load_filter

--- a/src/openbench/data/registry/manager.py
+++ b/src/openbench/data/registry/manager.py
@@ -348,9 +348,9 @@ class RegistryManager:
                         self._references[key] = ref
                         logger.debug("Added new user reference '%s'", name)
                 except Exception as e:
-                    logger.warning("Failed to merge user reference '%s': %s", name, e)
+                    raise RuntimeError(f"Failed to merge user reference {name!r} from {path}: {e}") from e
         except Exception as e:
-            logger.warning("Failed to read user reference catalog %s: %s", path, e)
+            raise RuntimeError(f"Failed to read user reference catalog {path}: {e}") from e
 
     def _merge_reference_dir(self, directory: Path) -> None:
         """Deep-merge individual user reference YAML files."""
@@ -383,7 +383,7 @@ class RegistryManager:
                         self._references[key] = ref
                         logger.debug("Added new user reference '%s' from %s", name, path.name)
             except Exception as e:
-                logger.warning("Failed to merge user reference from %s: %s", path.name, e)
+                raise RuntimeError(f"Failed to read user reference file {path}: {e}") from e
 
     def _merge_model_catalog(self, path: Path) -> None:
         """Deep-merge user model catalog on top of built-in entries."""
@@ -655,6 +655,18 @@ class RegistryManager:
         catalog_path = get_writable_reference_catalog_path()
         with _catalog_write_lock(catalog_path):
             catalog = self._read_catalog(catalog_path)
+            existing_key = next(
+                (candidate for candidate in catalog if normalize_name(candidate) == normalize_name(name)),
+                None,
+            )
+            existing_name = existing_key
+            if existing_name is None:
+                existing = self._references.get(normalize_name(name))
+                existing_name = existing.name if existing is not None else None
+            if existing_name is not None and existing_name != name:
+                raise ValueError(
+                    f"Reference name '{name}' conflicts with existing catalog entry '{existing_name}' case-insensitively"
+                )
             catalog[name] = dataset.to_dict()
             self._write_catalog(catalog_path, catalog)
         self._references[normalize_name(name)] = dataset
@@ -769,24 +781,8 @@ def _auto_resolve_variant(
 
     candidates.sort(key=_score)
 
-    # Prefer variants whose root_dir actually exists on disk
-    best_label, best, best_rank = candidates[0]
-    chosen_reason = f"best match: {best.name} (tim_res={best.tim_res}, grid_res={best.grid_res})"
-
-    if best.root_dir and not Path(best.root_dir).is_dir():
-        for _, ref, _ in candidates[1:]:
-            if ref.root_dir and Path(ref.root_dir).is_dir():
-                logger.info(
-                    "Auto-resolve: preferred %s has no data on disk, using %s instead",
-                    best.name,
-                    ref.name,
-                )
-                reasons.append(f"{best.name} not on disk, switched to {ref.name}")
-                return ref, "; ".join(reasons + [f"selected {ref.name}"])
-        logger.warning("Auto-resolve: %s selected but root_dir not found: %s", best.name, best.root_dir)
-        reasons.append(f"{best.name} selected but root_dir missing")
-
-    reasons.append(chosen_reason)
+    _best_label, best, _best_rank = candidates[0]
+    reasons.append(f"best match: {best.name} (tim_res={best.tim_res}, grid_res={best.grid_res})")
     return best, "; ".join(reasons)
 
 
@@ -825,7 +821,7 @@ def _normalize_legacy_varname_list(var_data: dict) -> tuple[str, list[FallbackVa
 def _build_reference(data: dict) -> ReferenceDataset:
     """Build a ReferenceDataset from a raw dict."""
     variables = {}
-    for var_name, var_data in data.get("variables", {}).items():
+    for var_name, var_data in (data.get("variables") or {}).items():
         primary_varname, fallbacks = _normalize_legacy_varname_list(var_data)
         variables[var_name] = VariableMapping(
             varname=primary_varname,
@@ -905,7 +901,7 @@ def _build_reference(data: dict) -> ReferenceDataset:
 def _build_model(data: dict) -> ModelProfile:
     """Build a ModelProfile from a raw dict."""
     variables = {}
-    for var_name, var_data in data.get("variables", {}).items():
+    for var_name, var_data in (data.get("variables") or {}).items():
         primary_varname, fallbacks = _normalize_legacy_varname_list(var_data)
         variables[var_name] = VariableMapping(
             varname=primary_varname,
@@ -981,7 +977,7 @@ def _deep_merge_model(existing: ModelProfile, overlay: dict) -> ModelProfile:
         delete_key = get_mapping_key_case_insensitive(variables, deleted)
         if delete_key is not None:
             variables.pop(delete_key, None)
-    for var_name, var_data in overlay.get("variables", {}).items():
+    for var_name, var_data in (overlay.get("variables") or {}).items():
         variable_key = get_mapping_key_case_insensitive(variables, var_name) or var_name
         variables[variable_key] = _merge_variable_mapping(
             variables.get(variable_key),
@@ -1059,7 +1055,7 @@ def _deep_merge_reference(existing: ReferenceDataset, overlay: dict) -> Referenc
 
     # Deep-merge variables
     variables = dict(existing.variables)
-    for var_name, var_data in overlay.get("variables", {}).items():
+    for var_name, var_data in (overlay.get("variables") or {}).items():
         variable_key = get_mapping_key_case_insensitive(variables, var_name) or var_name
         if var_data is None:
             variables.pop(variable_key, None)

--- a/src/openbench/data/registry/scanner.py
+++ b/src/openbench/data/registry/scanner.py
@@ -812,10 +812,13 @@ def _grid_resolution_from_subdir(root_sub_dir: str) -> str | None:
 
 def _matching_nc_files(directory: Path, pattern: str | list[str] | tuple[str, ...] | None) -> list[Path]:
     """Return NC files in directory matching one or more profile glob patterns."""
+    from pathlib import PurePosixPath
+
+    from openbench.data.coordinates import NC_SUFFIXES
+
     if not directory.is_dir():
         return []
 
-    patterns: list[str]
     if isinstance(pattern, (list, tuple)):
         patterns = [str(p) for p in pattern]
     elif pattern:
@@ -823,10 +826,22 @@ def _matching_nc_files(directory: Path, pattern: str | list[str] | tuple[str, ..
     else:
         patterns = ["*.nc", "*.nc4"]
 
+    def _casefold_match(file_path: Path, pat: str) -> bool:
+        rel = file_path.relative_to(directory).as_posix().casefold()
+        folded_pat = pat.casefold()
+        if "/" not in folded_pat and "**" not in folded_pat:
+            return fnmatch(file_path.name.casefold(), folded_pat)
+        rel_path = PurePosixPath(rel)
+        return rel_path.match(folded_pat) or (folded_pat.startswith("**/") and rel_path.match(folded_pat[3:]))
+
     files: dict[Path, None] = {}
     for pat in patterns:
         for file_path in directory.glob(pat):
-            if file_path.is_file() and file_path.suffix in {".nc", ".nc4"}:
+            if file_path.is_file() and file_path.suffix in NC_SUFFIXES:
+                files[file_path] = None
+        search = directory.rglob("*") if "/" in pat or "**" in pat else directory.iterdir()
+        for file_path in search:
+            if file_path.is_file() and file_path.suffix in NC_SUFFIXES and _casefold_match(file_path, pat):
                 files[file_path] = None
     return sorted(files)
 

--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -177,6 +177,7 @@ class ConfigManager:
             "max_lon": lon_range[1] if len(lon_range) > 1 else 180.0,
             "time_alignment": project.get("time_alignment", "intersection"),
             "num_cores": project.get("num_cores", DEFAULT_NUM_CORES),
+            "strict_reference": bool(project.get("strict_reference", False)),
             "evaluation": True,
             "comparison": bool((config.get("comparison") or {}).get("enabled", False)),
             "statistics": bool((config.get("statistics") or {}).get("enabled", False)),
@@ -212,6 +213,33 @@ class ConfigManager:
         for var in variables:
             if var in ref_sources:
                 ref_general[f"{var}_ref_source"] = ref_sources[var]
+
+        ref_source_configs: Dict[str, Dict[str, Any]] = {}
+        ref_overrides = reference.get("overrides") if isinstance(reference.get("overrides"), dict) else {}
+        for var in variables:
+            raw_sources = ref_general.get(f"{var}_ref_source", [])
+            source_names = raw_sources if isinstance(raw_sources, list) else [raw_sources]
+            for source_name in [name for name in source_names if name]:
+                override = ref_overrides.get(source_name)
+                if not isinstance(override, dict):
+                    continue
+                general_override: Dict[str, Any] = {}
+                for key in ("root_dir", "data_type", "tim_res", "data_groupby", "timezone", "grid_res", "fulllist"):
+                    if override.get(key) is not None:
+                        general_override[key] = override[key]
+                years_override = override.get("years")
+                if isinstance(years_override, list):
+                    if len(years_override) > 0:
+                        general_override["syear"] = years_override[0]
+                    if len(years_override) > 1:
+                        general_override["eyear"] = years_override[1]
+                variables_override = override.get("variables") if isinstance(override.get("variables"), dict) else {}
+                var_override = variables_override.get(var) if isinstance(variables_override.get(var), dict) else {}
+                ref_source_configs[f"{var}::{source_name}"] = {
+                    "general": general_override,
+                    **dict(var_override),
+                    "_explicit_override": True,
+                }
 
         sim_defaults = simulation.get("_defaults", {}) if isinstance(simulation, dict) else {}
         sim_entries = {k: v for k, v in simulation.items() if k != "_defaults"} if isinstance(simulation, dict) else {}
@@ -255,13 +283,14 @@ class ConfigManager:
             "scores": scores,
             "comparisons": comparisons,
             "statistics": statistics,
-            "ref_data": {"general": ref_general, "def_nml": {}, **ref_metadata},
+            "ref_data": {"general": ref_general, "def_nml": {}, "source_configs": ref_source_configs, **ref_metadata},
             "sim_data": {
                 "general": sim_general,
                 "def_nml": {},
                 "source_configs": sim_source_configs,
                 **({"_scan_root": sim_scan_root} if sim_scan_root else {}),
             },
+            **({"uncertainty": config["uncertainty"]} if isinstance(config.get("uncertainty"), dict) else {}),
         }
 
     def generate_main_nml(
@@ -697,6 +726,8 @@ class ConfigManager:
             project["unified_mask"] = False
         if not general.get("generate_report", True):
             project["generate_report"] = False
+        if general.get("strict_reference"):
+            project["strict_reference"] = True
         dask_config = general.get("dask")
         if isinstance(dask_config, dict) and dask_config.get("enabled"):
             project["dask"] = {k: v for k, v in dask_config.items() if v is not None}
@@ -757,6 +788,63 @@ class ConfigManager:
                 reference[var] = cleaned[0] if len(cleaned) == 1 else cleaned
             elif source:
                 reference[var] = source
+
+        selected_refs_by_var: Dict[str, set[str]] = {}
+        for var in variables:
+            raw_source = ref_general.get(f"{var}_ref_source", "")
+            selected_sources = raw_source if isinstance(raw_source, list) else [raw_source]
+            selected_refs_by_var[var] = {name for name in selected_sources if name}
+
+        def _reference_overrides() -> Dict[str, Any]:
+            overrides: Dict[str, Any] = {}
+            source_configs = ref_data.get("source_configs", {})
+            for compound_key, source_cfg in source_configs.items():
+                if not isinstance(source_cfg, dict) or "::" not in compound_key:
+                    continue
+                var_name, source_name = compound_key.split("::", 1)
+                if var_name not in variables or source_name not in selected_refs_by_var.get(var_name, set()):
+                    continue
+                if not source_cfg.get("_explicit_override"):
+                    continue
+                override = overrides.setdefault(source_name, {})
+                general_cfg = source_cfg.get("general", {}) if isinstance(source_cfg.get("general"), dict) else {}
+                if general_cfg:
+                    for key in ("root_dir", "dir", "data_type", "tim_res", "data_groupby", "timezone", "grid_res", "fulllist"):
+                        value = general_cfg.get(key)
+                        if value not in (None, ""):
+                            out_key = "root_dir" if key == "dir" else key
+                            override[out_key] = _maybe_transform_path(value) if out_key in {"root_dir", "fulllist"} else value
+                    syear = general_cfg.get("syear")
+                    eyear = general_cfg.get("eyear")
+                    if syear not in (None, "") or eyear not in (None, ""):
+                        years = []
+                        if syear not in (None, ""):
+                            years.append(int(syear))
+                        if eyear not in (None, ""):
+                            years.append(int(eyear))
+                        if years:
+                            override["years"] = years
+                var_override = {}
+                for key, value in source_cfg.items():
+                    if key in {"general", "_var_name", "def_nml_path", "var_config", "_explicit_override"}:
+                        continue
+                    if value not in (None, ""):
+                        var_override[key] = value
+                nested_var_cfg = source_cfg.get("var_config")
+                if isinstance(nested_var_cfg, dict):
+                    for key, value in nested_var_cfg.items():
+                        if key == "_explicit_override":
+                            continue
+                        if value not in (None, ""):
+                            var_override.setdefault(key, value)
+                if var_override:
+                    variables_override = override.setdefault("variables", {})
+                    variables_override[var_name] = var_override
+            return {source: override for source, override in overrides.items() if override}
+
+        ref_overrides = _reference_overrides()
+        if ref_overrides:
+            reference["overrides"] = ref_overrides
 
         # --- simulation ---
         sim_data = config.get("sim_data", {})
@@ -859,6 +947,9 @@ class ConfigManager:
             output["comparison"] = comparison
         if stats_section:
             output["statistics"] = stats_section
+        uncertainty = config.get("uncertainty")
+        if isinstance(uncertainty, dict) and uncertainty:
+            output["uncertainty"] = {k: v for k, v in uncertainty.items() if v is not None}
 
         return yaml.dump(output, default_flow_style=False, allow_unicode=True, sort_keys=False, indent=2)
 
@@ -1092,7 +1183,7 @@ class ConfigManager:
                     organized_configs[source_name]["_general"] = config["general"].copy()
                 # Store var-specific config - copy all fields except internal ones
                 var_config = {}
-                skip_fields = {"general", "_var_name", "def_nml_path"}
+                skip_fields = {"general", "_var_name", "def_nml_path", "_explicit_override"}
                 for field, value in config.items():
                     if field not in skip_fields:
                         var_config[field] = value

--- a/src/openbench/gui/data_validator.py
+++ b/src/openbench/gui/data_validator.py
@@ -13,11 +13,16 @@ import shlex
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any
 
+from openbench.data.coordinates import NC_SUFFIXES
 from openbench.gui.remote_python import quote_remote_path
 from openbench.gui.widgets._ssh_worker import execute_responsive
 from openbench.gui.path_utils import to_absolute_path, get_openbench_root
 
 logger = logging.getLogger(__name__)
+
+
+def _has_nc_suffix(value: str) -> bool:
+    return value.casefold().endswith(tuple(suffix.casefold() for suffix in NC_SUFFIXES))
 
 
 def safe_open(path: str):
@@ -159,6 +164,22 @@ class FilePathGenerator:
             return f"{base_dir.rstrip('/')}/{filename}"
         return os.path.join(base_dir, filename)
 
+    def _candidate_filenames(self) -> List[str]:
+        base = f"{self.prefix}{self.suffix}"
+        if _has_nc_suffix(base):
+            return [base]
+        return [f"{base}{ext}" for ext in NC_SUFFIXES]
+
+    def _candidate_patterns(self) -> List[str]:
+        base = f"{self.prefix}*{self.suffix}"
+        if _has_nc_suffix(base):
+            return [base]
+        return [f"{base}{ext}" for ext in NC_SUFFIXES]
+
+    def describe_pattern(self) -> str:
+        patterns = self._candidate_patterns()
+        return patterns[0] if len(patterns) == 1 else "{" + ",".join(patterns) + "}"
+
     def get_sample_paths(self) -> List[str]:
         """Get sample file paths for validation.
 
@@ -167,24 +188,28 @@ class FilePathGenerator:
         """
         base_dir = self._get_base_dir()
 
-        if self.data_groupby == "Single":
-            # Exact match for single file
-            filename = f"{self.prefix}{self.suffix}.nc"
-            return [self._build_path(filename)]
+        if str(self.data_groupby).lower() == "single":
+            candidates = [self._build_path(filename) for filename in self._candidate_filenames()]
+            if self._is_remote:
+                return candidates
+            existing = [path for path in candidates if os.path.exists(path)]
+            return existing or candidates[:1]
 
-        # For Year/Month/Day, use glob to find matching files
-        # Pattern: {prefix}*{suffix}.nc
-        pattern = f"{self.prefix}*{self.suffix}.nc"
+        # For Year/Month/Day, use glob to find matching files.
+        patterns = self._candidate_patterns()
 
         if self._is_remote and self._ssh_manager:
             # Remote mode: use SSH to list files
-            matching_files = self._remote_glob(base_dir, pattern)
+            matching_files = self._remote_glob(base_dir, patterns)
         else:
             # Local mode: use local glob
             import glob
 
-            full_pattern = os.path.join(base_dir, pattern)
-            matching_files = sorted(glob.glob(full_pattern))
+            matching_files = []
+            for pattern in patterns:
+                full_pattern = os.path.join(base_dir, pattern)
+                matching_files.extend(glob.glob(full_pattern))
+            matching_files = sorted(set(matching_files))
 
         if matching_files:
             # Return first, middle, and last file as samples
@@ -200,20 +225,30 @@ class FilePathGenerator:
         # The validation will report "no files found"
         return []
 
-    def _remote_glob(self, base_dir: str, pattern: str) -> List[str]:
+    def _remote_glob(self, base_dir: str, patterns: List[str]) -> List[str]:
         """Find files matching pattern on remote server via SSH."""
         self.last_error = None
+        pattern_desc = patterns[0] if len(patterns) == 1 else "{" + ",".join(patterns) + "}"
         try:
             # Use find command to match files
-            cmd = f"find {quote_remote_path(base_dir)} -maxdepth 1 -name {shlex.quote(pattern)} -type f 2>/dev/null | sort"
+            if len(patterns) == 1:
+                name_expr = f"-name {shlex.quote(patterns[0])}"
+            else:
+                parts = []
+                for index, pattern in enumerate(patterns):
+                    if index:
+                        parts.append("-o")
+                    parts.extend(["-name", shlex.quote(pattern)])
+                name_expr = r"\( " + " ".join(parts) + r" \)"
+            cmd = f"find {quote_remote_path(base_dir)} -maxdepth 1 {name_expr} -type f 2>/dev/null | sort"
             stdout, stderr, exit_code = execute_responsive(self._ssh_manager, cmd, timeout=30)
             if exit_code == 0 and stdout.strip():
                 return [line.strip() for line in stdout.strip().split("\n") if line.strip()]
             if exit_code != 0:
                 detail = stderr.strip() or stdout.strip() or f"exit code {exit_code}"
-                self.last_error = f"Remote glob failed for {base_dir.rstrip('/')}/{pattern}: {detail}"
+                self.last_error = f"Remote glob failed for {base_dir.rstrip('/')}/{pattern_desc}: {detail}"
         except Exception as exc:
-            self.last_error = f"Remote glob failed for {base_dir.rstrip('/')}/{pattern}: {exc}"
+            self.last_error = f"Remote glob failed for {base_dir.rstrip('/')}/{pattern_desc}: {exc}"
             logger.warning("%s", self.last_error)
         return []
 
@@ -592,10 +627,34 @@ class DataValidator:
                             f"Data years {data_syear}-{data_eyear} do not overlap required years {syear}-{eyear}",
                         )
                     )
+                elif data_syear > syear or data_eyear < eyear:
+                    checks.append(
+                        ValidationCheck(
+                            "time_range",
+                            False,
+                            f"Data years {data_syear}-{data_eyear} do not cover required years {syear}-{eyear}",
+                        )
+                    )
 
-        # For station data without prefix/suffix, skip file path validation
-        # Station data files may not follow the standard naming pattern
+        # For station data without prefix/suffix, validate the reachable root
+        # and station list rather than returning an empty successful result.
         if data_type == "stn" and not prefix and not suffix:
+            base_dir = FilePathGenerator(
+                root_dir=root_dir,
+                sub_dir=sub_dir,
+                prefix=prefix,
+                suffix=suffix,
+                data_groupby=data_groupby,
+                syear=syear,
+                eyear=eyear,
+                is_remote=self._is_remote,
+                ssh_manager=self._ssh_manager,
+                remote_openbench_root=self._remote_openbench_root,
+            )._get_base_dir()
+            checks.append(self._check_directory_exists(base_dir))
+            fulllist = general.get("fulllist") or source_config.get("fulllist") or var_config.get("fulllist")
+            if fulllist:
+                checks.append(self._check_file_exists(self._resolve_aux_path(fulllist, root_dir)))
             return SourceValidationResult(var_name, source_name, checks)
 
         # Generate file paths
@@ -618,7 +677,7 @@ class DataValidator:
         if not sample_paths:
             # No files found matching the pattern, or remote listing failed.
             base_dir = path_gen._get_base_dir()
-            pattern = f"{prefix}*{suffix}.nc"
+            pattern = path_gen.describe_pattern()
             if getattr(path_gen, "last_error", None):
                 checks.append(ValidationCheck("file_exists", False, path_gen.last_error))
             else:
@@ -643,11 +702,53 @@ class DataValidator:
 
         # Check time range (only for grid data with Single groupby)
         # For Year/Month/Day groupby, each file only contains partial data
-        if data_type == "grid" and data_groupby == "Single":
+        if data_type == "grid" and str(data_groupby).lower() == "single":
             check = self._validator.check_time_range(first_existing_path, int(syear), int(eyear))
             checks.append(check)
 
+        if data_type == "grid" and all(k in general_config for k in ("min_lat", "max_lat", "min_lon", "max_lon")):
+            checks.append(
+                self._validator.check_spatial_range(
+                    first_existing_path,
+                    float(general_config["min_lat"]),
+                    float(general_config["max_lat"]),
+                    float(general_config["min_lon"]),
+                    float(general_config["max_lon"]),
+                )
+            )
+
         return SourceValidationResult(var_name, source_name, checks)
+
+    def _resolve_aux_path(self, path: str, root_dir: str) -> str:
+        if self._is_remote:
+            normalized = str(path).replace("\\", "/")
+            if normalized.startswith("/"):
+                return normalized
+            root = str(root_dir).replace("\\", "/")
+            return f"{root.rstrip('/')}/{normalized}"
+        if os.path.isabs(str(path)):
+            return str(path)
+        return os.path.join(to_absolute_path(str(root_dir), get_openbench_root()), str(path))
+
+    def _check_directory_exists(self, path: str) -> ValidationCheck:
+        if self._is_remote and self._ssh_manager:
+            try:
+                stdout, stderr, exit_code = execute_responsive(
+                    self._ssh_manager, f"test -d {quote_remote_path(path)}", timeout=10
+                )
+                if exit_code == 0:
+                    return ValidationCheck("directory_exists", True, f"Directory exists: {path}")
+                detail = stderr.strip() or stdout.strip()
+                suffix = f": {detail}" if detail else ""
+                return ValidationCheck("directory_exists", False, f"Directory not found: {path}{suffix}")
+            except Exception as exc:
+                return ValidationCheck("directory_exists", False, f"Remote directory check failed: {exc}")
+        if os.path.isdir(path):
+            return ValidationCheck("directory_exists", True, f"Directory exists: {path}")
+        return ValidationCheck("directory_exists", False, f"Directory not found: {path}")
+
+    def _check_file_exists(self, path: str) -> ValidationCheck:
+        return self._validator.check_file_exists(path)
 
     def validate_all(
         self, sources: Dict[str, Dict[str, Dict]], general_config: Dict[str, Any], progress_callback=None

--- a/src/openbench/gui/pages/page_general.py
+++ b/src/openbench/gui/pages/page_general.py
@@ -796,6 +796,7 @@ class PageGeneral(BasePage):
             "python_path": existing_general.get("python_path", ""),
             "conda_env": existing_general.get("conda_env", ""),
             "local_openbench_path": existing_general.get("local_openbench_path", ""),
+            "strict_reference": bool(existing_general.get("strict_reference", False)),
         }
 
         io_config = self._collect_io_config(existing_general)

--- a/src/openbench/gui/pages/page_ref_data.py
+++ b/src/openbench/gui/pages/page_ref_data.py
@@ -51,27 +51,30 @@ from openbench.gui.path_utils import get_remote_ssh_manager
 def _registry_source_data(var_name: str, source_name: str) -> dict | None:
     """Build the GUI source config directly from a registry descriptor."""
     from openbench.data.registry.manager import get_registry
+    from openbench.util.names import get_mapping_key_case_insensitive
 
     ref = get_registry().get_reference(source_name)
     if ref is None:
         return None
 
+    years = list(ref.years or [])
     general = {
         "root_dir": ref.root_dir or "",
         "data_type": ref.data_type,
         "tim_res": ref.tim_res,
         "data_groupby": ref.data_groupby,
         "timezone": ref.timezone,
-        "syear": ref.years[0] if ref.years else "",
-        "eyear": ref.years[1] if len(ref.years) > 1 else "",
+        "syear": years[0] if years else "",
+        "eyear": years[1] if len(years) > 1 else "",
     }
     if ref.grid_res is not None:
         general["grid_res"] = ref.grid_res
     if ref.fulllist:
         general["fulllist"] = ref.fulllist
 
-    source_data = {"general": general}
-    var_mapping = ref.variables.get(var_name)
+    source_data = {"general": general, "_explicit_override": False}
+    var_key = get_mapping_key_case_insensitive(ref.variables or {}, var_name)
+    var_mapping = ref.variables.get(var_key) if var_key is not None else None
     if var_mapping:
         source_data.update(
             {
@@ -577,8 +580,7 @@ class PageRefData(BasePage):
                 combo.setCurrentIndex(0)
                 combo.blockSignals(False)
                 return
-            # After picker, select the resolved item in the combo if present,
-            # otherwise just proceed with the source_name we got.
+            self._select_combo_source(combo, source_name)
         else:
             source_name = combo_data
 
@@ -595,6 +597,19 @@ class PageRefData(BasePage):
 
         except ImportError:
             QMessageBox.warning(self, "Error", "Registry module not available.")
+
+    def _select_combo_source(self, combo: QComboBox, source_name: str):
+        """Make combo state reflect a resolved dataset name instead of a group row."""
+        combo.blockSignals(True)
+        try:
+            for i in range(combo.count()):
+                if combo.itemData(i) == source_name:
+                    combo.setCurrentIndex(i)
+                    return
+            combo.addItem(source_name, source_name)
+            combo.setCurrentIndex(combo.count() - 1)
+        finally:
+            combo.blockSignals(False)
 
     def _fill_advanced_fields(self, var_name: str, source_data: dict):
         """Populate the Advanced fields from *source_data*."""
@@ -619,6 +634,8 @@ class PageRefData(BasePage):
         # There is exactly one source per variable now
         source_name = next(iter(sources))
         source_data = sources[source_name]
+
+        source_data["_explicit_override"] = True
 
         fields = self._var_advanced_fields.get(var_name, {})
         for key, line_edit in fields.items():
@@ -678,8 +695,9 @@ class PageRefData(BasePage):
     def load_from_config(self):
         """Load from config.
 
-        For each variable, reads the single ``{var}_ref_source`` value, restores
-        the combo selection, and fills the advanced fields.
+        For each variable, reads the ``{var}_ref_source`` value, restores
+        all selected sources, and fills the advanced fields from the first
+        source that the single-select GUI can display.
         """
         import os
         import yaml
@@ -717,80 +735,77 @@ class PageRefData(BasePage):
         for var_name in selected:
             key = f"{var_name}_ref_source"
             raw = general_section.get(key, "")
-            # Accept both string and single-element list for backward compat
-            if isinstance(raw, list):
-                source_name = raw[0] if raw else ""
-            else:
-                source_name = raw or ""
-
-            if not source_name:
+            source_names = [name for name in raw if name] if isinstance(raw, list) else ([raw] if raw else [])
+            if not source_names:
                 continue
 
-            # Try to restore from saved source_configs (compound key)
-            compound_key = f"{var_name}::{source_name}"
-            source_data = None
+            loaded_sources = {}
+            first_source_data = None
+            for source_name in source_names:
+                # Try to restore from saved source_configs (compound key)
+                compound_key = f"{var_name}::{source_name}"
+                source_data = None
 
-            if compound_key in saved_source_configs:
-                saved = saved_source_configs[compound_key]
-                general = saved.get("general", {})
-                if general.get("root_dir") or general.get("dir"):
-                    source_data = saved.copy()
+                explicit_override = False
+                if compound_key in saved_source_configs and isinstance(saved_source_configs[compound_key], dict):
+                    source_data = saved_source_configs[compound_key].copy()
+                    source_data.setdefault("_explicit_override", True)
+                    explicit_override = bool(source_data.get("_explicit_override"))
 
-            # Fall back to def_nml file
-            if source_data is None:
-                def_nml_path = def_nml.get(source_name, "")
-                source_data = {"def_nml_path": def_nml_path}
+                # Fall back to def_nml file
+                if source_data is None:
+                    def_nml_path = def_nml.get(source_name, "")
+                    source_data = {"def_nml_path": def_nml_path}
 
-                if def_nml_path:
-                    nml_content = None
+                    if def_nml_path:
+                        nml_content = None
 
-                    if is_remote:
-                        if ssh_manager and ssh_manager.is_connected:
-                            remote_path = self._resolve_remote_def_nml_path(ssh_manager, def_nml_path)
-                            nml_content = self._load_remote_nml_content(ssh_manager, remote_path)
-                    else:
-                        full_path = self._resolve_def_nml_path(def_nml_path)
-                        if full_path and os.path.exists(full_path):
-                            try:
-                                with open(full_path, "r", encoding="utf-8") as f:
-                                    nml_content = yaml.safe_load(f) or {}
-                            except Exception as e:
-                                logger.warning("Failed to load def_nml file %s: %s", full_path, e)
+                        if is_remote:
+                            if ssh_manager and ssh_manager.is_connected:
+                                remote_path = self._resolve_remote_def_nml_path(ssh_manager, def_nml_path)
+                                nml_content = self._load_remote_nml_content(ssh_manager, remote_path)
+                        else:
+                            full_path = self._resolve_def_nml_path(def_nml_path)
+                            if full_path and os.path.exists(full_path):
+                                try:
+                                    with open(full_path, "r", encoding="utf-8") as f:
+                                        nml_content = yaml.safe_load(f) or {}
+                                except Exception as e:
+                                    logger.warning("Failed to load def_nml file %s: %s", full_path, e)
 
-                    if nml_content:
-                        if "general" in nml_content:
-                            source_data["general"] = nml_content["general"].copy()
-                        if var_name in nml_content:
-                            for field, value in nml_content[var_name].items():
-                                source_data[field] = value
+                        if nml_content:
+                            explicit_override = True
+                            if "general" in nml_content:
+                                source_data["general"] = nml_content["general"].copy()
+                            if var_name in nml_content:
+                                for field, value in nml_content[var_name].items():
+                                    source_data[field] = value
+                            source_data["_explicit_override"] = True
 
-            registry_data = _registry_source_data(var_name, source_name)
-            if registry_data:
-                registry_data["general"].update(source_data.get("general", {}))
-                registry_data.update({key: value for key, value in source_data.items() if key != "general"})
-                source_data = registry_data
+                registry_data = _registry_source_data(var_name, source_name)
+                if registry_data:
+                    registry_data["general"].update(source_data.get("general", {}))
+                    registry_data.update({key: value for key, value in source_data.items() if key != "general"})
+                    registry_data["_explicit_override"] = explicit_override
+                    source_data = registry_data
+                else:
+                    source_data["_explicit_override"] = explicit_override
 
-            self._source_configs[var_name] = {source_name: source_data}
+                loaded_sources[source_name] = source_data
+                if first_source_data is None:
+                    first_source_data = source_data
 
-            # Set the combo to the matching item (block signals to avoid re-trigger)
+            self._source_configs[var_name] = loaded_sources
+
+            first_source_name = next(iter(loaded_sources))
+            # Set the combo to the first matching item (block signals to avoid re-trigger)
             combo = self._var_combos.get(var_name)
             if combo:
-                combo.blockSignals(True)
-                matched = False
-                for i in range(combo.count()):
-                    item_data = combo.itemData(i)
-                    if item_data == source_name:
-                        combo.setCurrentIndex(i)
-                        matched = True
-                        break
-                if not matched:
-                    # Source not in combo — add it as a custom entry
-                    combo.addItem(source_name, source_name)
-                    combo.setCurrentIndex(combo.count() - 1)
-                combo.blockSignals(False)
+                self._select_combo_source(combo, first_source_name)
 
-            # Fill advanced fields
-            self._fill_advanced_fields(var_name, source_data)
+            # Fill advanced fields from the first displayed source
+            if first_source_data is not None:
+                self._fill_advanced_fields(var_name, first_source_data)
 
         # Persist loaded state back
         if self._source_configs:
@@ -895,7 +910,7 @@ class PageRefData(BasePage):
     def save_to_config(self):
         """Save to config.
 
-        Each variable stores exactly one source name as a string in
+        Each variable stores a source name as a string or a list of names in
         ``ref_data["general"]["{var}_ref_source"]``.
         """
         existing_ref_data = self.controller.config.get("ref_data", {})
@@ -922,20 +937,22 @@ class PageRefData(BasePage):
 
         for var_name, sources in self._source_configs.items():
             if sources:
-                # Single source per variable — store the name as a plain string
-                source_name = next(iter(sources))
-                general[f"{var_name}_ref_source"] = source_name
+                source_names = [name for name in sources if name]
+                if not source_names:
+                    continue
+                general[f"{var_name}_ref_source"] = source_names[0] if len(source_names) == 1 else source_names
 
-                source_data = sources[source_name]
-                def_nml_path = source_data.get("def_nml_path", "")
-                if not def_nml_path:
-                    basedir = self.controller.config.get("general", {}).get("basedir", "./output")
-                    def_nml_path = f"{basedir}/nml/ref/{source_name}.yaml"
-                def_nml[source_name] = def_nml_path
+                for source_name in source_names:
+                    source_data = sources[source_name]
+                    def_nml_path = source_data.get("def_nml_path", "")
+                    if not def_nml_path:
+                        basedir = self.controller.config.get("general", {}).get("basedir", "./output")
+                        def_nml_path = f"{basedir}/nml/ref/{source_name}.yaml"
+                    def_nml[source_name] = def_nml_path
 
-                compound_key = f"{var_name}::{source_name}"
-                source_configs[compound_key] = source_data.copy()
-                source_configs[compound_key]["_var_name"] = var_name
+                    compound_key = f"{var_name}::{source_name}"
+                    source_configs[compound_key] = source_data.copy()
+                    source_configs[compound_key]["_var_name"] = var_name
 
         ref_data = {
             **preserved,

--- a/src/openbench/gui/pages/page_registry.py
+++ b/src/openbench/gui/pages/page_registry.py
@@ -34,6 +34,7 @@ from PySide6.QtCore import Qt
 
 from openbench.gui.pages.base_page import BasePage
 from openbench.gui.path_utils import browse_directory
+from openbench.util.names import get_mapping_key_case_insensitive
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,51 @@ def _get_row_fallbacks(table, row) -> list:
         return []
     raw = item.data(FALLBACKS_ROLE)
     return list(raw) if isinstance(raw, list) else []
+
+
+def _merge_reference_editor_dataset(existing, edited):
+    """Apply visible editor fields without dropping hidden registry metadata."""
+    if existing is None:
+        return edited
+    schema = _schema()
+
+    variables = {}
+    for var_name, edited_var in edited.variables.items():
+        existing_key = get_mapping_key_case_insensitive(existing.variables, var_name)
+        old_var = existing.variables.get(existing_key) if existing_key is not None else None
+        if old_var is None:
+            variables[var_name] = edited_var
+            continue
+        variables[var_name] = schema.VariableMapping(
+            varname=edited_var.varname,
+            varunit=edited_var.varunit,
+            prefix=edited_var.prefix,
+            suffix=edited_var.suffix,
+            sub_dir=edited_var.sub_dir,
+            fallbacks=edited_var.fallbacks,
+            fulllist=old_var.fulllist,
+            max_uparea=old_var.max_uparea,
+            min_uparea=old_var.min_uparea,
+            compute=old_var.compute,
+            prefix_fallback=old_var.prefix_fallback,
+        )
+
+    return schema.ReferenceDataset(
+        name=edited.name,
+        description=edited.description,
+        category=edited.category,
+        data_type=edited.data_type,
+        tim_res=edited.tim_res,
+        data_groupby=edited.data_groupby,
+        timezone=edited.timezone,
+        years=existing.years,
+        variables=variables,
+        grid_res=edited.grid_res,
+        fulllist=existing.fulllist,
+        root_dir=edited.root_dir,
+        station_matching=existing.station_matching,
+        _provenance=existing._provenance,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -669,6 +715,7 @@ class PageRegistry(BasePage):
                 self.dataset_list.addItem(item)
         except Exception as exc:
             logger.warning("Failed to list references: %s", exc)
+            QMessageBox.critical(self, "Registry Error", f"Failed to load reference registry:\n{exc}")
 
     def _on_dataset_selected(self, row: int):
         if row < 0:
@@ -1083,7 +1130,13 @@ class PageRegistry(BasePage):
         )
 
         try:
-            _get_registry().save_reference(name, dataset)
+            existing_name = name
+            item = self.dataset_list.currentItem() if getattr(self, "dataset_list", None) is not None else None
+            if item is not None:
+                existing_name = item.data(Qt.UserRole) or name
+            registry = _get_registry()
+            dataset = _merge_reference_editor_dataset(registry.get_reference(existing_name), dataset)
+            registry.save_reference(name, dataset)
             _clear_cache()
             self._refresh_dataset_list()
             QMessageBox.information(self, "Saved", f"Dataset '{name}' saved to registry.")

--- a/src/openbench/runner/hashing.py
+++ b/src/openbench/runner/hashing.py
@@ -92,10 +92,24 @@ ALGORITHM_SOURCE_MODULES = (
 )
 
 
-def source_specific_section(section: dict[str, Any], source: str) -> dict[str, Any]:
+def source_specific_section(
+    section: dict[str, Any],
+    source: str,
+    *,
+    all_sources: list[str] | tuple[str, ...] | set[str] = (),
+) -> dict[str, Any]:
     """Return legacy namelist keys owned by one reference/simulation source."""
     prefix = f"{source}_"
-    return {key: value for key, value in section.items() if str(key).startswith(prefix)}
+    nested_prefixes = tuple(
+        f"{candidate}_"
+        for candidate in all_sources
+        if candidate != source and str(candidate).startswith(prefix)
+    )
+    return {
+        key: value
+        for key, value in section.items()
+        if str(key).startswith(prefix) and not str(key).startswith(nested_prefixes)
+    }
 
 
 def legacy_source_value(section: dict[str, Any], source: str, field: str, default: Any = "") -> Any:
@@ -323,7 +337,9 @@ def shared_mask_peer_payload(
             {
                 "sim_source": peer_source,
                 "config": stable_hash_data(sim_entry),
-                "namelist": stable_hash_data(source_specific_section(sim_section, peer_source)),
+                "namelist": stable_hash_data(
+                    source_specific_section(sim_section, peer_source, all_sources=candidate_sources)
+                ),
                 "inputs": input_file_signature(sim_section, peer_source),
             }
         )
@@ -360,8 +376,18 @@ def task_hash_payload(
     ref_section = {}
     sim_section = {}
     if namelists is not None:
-        ref_section = source_specific_section(namelists.reference.get(var_name, {}), ref_source)
-        sim_section = source_specific_section(namelists.simulation.get(var_name, {}), sim_source)
+        configured_refs = cfg.reference.sources.get(var_name, [])
+        ref_sources = [configured_refs] if isinstance(configured_refs, str) else list(configured_refs)
+        ref_section = source_specific_section(
+            namelists.reference.get(var_name, {}),
+            ref_source,
+            all_sources=ref_sources,
+        )
+        sim_section = source_specific_section(
+            namelists.simulation.get(var_name, {}),
+            sim_source,
+            all_sources=list(cfg.simulation),
+        )
 
     general_keys = (
         "syear",

--- a/src/openbench/runner/masking.py
+++ b/src/openbench/runner/masking.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 from typing import Callable
 
 logger = logging.getLogger(__name__)
@@ -51,11 +52,12 @@ def apply_unified_mask(
 
     ref_ds = None
     sim_ds = None
+    staged_path = None
     try:
         import xarray as xr
 
-        ref_ds = xr.open_dataset(ref_path)
-        sim_ds = xr.open_dataset(sim_path)
+        ref_ds = xr.open_dataset(ref_path, chunks="auto")
+        sim_ds = xr.open_dataset(sim_path, chunks="auto")
 
         # The flat file stores the variable under the configured name OR the
         # relabelled evaluation item (when a fallback/convert derived it, e.g.
@@ -99,28 +101,34 @@ def apply_unified_mask(
             if o_aligned.sizes.get("time", 0) == 0:
                 raise ValueError(f"Unified mask: no overlapping timestamps for {var_name}")
 
-        # Apply mask: NaN where either is NaN
-        mask = np.isnan(s_aligned.values) | np.isnan(o_aligned.values)
-        o_data = o.load()
+        # Keep the mask lazy so chunked/dask-backed inputs are not materialized
+        # twice in memory before the NetCDF writer gets a chance to stream them.
+        invalid_overlap = ~(np.isfinite(s_aligned) & np.isfinite(o_aligned))
         if same_values:
-            o_data.values[mask] = np.nan
+            o_data = o.where(~invalid_overlap)
         else:
-            masked_overlap = o_aligned.load()
-            masked_overlap.values[mask] = np.nan
-            o_data.loc[{"time": masked_overlap["time"]}] = masked_overlap
+            invalid_full = invalid_overlap.reindex_like(o, fill_value=False)
+            o_data = o.where(~invalid_full)
 
-        # Close datasets before writing
+        # Write to a sibling staging target while the lazy source datasets are
+        # open, then close them before replacing the original. Windows refuses
+        # to replace an open NetCDF file even when the replacement itself is atomic.
+        fd, staged_path = tempfile.mkstemp(
+            prefix=f".{os.path.basename(ref_path)}.mask-",
+            suffix=".nc",
+            dir=os.path.dirname(ref_path),
+        )
+        os.close(fd)
+        write_netcdf_atomic_fn(o_data, staged_path, compression=False)
         ref_ds.close()
         ref_ds = None
         sim_ds.close()
         sim_ds = None
-
-        # Write masked ref back. Use an atomic replace so a failed NetCDF rewrite
-        # does not leave the existing reference file truncated or otherwise unreadable.
-        write_netcdf_atomic_fn(o_data, ref_path, compression=False)
+        os.replace(staged_path, ref_path)
+        staged_path = None
         logger.debug("Unified mask applied: %s (sim=%s)", var_name, sim_source)
 
-        del o, s, o_aligned, s_aligned, mask, o_data
+        del o, s, o_aligned, s_aligned, invalid_overlap, o_data
 
     except Exception:
         logger.exception("Unified mask failed for %s (sim=%s)", var_name, sim_source)
@@ -135,4 +143,9 @@ def apply_unified_mask(
             try:
                 sim_ds.close()
             except Exception:
+                pass
+        if staged_path is not None:
+            try:
+                os.unlink(staged_path)
+            except FileNotFoundError:
                 pass

--- a/tests/test_audit_bugfixes.py
+++ b/tests/test_audit_bugfixes.py
@@ -562,3 +562,35 @@ def test_vertical_coordinate_aliases_are_centralized():
         source = Path(path).read_text(encoding="utf-8")
         assert "COORDINATE_MAP_WITH_VERTICAL" in source
         assert '"elevation": "elev"' not in source
+
+
+def test_selection_ref_fallbacks_and_upper_nc4(tmp_path, monkeypatch):
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    from openbench.data._processing_selection import SelectionMixin
+
+    class Dummy(SelectionMixin):
+        item = "Runoff"
+        ref_source = "RefA"
+        RefA_model = "RefA"
+        RefA_fallbacks = [{"varname": "Q", "varunit": "kg m-2 s-1", "convert": "value * 2"}]
+        ref_varunit = "mm day-1"
+        compare_tim_res = "Month"
+
+        def apply_custom_filter(self, datasource, ds, varname):
+            raise RuntimeError("force fallback")
+
+    path = tmp_path / "ALT_2000.NC4"
+    (
+        xr.Dataset({"Q": ("time", np.array([1.0]))}, coords={"time": pd.date_range("2000-01-01", periods=1)})
+        .to_netcdf(path)
+    )
+    dummy = Dummy()
+
+    assert dummy._find_data_files(str(tmp_path), "ALT_", 2000, "", "ref", ["missing"]) == [str(path)]
+    da = dummy.select_var(2000, 2000, "Month", str(path), ["missing"], "ref")
+    assert float(da.values[0]) == 2.0
+    assert dummy.ref_varname == ["Q"]
+    assert dummy.ref_varunit == "mm day-1"

--- a/tests/test_cli_check_preflight.py
+++ b/tests/test_cli_check_preflight.py
@@ -897,7 +897,7 @@ def test_check_detects_recursive_include(tmp_path):
     assert "Recursive !include detected" in result.output
 
 
-def test_check_matches_adapter_lowres_reference_fallback(tmp_path, monkeypatch):
+def test_check_rejects_missing_requested_reference_resolution(tmp_path, monkeypatch):
     sim_root = tmp_path / "sim"
     sim_root.mkdir()
     mid_root = tmp_path / "Grid" / "MidRes"
@@ -925,9 +925,10 @@ def test_check_matches_adapter_lowres_reference_fallback(tmp_path, monkeypatch):
 
     result = runner.invoke(cli, ["check", str(path)])
 
-    assert result.exit_code == 0, result.output
-    assert "LowRes" in result.output
-    assert "Ready to run" in result.output
+    assert result.exit_code == 1, result.output
+    assert "Grid/MidRes" in result.output
+    assert "Grid/LowRes" not in result.output
+    assert "Reference data path does not exist" in result.output
 
 
 def test_check_reports_multi_reference_task_count_and_effective_root(tmp_path, monkeypatch):

--- a/tests/test_config/test_adapter.py
+++ b/tests/test_config/test_adapter.py
@@ -933,3 +933,115 @@ def test_statistics_context_per_pair_uses_pair_specific_ref_prefix():
 
     assert context.stats_nml["Hellinger_Distance"]["ET_SimA2_prefix"] == "ET_ref_RefA_SimA_et_ref"
     assert context.stats_nml["Hellinger_Distance"]["ET_SimB2_prefix"] == "ET_ref_RefA_SimB_et_ref"
+
+
+def test_adapter_uses_reference_override_and_fallbacks(monkeypatch, tmp_path):
+    from openbench.data.registry.schema import FallbackVar, ReferenceDataset, VariableMapping
+
+    ref_root = tmp_path / "ref"
+    ref_root.mkdir()
+    (ref_root / "alt.nc4").write_bytes(b"x")
+    ref = ReferenceDataset(
+        name="RefA",
+        description="",
+        category="Water",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Single",
+        timezone=0,
+        years=[2000, 2001],
+        root_dir="/wrong",
+        variables={
+            "Runoff": VariableMapping(
+                varname="runoff",
+                varunit="mm day-1",
+                prefix="",
+                suffix="",
+                fallbacks=[FallbackVar(varname="q", varunit="kg m-2 s-1", convert="value * 86400")],
+                prefix_fallback=["alt_"],
+            )
+        },
+        grid_res=0.5,
+    )
+    registry = SimpleNamespace(
+        get_model=lambda name: SimpleNamespace(tim_res="Month", grid_res=0.5, data_type="grid", variables={}),
+        get_resolution_variants=lambda name: {},
+        get_reference=lambda name, **kwargs: ref,
+    )
+    monkeypatch.setattr("openbench.data.registry.manager.get_registry", lambda: registry)
+    cfg = OpenBenchConfig(
+        project=ProjectConfig(name="override", output_dir="./out", years=[2000, 2001]),
+        evaluation=EvaluationConfig(variables=["Runoff"]),
+        reference=ReferenceConfig(
+            data_root="/common",
+            sources={"Runoff": "RefA"},
+            overrides={"RefA": {"root_dir": str(ref_root), "variables": {"Runoff": {"varname": "q2"}}}},
+        ),
+        simulation={"SimA": SimulationEntry(model="M", root_dir="/sim", tim_res="Month", grid_res=0.5)},
+    )
+
+    _main, ref_nml, _sim = adapter_module.build_legacy_namelists(cfg)
+
+    section = ref_nml["Runoff"]
+    assert section["RefA_dir"] == str(ref_root)
+    assert section["RefA_varname"] == "q2"
+    assert section["RefA_prefix_fallback"] == ["alt_"]
+    assert section["RefA_fallbacks"][0]["varname"] == "q"
+    assert section["RefA_fallbacks"][0]["convert"] == "value * 86400"
+
+
+def test_find_nc_dir_does_not_substitute_lowres(tmp_path):
+    mid = tmp_path / "Grid" / "MidRes" / "Water" / "Runoff" / "Demo"
+    low = tmp_path / "Grid" / "LowRes" / "Water" / "Runoff" / "Demo"
+    mid.mkdir(parents=True)
+    low.mkdir(parents=True)
+    (low / "demo.nc").write_bytes(b"x")
+
+    assert adapter_module._find_nc_dir(str(mid), str(tmp_path / "Grid" / "MidRes"), "Water/Runoff/Demo") == str(mid)
+
+
+
+def test_adapter_reference_data_root_still_overrides_catalog_root(monkeypatch):
+    from openbench.data.registry.schema import ReferenceDataset, VariableMapping
+
+    ref = ReferenceDataset(
+        name="RefA",
+        description="",
+        category="Water",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Single",
+        timezone=0,
+        years=[2000, 2001],
+        root_dir="/catalog/root",
+        variables={"Runoff": VariableMapping(varname="runoff", varunit="mm day-1")},
+        grid_res=0.5,
+    )
+    registry = SimpleNamespace(
+        get_model=lambda name: SimpleNamespace(tim_res="Month", grid_res=0.5, data_type="grid", variables={}),
+        get_resolution_variants=lambda name: {},
+        get_reference=lambda name, **kwargs: ref,
+    )
+    monkeypatch.setattr("openbench.data.registry.manager.get_registry", lambda: registry)
+    cfg = OpenBenchConfig(
+        project=ProjectConfig(name="root", output_dir="./out", years=[2000, 2001]),
+        evaluation=EvaluationConfig(variables=["Runoff"]),
+        reference=ReferenceConfig(data_root="/config/root", sources={"Runoff": "RefA"}),
+        simulation={"SimA": SimulationEntry(model="M", root_dir="/sim", tim_res="Month", grid_res=0.5)},
+    )
+
+    _main, ref_nml, _sim = adapter_module.build_legacy_namelists(cfg)
+
+    assert ref_nml["Runoff"]["RefA_dir"] == "/config/root"
+
+
+def test_adapter_rejects_programmatic_unsafe_labels():
+    cfg = OpenBenchConfig(
+        project=ProjectConfig(name="unsafe", output_dir="./out", years=[2000, 2001]),
+        evaluation=EvaluationConfig(variables=["Runoff"]),
+        reference=ReferenceConfig(sources={"Runoff": "CON"}),
+        simulation={"SimA ": SimulationEntry(model="M", root_dir="/sim", tim_res="Month", grid_res=0.5)},
+    )
+
+    with pytest.raises(ConfigError, match="path-safe"):
+        adapter_module.build_runner_config(cfg)

--- a/tests/test_config/test_loader.py
+++ b/tests/test_config/test_loader.py
@@ -710,3 +710,106 @@ def test_simulation_defaults_must_be_mapping():
 
     with pytest.raises(ConfigError, match="simulation._defaults must be a mapping"):
         _build_config(raw)
+
+
+
+def test_reference_rejects_duplicate_sources(tmp_path):
+    cfg = tmp_path / "openbench.yaml"
+    cfg.write_text(
+        """
+project:
+  name: dupref
+  output_dir: ./out
+  years: [2000, 2001]
+evaluation:
+  variables: [Runoff]
+reference:
+  Runoff: [RefA, RefA]
+simulation:
+  SimA:
+    model: M
+    root_dir: /tmp/model
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="duplicate reference source"):
+        load_config(cfg)
+
+
+def test_reference_rejects_path_unsafe_source_name(tmp_path):
+    cfg = tmp_path / "openbench.yaml"
+    cfg.write_text(
+        """
+project:
+  name: saferef
+  output_dir: ./out
+  years: [2000, 2001]
+evaluation:
+  variables: [Runoff]
+reference:
+  Runoff: "../RefA"
+simulation:
+  SimA:
+    model: M
+    root_dir: /tmp/model
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="path-safe"):
+        load_config(cfg)
+
+
+def test_reference_overrides_schema_loaded(tmp_path):
+    cfg = tmp_path / "openbench.yaml"
+    cfg.write_text(
+        """
+project:
+  name: refoverride
+  output_dir: ./out
+  years: [2000, 2001]
+evaluation:
+  variables: [Runoff]
+reference:
+  data_root: /common
+  Runoff: RefA
+  overrides:
+    RefA:
+      root_dir: /specific/ref
+      variables:
+        Runoff:
+          varname: q
+          varunit: mm day-1
+          prefix_fallback: [alt_]
+simulation:
+  SimA:
+    model: M
+    root_dir: /tmp/model
+""",
+        encoding="utf-8",
+    )
+    loaded = load_config(cfg)
+    assert loaded.reference.overrides["RefA"]["root_dir"] == "/specific/ref"
+    assert loaded.reference.overrides["RefA"]["variables"]["Runoff"]["varname"] == "q"
+
+
+def test_simulation_label_rejects_surrounding_space(tmp_path):
+    cfg = tmp_path / "openbench.yaml"
+    cfg.write_text(
+        """
+project:
+  name: safesim
+  output_dir: ./out
+  years: [2000, 2001]
+evaluation:
+  variables: [Runoff]
+reference:
+  Runoff: RefA
+simulation:
+  "SimA ":
+    model: M
+    root_dir: /tmp/model
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ConfigError, match="path-safe"):
+        load_config(cfg)

--- a/tests/test_config/test_migration.py
+++ b/tests/test_config/test_migration.py
@@ -518,3 +518,55 @@ def test_migrate_normalizes_simulation_level_tim_res(tmp_path):
     migrate_config(main, out)
 
     assert yaml.safe_load(out.read_text(encoding="utf-8"))["simulation"]["SimA"]["tim_res"] == "Month"
+
+
+def test_migration_preserves_per_reference_roots_as_overrides(tmp_path):
+    import yaml
+
+    old = tmp_path / "old"
+    old.mkdir()
+    ref_a = tmp_path / "refs" / "A"
+    ref_b = tmp_path / "refs" / "B"
+    ref_a.mkdir(parents=True)
+    ref_b.mkdir(parents=True)
+    (old / "a.yaml").write_text(yaml.safe_dump({"general": {"root_dir": str(ref_a)}}), encoding="utf-8")
+    (old / "b.yaml").write_text(yaml.safe_dump({"general": {"root_dir": str(ref_b)}}), encoding="utf-8")
+    (old / "ref.yaml").write_text(
+        yaml.safe_dump(
+            {"general": {"Runoff_ref_source": ["RefA", "RefB"]}, "def_nml": {"RefA": "a.yaml", "RefB": "b.yaml"}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (old / "simdef.yaml").write_text(
+        yaml.safe_dump({"general": {"root_dir": "/sim", "model_namelist": "M.nml"}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    (old / "sim.yaml").write_text(
+        yaml.safe_dump({"general": {"Runoff_sim_source": "SimA"}, "def_nml": {"SimA": "simdef.yaml"}}, sort_keys=False),
+        encoding="utf-8",
+    )
+    (old / "main.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "general": {
+                    "basename": "m",
+                    "basedir": "./out",
+                    "syear": 2000,
+                    "eyear": 2001,
+                    "reference_nml": "ref.yaml",
+                    "simulation_nml": "sim.yaml",
+                },
+                "evaluation_items": {"Runoff": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    out = tmp_path / "openbench.yaml"
+    migrate_config(old / "main.yaml", out)
+    data = yaml.safe_load(out.read_text(encoding="utf-8"))
+
+    assert data["reference"]["overrides"]["RefA"]["root_dir"] == str(ref_a)
+    assert data["reference"]["overrides"]["RefB"]["root_dir"] == str(ref_b)

--- a/tests/test_gui_config_manager.py
+++ b/tests/test_gui_config_manager.py
@@ -387,6 +387,91 @@ def test_unified_config_converts_to_gui_internal_shape():
 
     round_tripped = yaml.safe_load(ConfigManager().generate_config_yaml(gui_config))
     assert round_tripped["reference"]["data_root"] == "/ref"
+    assert round_tripped["reference"]["Evapotranspiration"] == ["GLEAM", "ERA5LAND"]
+
+
+def test_unified_config_round_trips_strict_reference_and_uncertainty():
+    unified = {
+        "project": {"name": "demo", "output_dir": "/out", "years": [2000, 2001], "strict_reference": True},
+        "evaluation": {"variables": ["Runoff"]},
+        "reference": {"Runoff": ["RefA", "RefB"]},
+        "simulation": {"CaseA": {"model": "CoLM2024", "root_dir": "/sim"}},
+        "metrics": ["RMSE"],
+        "uncertainty": {"enabled": True, "metrics": ["RMSE"], "n_resamples": 25, "seed": 9},
+    }
+
+    gui_config = ConfigManager().unified_to_gui_config(unified)
+    exported = yaml.safe_load(ConfigManager().generate_config_yaml(gui_config))
+
+    assert gui_config["general"]["strict_reference"] is True
+    assert gui_config["uncertainty"] == unified["uncertainty"]
+    assert exported["project"]["strict_reference"] is True
+    assert exported["reference"]["Runoff"] == ["RefA", "RefB"]
+    assert exported["uncertainty"] == unified["uncertainty"]
+
+
+def test_generate_config_yaml_exports_reference_overrides_for_runtime(tmp_path):
+    config = _config()
+    config["evaluation_items"] = {"Runoff": True}
+    config["ref_data"] = {
+        "general": {"Runoff_ref_source": ["RefA", "RefB"]},
+        "source_configs": {
+            "Runoff::RefA": {
+                "general": {
+                    "root_dir": "ref/a",
+                    "data_type": "grid",
+                    "tim_res": "Month",
+                    "data_groupby": "Single",
+                    "timezone": 0,
+                    "grid_res": 0.5,
+                    "syear": 2000,
+                    "eyear": 2002,
+                },
+                "varname": "manual_q_a",
+                "prefix": "a_",
+                "suffix": "",
+                "_explicit_override": True,
+            },
+            "Runoff::RefB": {
+                "general": {"root_dir": "ref/b", "data_type": "grid", "data_groupby": "Year"},
+                "varname": "manual_q_b",
+                "_explicit_override": True,
+            },
+        },
+    }
+
+    data = yaml.safe_load(ConfigManager().generate_config_yaml(config, path_transform=lambda p: f"/remote/{p}"))
+
+    assert data["reference"]["Runoff"] == ["RefA", "RefB"]
+    assert data["reference"]["overrides"]["RefA"]["root_dir"] == "/remote/ref/a"
+    assert data["reference"]["overrides"]["RefA"]["years"] == [2000, 2002]
+    assert data["reference"]["overrides"]["RefA"]["variables"]["Runoff"]["varname"] == "manual_q_a"
+    assert data["reference"]["overrides"]["RefB"]["root_dir"] == "/remote/ref/b"
+    assert data["reference"]["overrides"]["RefB"]["variables"]["Runoff"]["varname"] == "manual_q_b"
+
+
+def test_unified_config_imports_reference_overrides_into_gui_source_configs():
+    unified = {
+        "project": {"name": "demo", "output_dir": "/out", "years": [2000, 2002]},
+        "evaluation": {"variables": ["Runoff"]},
+        "reference": {
+            "Runoff": ["RefA", "RefB"],
+            "overrides": {
+                "RefA": {
+                    "variables": {"Runoff": {"varname": "manual_q_a", "prefix": "a_"}},
+                }
+            },
+        },
+        "simulation": {"CaseA": {"model": "CoLM2024", "root_dir": "/sim"}},
+    }
+
+    gui_config = ConfigManager().unified_to_gui_config(unified)
+
+    ref_a = gui_config["ref_data"]["source_configs"]["Runoff::RefA"]
+    assert ref_a["general"] == {}
+    assert ref_a["varname"] == "manual_q_a"
+    assert ref_a["_explicit_override"] is True
+    assert "Runoff::RefB" not in gui_config["ref_data"]["source_configs"]
 
 
 def test_generate_config_yaml_preserves_simulation_variables_and_fulllist(tmp_path):

--- a/tests/test_gui_save_preserves_fields.py
+++ b/tests/test_gui_save_preserves_fields.py
@@ -408,6 +408,7 @@ def test_general_save_preserves_runtime_local_openbench_path():
                 "python_path": "/usr/bin/python",
                 "conda_env": "base",
                 "local_openbench_path": "/repo/openbench",
+                "strict_reference": True,
                 "remote": {"host": "example"},
             }
         }
@@ -444,6 +445,7 @@ def test_general_save_preserves_runtime_local_openbench_path():
 
     general = controller.config["general"]
     assert general["local_openbench_path"] == "/repo/openbench"
+    assert general["strict_reference"] is True
     assert general["remote"] == {"host": "example"}
 
 
@@ -524,3 +526,222 @@ def test_runtime_page_startup_autoloads_instead_of_clearing_cached_settings():
 
     assert "self._auto_load_settings()" in source
     assert "self._clear_cached_settings_file()" not in source
+
+
+def test_ref_data_load_save_preserves_multiple_reference_sources(monkeypatch):
+    from types import SimpleNamespace
+
+    import openbench.data.registry.manager as manager_module
+
+    def _ref(name):
+        return SimpleNamespace(
+            root_dir=f"/ref/{name}",
+            data_type="grid",
+            tim_res="Month",
+            data_groupby="Year",
+            timezone=0,
+            years=[2000, 2020],
+            grid_res=0.5,
+            fulllist="",
+            variables={
+                "Runoff": SimpleNamespace(varname=f"{name}_q", varunit="mm", prefix=f"{name}_", suffix="", sub_dir="")
+            },
+        )
+
+    monkeypatch.setattr(manager_module, "get_registry", lambda: SimpleNamespace(get_reference=_ref))
+    controller = FakeController(
+        {
+            "general": {"basedir": "/out"},
+            "evaluation_items": {"Runoff": True},
+            "ref_data": {"general": {"Runoff_ref_source": ["RefA", "RefB"]}, "def_nml": {}},
+        }
+    )
+    controller.storage = object()
+    page = PageRefData.__new__(PageRefData)
+    page.controller = controller
+    page.data_root_input = FakeText("")
+    page._source_configs = {}
+    page._var_combos = {"Runoff": FakeLoadCombo([("Choose", None), ("RefA", "RefA")])}
+    page._var_advanced_fields = {
+        "Runoff": {key: FakeText("") for key in ("varname", "varunit", "prefix", "suffix", "sub_dir")}
+    }
+    page._rebuild_variable_groups = lambda: None
+
+    page.load_from_config()
+
+    ref_data = controller.config["ref_data"]
+    assert ref_data["general"]["Runoff_ref_source"] == ["RefA", "RefB"]
+    assert set(ref_data["def_nml"]) == {"RefA", "RefB"}
+    assert set(ref_data["source_configs"]) == {"Runoff::RefA", "Runoff::RefB"}
+    assert ref_data["source_configs"]["Runoff::RefA"]["_explicit_override"] is False
+    assert ref_data["source_configs"]["Runoff::RefB"]["_explicit_override"] is False
+
+
+def test_registry_source_data_uses_case_insensitive_variable_and_null_years(monkeypatch):
+    from types import SimpleNamespace
+
+    import openbench.data.registry.manager as manager_module
+    from openbench.gui.pages import page_ref_data
+
+    ref = SimpleNamespace(
+        root_dir="/ref/demo",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Year",
+        timezone=0,
+        years=None,
+        grid_res=1.0,
+        fulllist="",
+        variables={"runoff": SimpleNamespace(varname="q", varunit="mm", prefix="q_", suffix="", sub_dir="Runoff/Demo")},
+    )
+    monkeypatch.setattr(manager_module, "get_registry", lambda: SimpleNamespace(get_reference=lambda _name: ref))
+
+    source = page_ref_data._registry_source_data("Runoff", "Demo")
+
+    assert source["general"]["syear"] == ""
+    assert source["general"]["eyear"] == ""
+    assert source["varname"] == "q"
+    assert source["sub_dir"] == "Runoff/Demo"
+
+
+def test_ref_multi_resolution_group_selection_updates_combo_state(qapp, monkeypatch):
+    from PySide6.QtWidgets import QComboBox
+
+    from openbench.gui.pages import page_ref_data
+
+    controller = FakeController({"general": {"basedir": "/out"}, "ref_data": {"general": {}}})
+    page = PageRefData.__new__(PageRefData)
+    page.controller = controller
+    page.data_root_input = FakeText("")
+    page._source_configs = {}
+    page._var_advanced_fields = {
+        "Runoff": {key: FakeText("") for key in ("varname", "varunit", "prefix", "suffix", "sub_dir")}
+    }
+    combo = QComboBox()
+    combo.addItem("Choose", None)
+    combo.addItem("Demo (LowRes/MidRes)", {"group": "Demo", "variants": ["Demo_LowRes", "Demo_MidRes"]})
+    combo.setCurrentIndex(1)
+    page._pick_resolution = lambda _group, _var: "Demo_MidRes"
+    monkeypatch.setattr(
+        page_ref_data,
+        "_registry_source_data",
+        lambda _var, source: {"general": {"root_dir": "/ref"}, "varname": source},
+    )
+
+    page._on_dataset_selected("Runoff", combo)
+
+    assert combo.currentData() == "Demo_MidRes"
+    assert controller.config["ref_data"]["general"]["Runoff_ref_source"] == "Demo_MidRes"
+
+
+def test_ref_advanced_overrides_are_written_to_exported_reference_namelist(tmp_path):
+    import yaml
+
+    from openbench.gui.config_manager import ConfigManager
+
+    out = tmp_path / "nml" / "ref"
+    cfg = {
+        "general": {"basedir": str(tmp_path / "out")},
+        "evaluation_items": {"Runoff": True},
+        "ref_data": {
+            "general": {"Runoff_ref_source": ["RefA", "RefB"]},
+            "def_nml": {"RefA": "", "RefB": ""},
+            "source_configs": {
+                "Runoff::RefA": {
+                    "general": {"root_dir": "ref/a", "data_type": "grid", "data_groupby": "Year"},
+                    "varname": "manual_q_a",
+                    "prefix": "a_",
+                    "suffix": "",
+                },
+                "Runoff::RefB": {
+                    "general": {"root_dir": "ref/b", "data_type": "grid", "data_groupby": "Year"},
+                    "varname": "manual_q_b",
+                    "prefix": "b_",
+                    "suffix": "",
+                },
+            },
+        },
+    }
+
+    copied, _ = ConfigManager()._copy_data_namelists(
+        cfg["ref_data"]["def_nml"], str(out), ["Runoff"], str(tmp_path), "ref", cfg["ref_data"]["source_configs"]
+    )
+
+    assert set(copied) == {"RefA", "RefB"}
+    ref_a = yaml.safe_load((out / "RefA.yaml").read_text())
+    assert ref_a["general"]["root_dir"] == str(tmp_path / "ref" / "a")
+    assert ref_a["Runoff"]["varname"] == "manual_q_a"
+    assert yaml.safe_load((out / "RefB.yaml").read_text())["Runoff"]["varname"] == "manual_q_b"
+
+
+def test_registry_autofill_does_not_export_reference_overrides_when_data_root_is_explicit(monkeypatch):
+    from types import SimpleNamespace
+
+    import yaml
+
+    import openbench.data.registry.manager as manager_module
+    from openbench.gui.config_manager import ConfigManager
+
+    ref = SimpleNamespace(
+        root_dir="/registry/root/that/must/not/override/data_root",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Year",
+        timezone=0,
+        years=[2000, 2002],
+        grid_res=0.5,
+        fulllist="",
+        variables={"Runoff": SimpleNamespace(varname="q", varunit="mm", prefix="q_", suffix="", sub_dir="Runoff/Demo")},
+    )
+    monkeypatch.setattr(manager_module, "get_registry", lambda: SimpleNamespace(get_reference=lambda _name: ref))
+
+    gui_config = ConfigManager().unified_to_gui_config(
+        {
+            "project": {"name": "demo", "output_dir": "/out", "years": [2000, 2002]},
+            "evaluation": {"variables": ["Runoff"]},
+            "reference": {"data_root": "/explicit/data_root", "Runoff": "RefA"},
+            "simulation": {"CaseA": {"model": "CoLM2024", "root_dir": "/sim"}},
+        }
+    )
+    controller = FakeController(gui_config)
+    controller.storage = object()
+    page = PageRefData.__new__(PageRefData)
+    page.controller = controller
+    page.data_root_input = FakeText("")
+    page._source_configs = {}
+    page._var_combos = {"Runoff": FakeLoadCombo([("Choose", None), ("RefA", "RefA")])}
+    page._var_advanced_fields = {
+        "Runoff": {key: FakeText("") for key in ("varname", "varunit", "prefix", "suffix", "sub_dir")}
+    }
+    page._rebuild_variable_groups = lambda: None
+
+    page.load_from_config()
+    exported = yaml.safe_load(ConfigManager().generate_config_yaml(controller.config))
+
+    assert controller.config["ref_data"]["source_configs"]["Runoff::RefA"]["_explicit_override"] is False
+    assert exported["reference"]["data_root"] == "/explicit/data_root"
+    assert exported["reference"]["Runoff"] == "RefA"
+    assert "overrides" not in exported["reference"]
+
+
+def test_ref_advanced_edit_marks_source_config_as_explicit_override():
+    controller = FakeController({"general": {"basedir": "/out"}, "ref_data": {"general": {}}})
+    page = PageRefData.__new__(PageRefData)
+    page.controller = controller
+    page.data_root_input = FakeText("")
+    page._source_configs = {"Runoff": {"RefA": {"general": {"root_dir": "/ref"}, "_explicit_override": False}}}
+    page._var_advanced_fields = {
+        "Runoff": {
+            "varname": FakeText("manual_q"),
+            "varunit": FakeText(""),
+            "sub_dir": FakeText(""),
+            "prefix": FakeText(""),
+            "suffix": FakeText(""),
+        }
+    }
+
+    page._on_advanced_field_edited("Runoff")
+
+    saved = controller.config["ref_data"]["source_configs"]["Runoff::RefA"]
+    assert saved["_explicit_override"] is True
+    assert saved["varname"] == "manual_q"

--- a/tests/test_gui_scan_alignment_fixes.py
+++ b/tests/test_gui_scan_alignment_fixes.py
@@ -13,6 +13,7 @@ Covers four reported GUI defects:
 
 from types import SimpleNamespace
 
+import pytest
 import yaml
 
 from openbench.gui import path_utils
@@ -737,3 +738,98 @@ def test_remote_model_sync_accepts_registry_name(monkeypatch, tmp_path):
     written = yaml.safe_load(model_file.read_text())
     assert written["general"]["model"] == "CoLM2024"
     assert staged == ["CoLM2024"]
+
+
+def test_gui_reference_validation_accepts_nc4_and_uppercase_netcdf_suffixes(tmp_path):
+    from openbench.gui.data_validator import DataValidator
+
+    data_root = tmp_path / "ref"
+    data_root.mkdir()
+    (data_root / "runoff_2001.NC4").touch()
+
+    result = DataValidator().validate_source(
+        "Runoff",
+        "DemoRef",
+        {"general": {"root_dir": str(data_root), "data_type": "grid", "data_groupby": "Year"}, "prefix": "runoff_"},
+        {"syear": 2001, "eyear": 2001},
+    )
+
+    file_check = next(check for check in result.checks if check.name == "file_exists")
+    assert file_check.passed is True
+    assert file_check.message.endswith("runoff_2001.NC4")
+
+
+def test_gui_station_reference_validation_rejects_missing_root_without_pattern():
+    from openbench.gui.data_validator import DataValidator
+
+    result = DataValidator().validate_source(
+        "Streamflow",
+        "BadStationRef",
+        {
+            "general": {"root_dir": "/definitely/missing/openbench/ref", "data_type": "stn", "data_groupby": "Single"},
+            "varname": "q",
+        },
+        {"syear": 2000, "eyear": 2001},
+    )
+
+    assert result.is_valid is False
+    assert [(check.name, check.passed) for check in result.checks] == [("directory_exists", False)]
+
+
+def test_gui_reference_validation_rejects_partially_covering_descriptor_years(tmp_path):
+    from openbench.gui.data_validator import DataValidator
+
+    data_root = tmp_path / "ref"
+    data_root.mkdir()
+    (data_root / "runoff_2001.nc").touch()
+
+    result = DataValidator().validate_source(
+        "Runoff",
+        "DemoRef",
+        {
+            "general": {
+                "root_dir": str(data_root),
+                "data_type": "grid",
+                "data_groupby": "Year",
+                "syear": 2001,
+                "eyear": 2002,
+            },
+            "prefix": "runoff_",
+        },
+        {"syear": 2000, "eyear": 2002},
+    )
+
+    time_check = next(check for check in result.checks if check.name == "time_range")
+    assert time_check.passed is False
+    assert "do not cover" in time_check.message
+
+
+def test_gui_grid_reference_validation_checks_spatial_range_for_single_file(tmp_path):
+    xr = pytest.importorskip("xarray")
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    from openbench.gui.data_validator import DataValidator
+
+    data_root = tmp_path / "ref"
+    data_root.mkdir()
+    path = data_root / "runoff.nc"
+    ds = xr.Dataset(
+        {"q": (("time", "lat", "lon"), np.ones((2, 2, 2)))},
+        coords={"time": pd.date_range("2000-01-01", periods=2, freq="YS"), "lat": [0.0, 1.0], "lon": [0.0, 1.0]},
+    )
+    ds.to_netcdf(path)
+
+    result = DataValidator().validate_source(
+        "Runoff",
+        "SpatialRef",
+        {
+            "general": {"root_dir": str(data_root), "data_type": "grid", "data_groupby": "Single"},
+            "varname": "q",
+            "prefix": "runoff",
+        },
+        {"syear": 2000, "eyear": 2001, "min_lat": -10, "max_lat": 10, "min_lon": -10, "max_lon": 10},
+    )
+
+    spatial_check = next(check for check in result.checks if check.name == "spatial_range")
+    assert spatial_check.passed is False
+    assert "Spatial range insufficient" in spatial_check.message

--- a/tests/test_registry_reference_regressions.py
+++ b/tests/test_registry_reference_regressions.py
@@ -1,0 +1,213 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from openbench.data.registry import manager as registry_manager
+from openbench.data.registry.manager import RegistryManager, _auto_resolve_variant
+from openbench.data.registry.schema import (
+    ReferenceDataset,
+    StationMatchingConfig,
+    VariableMapping,
+)
+
+
+def _ref(name, root_dir=None, grid_res=0.5):
+    return ReferenceDataset(
+        name=name,
+        description="demo",
+        category="Water",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Year",
+        timezone=0,
+        years=[2000, 2001],
+        variables={"Runoff": VariableMapping(varname="runoff", varunit="mm")},
+        grid_res=grid_res,
+        root_dir=root_dir,
+    )
+
+
+def test_save_reference_rejects_case_insensitive_duplicate(monkeypatch, tmp_path: Path):
+    catalog = tmp_path / "references" / "reference_catalog.yaml"
+    catalog.parent.mkdir()
+    catalog.write_text(yaml.safe_dump({"DemoRef": _ref("DemoRef").to_dict()}), encoding="utf-8")
+    monkeypatch.setattr(registry_manager, "get_writable_reference_catalog_path", lambda: catalog)
+
+    with pytest.raises(ValueError, match="conflicts with existing catalog entry"):
+        RegistryManager(user_dir=tmp_path).save_reference("demoref", _ref("demoref"))
+
+
+def test_user_reference_catalog_malformed_fails_closed(tmp_path: Path):
+    refs = tmp_path / "references"
+    refs.mkdir()
+    (refs / "reference_catalog.yaml").write_text("bad: [", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="Failed to read user reference catalog"):
+        RegistryManager(user_dir=tmp_path)
+
+
+def test_auto_resolve_does_not_switch_variants_by_catalog_root_dir(tmp_path: Path):
+    missing_preferred = _ref("Demo_LowRes", root_dir=str(tmp_path / "missing"), grid_res=0.5)
+    existing_worse = _ref("Demo_MidRes", root_dir=str(tmp_path), grid_res=1.0)
+
+    picked, reason = _auto_resolve_variant(
+        {"LowRes": missing_preferred, "MidRes": existing_worse},
+        sim_tim_res="Month",
+        sim_grid_res=0.5,
+    )
+
+    assert picked is missing_preferred
+    assert "switched" not in reason
+
+
+def test_matching_nc_files_honors_uppercase_explicit_glob(tmp_path: Path):
+    from openbench.data.registry.scanner import _matching_nc_files
+
+    upper = tmp_path / "CASE.NC4"
+    upper.write_text("placeholder", encoding="utf-8")
+
+    assert _matching_nc_files(tmp_path, "*.nc4") == [upper]
+
+
+def test_registry_page_reference_edit_preserves_hidden_descriptor_fields():
+    from openbench.gui.pages.page_registry import _merge_reference_editor_dataset
+
+    existing = ReferenceDataset(
+        name="Demo",
+        description="old",
+        category="Water",
+        data_type="grid",
+        tim_res="Month",
+        data_groupby="Year",
+        timezone=0,
+        years=[1999, 2000],
+        variables={
+            "Runoff": VariableMapping(
+                varname="old_q",
+                varunit="mm",
+                fulllist="stations.csv",
+                max_uparea=1000.0,
+                min_uparea=10.0,
+                compute="a + b",
+                prefix_fallback=["alt_"],
+            )
+        },
+        fulllist="dataset.csv",
+        station_matching=StationMatchingConfig(dataset_file="stations.nc"),
+        _provenance={"tim_res": "scan"},
+    )
+    edited = ReferenceDataset(
+        name="Demo",
+        description="new",
+        category="Water",
+        data_type="grid",
+        tim_res="Day",
+        data_groupby="Month",
+        timezone=8,
+        years=[],
+        variables={"runoff": VariableMapping(varname="new_q", varunit="kg", prefix="p")},
+        grid_res=0.25,
+        root_dir="/new/root",
+    )
+
+    merged = _merge_reference_editor_dataset(existing, edited)
+
+    assert merged.description == "new"
+    assert merged.years == [1999, 2000]
+    assert merged.fulllist == "dataset.csv"
+    assert merged.station_matching is existing.station_matching
+    assert merged._provenance == {"tim_res": "scan"}
+    var = merged.variables["runoff"]
+    assert var.varname == "new_q"
+    assert var.fulllist == "stations.csv"
+    assert var.max_uparea == 1000.0
+    assert var.compute == "a + b"
+    assert var.prefix_fallback == ["alt_"]
+
+
+def test_user_reference_catalog_invalid_entry_fails_closed(tmp_path: Path):
+    refs = tmp_path / "references"
+    refs.mkdir()
+    (refs / "reference_catalog.yaml").write_text(
+        yaml.safe_dump({"Broken": {"name": "Broken", "tim_res": "Month"}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to merge user reference"):
+        RegistryManager(user_dir=tmp_path)
+
+
+def test_save_reference_rejects_case_variant_of_bundled_reference(monkeypatch, tmp_path: Path):
+    catalog = tmp_path / "references" / "reference_catalog.yaml"
+    catalog.parent.mkdir()
+    monkeypatch.setattr(registry_manager, "get_writable_reference_catalog_path", lambda: catalog)
+
+    bundled_name = "CLARA_3_LowRes"
+    bundled = RegistryManager(user_dir=tmp_path).get_reference(bundled_name)
+    assert bundled is not None
+
+    with pytest.raises(ValueError, match=bundled_name):
+        RegistryManager(user_dir=tmp_path).save_reference(bundled_name.lower(), bundled)
+
+
+def test_save_reference_allows_exact_case_bundled_overlay(monkeypatch, tmp_path: Path):
+    catalog = tmp_path / "references" / "reference_catalog.yaml"
+    catalog.parent.mkdir()
+    monkeypatch.setattr(registry_manager, "get_writable_reference_catalog_path", lambda: catalog)
+
+    bundled_name = "CLARA_3_LowRes"
+    bundled = RegistryManager(user_dir=tmp_path).get_reference(bundled_name)
+    assert bundled is not None
+
+    RegistryManager(user_dir=tmp_path).save_reference(bundled_name, bundled)
+
+    assert bundled_name in yaml.safe_load(catalog.read_text(encoding="utf-8"))
+
+
+def test_registry_page_refresh_surfaces_registry_load_failure(monkeypatch):
+    from openbench.gui.pages import page_registry
+    from openbench.gui.pages.page_registry import PageRegistry
+
+    messages = []
+
+    class FakeList:
+        def clear(self):
+            messages.append("cleared")
+
+        def addItem(self, _item):  # pragma: no cover - must not continue to populate
+            raise AssertionError("should not populate after registry load failure")
+
+    class BrokenRegistry:
+        def list_references(self):
+            raise RuntimeError("bad catalog")
+
+    monkeypatch.setattr(page_registry, "_get_registry", lambda: BrokenRegistry())
+    monkeypatch.setattr(page_registry.QMessageBox, "critical", lambda *args: messages.append(args[2]))
+
+    page = PageRegistry.__new__(PageRegistry)
+    page.dataset_list = FakeList()
+
+    PageRegistry._refresh_dataset_list(page)
+
+    assert "cleared" in messages
+    assert any("bad catalog" in str(message) for message in messages)
+
+
+def test_matching_nc_files_preserves_path_glob_semantics_case_insensitive(tmp_path: Path):
+    from openbench.data.registry.scanner import _matching_nc_files
+
+    nested = tmp_path / "sub"
+    nested.mkdir()
+    direct = tmp_path / "ROOT.NC4"
+    child = nested / "CASE.NC4"
+    direct.write_text("placeholder", encoding="utf-8")
+    child.write_text("placeholder", encoding="utf-8")
+
+    lower = tmp_path / "lower.nc4"
+    lower.write_text("placeholder", encoding="utf-8")
+
+    assert _matching_nc_files(tmp_path, "*.nc4") == [direct, lower]
+    assert _matching_nc_files(tmp_path, "*.NC4") == [direct, lower]
+    assert _matching_nc_files(tmp_path, "sub/*.nc4") == [child]
+    assert _matching_nc_files(tmp_path, "**/*.nc4") == [direct, lower, child]

--- a/tests/test_remote_shell_quoting.py
+++ b/tests/test_remote_shell_quoting.py
@@ -38,10 +38,12 @@ def test_remote_glob_quotes_directory_and_find_pattern():
 
     assert gen.get_sample_paths() == ["/remote/proj/a.nc"]
 
-    pattern = f"{prefix}*{suffix}.nc"
-    assert ssh.commands == [
-        f"find {shlex.quote(root)} -maxdepth 1 -name {shlex.quote(pattern)} -type f 2>/dev/null | sort"
-    ]
+    patterns = [f"{prefix}*{suffix}{ext}" for ext in (".nc", ".nc4", ".NC", ".NC4")]
+    command = ssh.commands[0]
+    assert command.startswith(f"find {shlex.quote(root)} -maxdepth 1 " + r"\( ")
+    assert command.endswith(r" \) -type f 2>/dev/null | sort")
+    for pattern in patterns:
+        assert f"-name {shlex.quote(pattern)}" in command
 
 
 def test_remote_validator_quotes_file_checks():
@@ -109,7 +111,7 @@ def test_remote_glob_exposes_ssh_failures_instead_of_looking_empty():
     )
 
     assert gen.get_sample_paths() == []
-    assert gen.last_error == "Remote glob failed for /remote/data/tas*.nc: network down"
+    assert gen.last_error == "Remote glob failed for /remote/data/{tas*.nc,tas*.nc4,tas*.NC,tas*.NC4}: network down"
 
 
 def test_remote_validation_reports_listing_failure_not_no_files():
@@ -134,4 +136,7 @@ def test_remote_validation_reports_listing_failure_not_no_files():
 
     assert result.checks[0].name == "file_exists"
     assert result.checks[0].passed is False
-    assert result.checks[0].message == "Remote glob failed for /remote/data/tas*.nc: network down"
+    assert (
+        result.checks[0].message
+        == "Remote glob failed for /remote/data/{tas*.nc,tas*.nc4,tas*.NC,tas*.NC4}: network down"
+    )

--- a/tests/test_runner/test_cache.py
+++ b/tests/test_runner/test_cache.py
@@ -151,8 +151,23 @@ def test_algorithm_source_fingerprint_tracks_runner_processing_and_comparisons()
     assert "openbench.data._processing_grid_regrid" in modules
 
 
+def test_source_specific_section_does_not_capture_longer_source_name():
+    from openbench.runner.hashing import source_specific_section
+
+    section = {
+        "LAI_Yuan2011_varname": "lai",
+        "LAI_Yuan2011_8Day_varname": "lai_8day",
+    }
+
+    assert source_specific_section(
+        section,
+        "LAI_Yuan2011",
+        all_sources=["LAI_Yuan2011", "LAI_Yuan2011_8Day"],
+    ) == {"LAI_Yuan2011_varname": "lai"}
+
+
 def test_unified_mask_missing_inputs_raise(tmp_path):
-    from openbench.runner.masking import apply_unified_mask
+    import openbench.runner.masking as masking_module
 
     info = {
         "casedir": str(tmp_path),
@@ -162,10 +177,82 @@ def test_unified_mask_missing_inputs_raise(tmp_path):
     }
 
     with pytest.raises(FileNotFoundError, match="Unified mask input file not found"):
-        apply_unified_mask(
+        masking_module.apply_unified_mask(
             info,
             "GPP",
             "RefA",
             "SimA",
             write_netcdf_atomic_fn=lambda *args, **kwargs: None,
         )
+
+
+def test_unified_mask_keeps_chunked_data_lazy_until_writer(tmp_path, monkeypatch):
+    import dask.array as da
+    import numpy as np
+    import xarray as xr
+    from dask.base import is_dask_collection
+
+    import openbench.runner.masking as masking_module
+
+    ref_path = tmp_path / "data" / "GPP_ref_RefA_ref.nc"
+    sim_path = tmp_path / "data" / "GPP_sim_SimA_sim.nc"
+    ref_path.parent.mkdir()
+    ref_path.touch()
+    sim_path.touch()
+    coords = {"time": [0, 1], "lat": [0.0], "lon": [0.0]}
+
+    states = {"ref": "closed", "sim": "closed"}
+
+    def dataset(name, values):
+        states[name] = "open"
+        result = xr.DataArray(
+            da.from_array(values, chunks=(1, 1, 1)),
+            coords=coords,
+            dims=("time", "lat", "lon"),
+            name=name,
+        ).to_dataset()
+        result.set_close(lambda: states.__setitem__(name, "closed"))
+        return result
+
+    open_calls = []
+
+    def open_dataset(path, **kwargs):
+        open_calls.append(kwargs)
+        if str(path) == str(ref_path):
+            return dataset("ref", [[[1.0]], [[2.0]]])
+        return dataset("sim", [[[1.0]], [[float("nan")]]])
+
+    monkeypatch.setattr(xr, "open_dataset", open_dataset)
+    observed = {}
+
+    def writer(data, *_args, **_kwargs):
+        observed["lazy"] = is_dask_collection(data.data)
+        observed["values"] = data.compute().values
+        Path(_args[0]).write_bytes(b"masked")
+
+    real_replace = masking_module.os.replace
+
+    def replace_after_close(source, target):
+        assert states == {"ref": "closed", "sim": "closed"}
+        real_replace(source, target)
+
+    monkeypatch.setattr(masking_module.os, "replace", replace_after_close)
+
+    masking_module.apply_unified_mask(
+        {
+            "casedir": str(tmp_path),
+            "ref_varname": "ref",
+            "sim_varname": "sim",
+            "time_alignment": "intersection",
+        },
+        "GPP",
+        "RefA",
+        "SimA",
+        write_netcdf_atomic_fn=writer,
+    )
+
+    assert observed["lazy"] is True
+    assert open_calls == [{"chunks": "auto"}, {"chunks": "auto"}]
+    assert ref_path.read_bytes() == b"masked"
+    assert observed["values"][0, 0, 0] == 1.0
+    assert np.isnan(observed["values"][1, 0, 0])


### PR DESCRIPTION
## Summary
- preserve GUI reference lists, overrides, strict mode, and registry metadata end to end
- fail explicitly for invalid or unavailable reference inputs instead of silently substituting data
- make mixed NetCDF discovery, masking, and cache keys correct and scalable
- add regression coverage for reference GUI, registry, runtime, and cache paths

## Validation
- `pytest -q`: 1729 passed, 5 skipped
- targeted reference tests: 285 passed
- `ruff check`: passed
- `py_compile`: passed
- `git diff --check`: passed

## Scope note
Uncertainty-only runtime changes and compatibility aliases for the six removed reference names are intentionally excluded.