### PR TITLE
Fix simulation workflows end to end

### DIFF
--- a/src/openbench/cli/sim.py
+++ b/src/openbench/cli/sim.py
@@ -223,9 +223,7 @@ def scan(
             )
 
         if station_staging_path is not None:
-            if station_output_path.exists():
-                shutil.rmtree(station_output_path)
-            os.replace(station_staging_path, station_output_path)
+            _replace_directory_preserving_old_on_failure(station_staging_path, station_output_path)
             _rebase_station_artifacts(result, station_staging_path, station_output_path)
             station_staging_path = None
 
@@ -246,6 +244,21 @@ def scan(
 
     click.secho(f"Wrote {sim_path}", fg="green", bold=True)
     click.secho(f"Wrote {report_path}", fg="green", bold=True)
+
+
+def _replace_directory_preserving_old_on_failure(source: Path, target: Path) -> None:
+    if not target.exists():
+        os.replace(source, target)
+        return
+    backup = target.parent / f".{target.name}.old.{next(tempfile._get_candidate_names())}"
+    os.replace(target, backup)
+    try:
+        os.replace(source, target)
+    except Exception:
+        if not target.exists():
+            os.replace(backup, target)
+        raise
+    shutil.rmtree(backup, ignore_errors=True)
 
 
 def _rebase_station_artifacts(result, old_root: Path, new_root: Path) -> None:

--- a/src/openbench/config/adapter.py
+++ b/src/openbench/config/adapter.py
@@ -538,7 +538,6 @@ class StatisticsContext:
     statistic_fig: dict[str, Any]
 
 
-
 _UNSAFE_SOURCE_CHARS = set('<>:"/\\|?*')
 _WINDOWS_RESERVED_SOURCE_NAMES = {
     "CON",
@@ -1156,12 +1155,13 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
                 inline_vars.get("tim_res") or sim_entry.tim_res or (model_profile.tim_res if model_profile else "Month")
             )
 
-            # Construct sim directory: root_dir from sim_entry, optionally with sub_dir from profile
+            # Construct sim directory: root_dir plus inline sub_dir (highest priority) or profile sub_dir.
             sim_dir = sim_entry.root_dir
-            if model_profile and profile_key is not None:
-                profile_sub = model_profile.variables[profile_key].sub_dir
-                if profile_sub:
-                    sim_dir = os.path.join(sim_dir, profile_sub)
+            sub_dir = inline_vars.get("sub_dir")
+            if sub_dir is None and model_profile and profile_key is not None:
+                sub_dir = model_profile.variables[profile_key].sub_dir
+            if sub_dir:
+                sim_dir = os.path.join(sim_dir, str(sub_dir))
 
             prefix = sim_label
             var_section[f"{prefix}_model"] = model_name
@@ -1182,11 +1182,24 @@ def build_legacy_namelists(cfg: OpenBenchConfig) -> tuple[dict, dict, dict]:
             var_section[f"{prefix}_prefix"] = var_prefix
             var_section[f"{prefix}_suffix"] = var_suffix
 
-            # Pass prefix_fallback if this variable may be in alternative files
-            if model_profile and profile_key is not None:
+            # Pass inline/profile compute and fallbacks through to runtime.
+            compute_expr = inline_vars.get("compute")
+            if compute_expr is None and model_profile and profile_key is not None:
+                compute_expr = getattr(model_profile.variables[profile_key], "compute", None)
+            if compute_expr:
+                var_section[f"{prefix}_compute"] = compute_expr
+
+            fallback_dicts = inline_vars.get("fallbacks")
+            if fallback_dicts is None and model_profile and profile_key is not None:
+                fallback_dicts = _fallbacks_to_dicts(model_profile.variables[profile_key])
+            if fallback_dicts:
+                var_section[f"{prefix}_fallbacks"] = fallback_dicts
+
+            pf = inline_vars.get("prefix_fallback")
+            if pf is None and model_profile and profile_key is not None:
                 pf = model_profile.variables[profile_key].prefix_fallback
-                if pf:
-                    var_section[f"{prefix}_prefix_fallback"] = pf
+            if pf:
+                var_section[f"{prefix}_prefix_fallback"] = pf
             var_section[f"{prefix}_timezone"] = inline_vars.get("timezone", 0)
 
             # Optional station-related fields: inline config > entry-level > model profile

--- a/src/openbench/config/loader.py
+++ b/src/openbench/config/loader.py
@@ -954,10 +954,14 @@ def _build_evaluation(raw: dict[str, Any]) -> EvaluationConfig:
     return EvaluationConfig(variables=variables)
 
 
-
 _UNSAFE_SOURCE_CHARS = set('<>:"/\\|?*')
 _WINDOWS_RESERVED_SOURCE_NAMES = {
-    "CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
 }
 
 

--- a/src/openbench/config/runtime_info.py
+++ b/src/openbench/config/runtime_info.py
@@ -530,7 +530,10 @@ class GeneralInfoReader:
         csv_dir = os.path.dirname(os.path.abspath(csv_path))
 
         def _resolve(p):
-            if pd.isna(p) or os.path.isabs(str(p)):
+            if pd.isna(p):
+                return p
+            p = os.path.expanduser(os.path.expandvars(str(p)))
+            if os.path.isabs(p):
                 return p
             # Try 1: resolve against CSV dir
             resolved = os.path.normpath(os.path.join(csv_dir, p))

--- a/src/openbench/core/evaluation.py
+++ b/src/openbench/core/evaluation.py
@@ -812,9 +812,18 @@ class Evaluation_stn(metrics, scores):
                     )
                     results = [self.make_evaluation_parallel(station_list, iik) for iik in station_indices]
 
-            # Filter out None results from stations that failed or were skipped
-            valid_results = [r if r is not None else {} for r in results]
-            station_list = pd.concat([station_list, pd.DataFrame(valid_results)], axis=1)
+            skipped = sum(1 for r in results if r is None)
+            if skipped:
+                raise RuntimeError(f"Station evaluation failed for {skipped}/{len(station_indices)} station(s)")
+            if not results:
+                raise RuntimeError("Station evaluation produced no station results")
+            station_list = pd.concat([station_list, pd.DataFrame(results)], axis=1)
+            metric_columns = set((getattr(self, "metrics", None) or []) + (getattr(self, "scores", None) or []))
+            metric_columns.update(["KGESS", "RMSE", "correlation"])
+            present = [col for col in metric_columns if col in station_list.columns]
+            numeric_results = station_list[present].apply(pd.to_numeric, errors="coerce") if present else None
+            if numeric_results is None or not np.isfinite(numeric_results.to_numpy(dtype=float)).any():
+                raise RuntimeError("Station evaluation produced no finite metric/score rows")
 
             logging.info("Evaluation finished")
             logging.info("=======================================")

--- a/src/openbench/data/_processing_config.py
+++ b/src/openbench/data/_processing_config.py
@@ -270,11 +270,30 @@ class ProcessingConfigMixin:
             # 3. Auto-scan sim directory (generates list on the fly)
             stnlist_path = None
 
-            # Priority 1: explicit fulllist
-            if hasattr(self, "ref_fulllist") and self.ref_fulllist and os.path.exists(self.ref_fulllist):
-                stnlist_path = self.ref_fulllist
-            elif hasattr(self, "sim_fulllist") and self.sim_fulllist and os.path.exists(self.sim_fulllist):
-                stnlist_path = self.sim_fulllist
+            # Priority 1: explicit fulllist. For station×station, merge ref and sim lists by ID
+            # so downstream station processing/evaluation has both file paths.
+            ref_list_path = getattr(self, "ref_fulllist", "")
+            sim_list_path = getattr(self, "sim_fulllist", "")
+            ref_list_is_merged = False
+            if ref_list_path and os.path.exists(ref_list_path):
+                ref_columns = set(pd.read_csv(ref_list_path, nrows=0).columns)
+                ref_list_is_merged = {"ref_dir", "sim_dir"}.issubset(ref_columns)
+            if ref_list_is_merged:
+                stnlist_path = ref_list_path
+            elif (
+                self.ref_data_type == "stn"
+                and self.sim_data_type == "stn"
+                and ref_list_path
+                and sim_list_path
+                and os.path.exists(ref_list_path)
+                and os.path.exists(sim_list_path)
+            ):
+                self.station_list = self._merge_station_fulllists(sim_list_path, ref_list_path)
+                stnlist_path = "__merged__"
+            elif ref_list_path and os.path.exists(ref_list_path):
+                stnlist_path = ref_list_path
+            elif sim_list_path and os.path.exists(sim_list_path):
+                stnlist_path = sim_list_path
 
             # Priority 2: previously generated list
             if not stnlist_path:
@@ -288,8 +307,9 @@ class ProcessingConfigMixin:
                 if sim_dir and os.path.isdir(sim_dir):
                     stnlist_path = self._auto_generate_station_list(sim_dir)
 
-            if stnlist_path and os.path.exists(stnlist_path):
-                self.station_list = Convert_Type.convert_Frame(pd.read_csv(stnlist_path, header=0))
+            if stnlist_path == "__merged__" or (stnlist_path and os.path.exists(stnlist_path)):
+                if stnlist_path != "__merged__":
+                    self.station_list = Convert_Type.convert_Frame(pd.read_csv(stnlist_path, header=0))
                 canonical_list_path = os.path.join(self.casedir, f"stn_{self.ref_source}_{self.sim_source}_list.txt")
                 os.makedirs(os.path.dirname(canonical_list_path), exist_ok=True)
                 write_file_atomic(
@@ -306,6 +326,51 @@ class ProcessingConfigMixin:
 
             output_dir = os.path.join(self.casedir, "data", f"stn_{self.ref_source}_{self.sim_source}")
             os.makedirs(output_dir, exist_ok=True)
+
+    @staticmethod
+    def _normalize_station_fulllist(df: pd.DataFrame, side: str) -> pd.DataFrame:
+        df = df.copy()
+        rename = {
+            "DIR": f"{side}_dir",
+            "LON": f"{side}_lon",
+            "LAT": f"{side}_lat",
+            "SYEAR": f"{side}_syear",
+            "EYEAR": f"{side}_eyear",
+            "lon": f"{side}_lon",
+            "lat": f"{side}_lat",
+        }
+        df.rename(columns={k: v for k, v in rename.items() if k in df.columns and v not in df.columns}, inplace=True)
+        if f"{side}_dir" not in df.columns and "dir" in df.columns:
+            df.rename(columns={"dir": f"{side}_dir"}, inplace=True)
+        if f"{side}_syear" not in df.columns and "use_syear" in df.columns:
+            df[f"{side}_syear"] = df["use_syear"]
+        if f"{side}_eyear" not in df.columns and "use_eyear" in df.columns:
+            df[f"{side}_eyear"] = df["use_eyear"]
+        return df
+
+    def _merge_station_fulllists(self, sim_path: str, ref_path: str) -> pd.DataFrame:
+        sim = self._normalize_station_fulllist(pd.read_csv(sim_path, header=0), "sim")
+        ref = self._normalize_station_fulllist(pd.read_csv(ref_path, header=0), "ref")
+        from openbench.config.runtime_info import GeneralInfoReader
+
+        GeneralInfoReader._resolve_relative_paths(sim, "sim_dir", sim_path, getattr(self, "sim_dir", ""))
+        GeneralInfoReader._resolve_relative_paths(ref, "ref_dir", ref_path, getattr(self, "ref_dir", ""))
+        merged = pd.merge(sim, ref, how="inner", on="ID", suffixes=("", "_refdup"))
+        if merged.empty:
+            raise RuntimeError(
+                f"No shared station IDs between simulation fulllist {sim_path} and reference fulllist {ref_path}"
+            )
+        for col in ("sim_syear", "ref_syear", "sim_eyear", "ref_eyear"):
+            if col in merged.columns:
+                merged[col] = pd.to_numeric(merged[col], errors="coerce")
+        if {"sim_syear", "ref_syear"}.issubset(merged.columns):
+            merged["use_syear"] = merged[["sim_syear", "ref_syear"]].max(axis=1).astype(int)
+        if {"sim_eyear", "ref_eyear"}.issubset(merged.columns):
+            merged["use_eyear"] = merged[["sim_eyear", "ref_eyear"]].min(axis=1).astype(int)
+        bad = merged.get("use_syear", pd.Series(dtype=float)) > merged.get("use_eyear", pd.Series(dtype=float))
+        if bool(bad.any()):
+            raise RuntimeError(f"Station fulllists have no overlapping years for {int(bad.sum())} station(s)")
+        return Convert_Type.convert_Frame(merged)
 
     def _auto_generate_station_list(self, sim_dir: str) -> str | None:
         """Auto-scan a station simulation directory and generate a station list CSV."""

--- a/src/openbench/data/_processing_selection.py
+++ b/src/openbench/data/_processing_selection.py
@@ -101,11 +101,15 @@ class SelectionMixin:
                             fb_var = fb.get("varname") if isinstance(fb, dict) else getattr(fb, "varname", "")
                             actual_fb_var = get_xarray_key_case_insensitive(ds, fb_var) if fb_var else None
                             if actual_fb_var is not None:
-                                logging.warning("Variable '%s' not found, using fallback '%s'", target_var, actual_fb_var)
+                                logging.warning(
+                                    "Variable '%s' not found, using fallback '%s'", target_var, actual_fb_var
+                                )
                                 target_var = actual_fb_var
                                 actual_target_var = actual_fb_var
                                 setattr(self, f"{datasource}_varname", [target_var])
-                                fb_convert = fb.get("convert", "") if isinstance(fb, dict) else getattr(fb, "convert", "")
+                                fb_convert = (
+                                    fb.get("convert", "") if isinstance(fb, dict) else getattr(fb, "convert", "")
+                                )
                                 fb_unit = fb.get("varunit", "") if isinstance(fb, dict) else getattr(fb, "varunit", "")
                                 if fb_convert:
                                     setattr(self, f"_fb_convert_{datasource}", fb_convert)
@@ -291,6 +295,7 @@ class SelectionMixin:
                 candidates.append(str(name))
 
         try:
+            candidates.extend(self._compute_dependency_varnames_for_file_lookup(datasource))
             source = getattr(self, f"{datasource}_source", "")
             for fb in getattr(self, f"{source}_fallbacks", None) or []:
                 fb_var = fb.get("varname") if isinstance(fb, dict) else getattr(fb, "varname", "")
@@ -319,6 +324,56 @@ class SelectionMixin:
             logging.debug("Variable-aware prefix fallback lookup skipped: %s", exc)
 
         return list(dict.fromkeys(candidates))
+
+    def _compute_dependency_varnames_for_file_lookup(self, datasource: str) -> list[str]:
+        expressions = [getattr(self, f"{datasource}_compute", "")]
+        try:
+            source = getattr(self, f"{datasource}_source", "")
+            model = getattr(self, f"{source}_model", source)
+            from openbench.data.registry.manager import get_registry
+
+            profile = get_registry().get_model(model)
+            item = getattr(self, "item", "")
+            profile_key = get_mapping_key_case_insensitive(profile.variables, item) if profile else None
+            if profile and profile_key is not None:
+                expressions.append(profile.variables[profile_key].compute or "")
+        except Exception as exc:
+            logging.debug("Compute dependency lookup skipped: %s", exc)
+        deps = []
+        for expr in expressions:
+            deps.extend(re.findall(r"ds\[['\"]([^'\"]+)['\"]\]", str(expr)))
+        return list(dict.fromkeys(dep for dep in deps if dep))
+
+    def _find_compute_dependency_files(self, dirx: str, year: int | None, datasource: str) -> list[str]:
+        deps = self._compute_dependency_varnames_for_file_lookup(datasource)
+        if not deps:
+            return []
+        year_token = f"*{year}*" if year is not None else "*"
+        pattern = os.path.join(dirx, "**", f"{year_token}.nc")
+        files = sorted(
+            set(
+                glob.glob(pattern, recursive=True)
+                + glob.glob(pattern + "4", recursive=True)
+                + glob.glob(pattern[:-3] + ".NC", recursive=True)
+                + glob.glob(pattern[:-3] + ".NC4", recursive=True)
+            )
+        )
+        selected = []
+        found = set()
+        for file_path in files:
+            try:
+                with _xr().open_dataset(file_path, decode_times=False) as ds:
+                    available = {str(name).lower(): str(name) for name in ds.variables}
+                    hits = [dep for dep in deps if dep.lower() in available]
+                    if hits:
+                        selected.append(file_path)
+                        found.update(hits)
+            except Exception as exc:
+                logging.debug("Could not inspect compute dependency file %s: %s", file_path, exc)
+        if selected and set(deps).issubset(found):
+            logging.info("Using %d files containing compute dependencies%s", len(selected), f" for year {year}" if year else "")
+            return selected
+        return []
 
     def _files_contain_any_var(self, files: list, varnames: list[str]) -> bool:
         if not varnames:
@@ -355,7 +410,7 @@ class SelectionMixin:
         suffix: str,
         datasource: str = "sim",
         varname: List[str] | None = None,
-    ) -> str:
+    ) -> str | list[str]:
         """Find a single data file, trying prefix fallbacks and .nc/.nc4 extensions."""
         candidate_varnames = self._candidate_varnames_for_file_lookup(varname, datasource)
         first_existing_path = None
@@ -370,6 +425,9 @@ class SelectionMixin:
                     if try_prefix != prefix:
                         logging.info(f"Using fallback prefix '{try_prefix}' for single file")
                     return path
+        compute_files = self._find_compute_dependency_files(dirx, None, datasource)
+        if compute_files:
+            return compute_files
         if first_existing_path is not None:
             return first_existing_path
         raise FileNotFoundError(f"Data file not found: {os.path.join(dirx, f'{prefix}{suffix}.nc[4]')}")
@@ -402,11 +460,23 @@ class SelectionMixin:
             # entirely. The intentional wildcard is between {year} and {suffix}.
             escaped_prefix = glob.escape(try_prefix)
             escaped_suffix = glob.escape(suffix)
-            # Try primary path with .nc/.nc4 and upper-case variants.
-            var_files = glob_nc_pattern(os.path.join(dirx, f"{escaped_prefix}{year}*{escaped_suffix}.nc"))
-            # Try subdirectory path
-            if not var_files:
-                var_files = glob_nc_pattern(os.path.join(dirx, str(year), f"{escaped_prefix}{year}*{escaped_suffix}.nc"))
+            # Try primary path, then year subdir, then scanner-style nested date dirs.
+            patterns = [
+                os.path.join(dirx, f"{escaped_prefix}{year}*{escaped_suffix}.nc"),
+                os.path.join(dirx, str(year), f"{escaped_prefix}{year}*{escaped_suffix}.nc"),
+                os.path.join(dirx, "**", f"{escaped_prefix}{year}*{escaped_suffix}.nc"),
+            ]
+            var_files = []
+            for pattern_path in patterns:
+                var_files = glob_nc_pattern(pattern_path)
+                if "**" in pattern_path:
+                    var_files = sorted(set(var_files + glob.glob(pattern_path, recursive=True)))
+                    if pattern_path.endswith(".nc"):
+                        var_files = sorted(set(var_files + glob.glob(pattern_path + "4", recursive=True)))
+                        var_files = sorted(set(var_files + glob.glob(pattern_path[:-3] + ".NC", recursive=True)))
+                        var_files = sorted(set(var_files + glob.glob(pattern_path[:-3] + ".NC4", recursive=True)))
+                if var_files:
+                    break
 
             # Filter: only keep files where part between prefix+year and suffix has no letters
             if var_files:
@@ -418,6 +488,19 @@ class SelectionMixin:
                     if pattern.match(os.path.basename(f)):
                         filtered.append(f)
                 var_files = filtered
+
+            if not var_files and (try_prefix or suffix):
+                exact = os.path.join(dirx, "**", f"{escaped_prefix}{escaped_suffix}.nc")
+                nested = set(glob.glob(exact, recursive=True))
+                nested.update(glob.glob(exact + "4", recursive=True))
+                nested.update(glob.glob(exact[:-3] + ".NC", recursive=True))
+                nested.update(glob.glob(exact[:-3] + ".NC4", recursive=True))
+                year_dir = re.compile(rf"^{year}(?:[-_](?:0[1-9]|1[0-2]))?(?:[-_](?:0[1-9]|[12]\d|3[01]))?$")
+                var_files = sorted(
+                    path
+                    for path in nested
+                    if any(year_dir.fullmatch(part) for part in os.path.relpath(path, dirx).split(os.sep)[:-1])
+                )
 
             if var_files:
                 if first_matching_pattern_files is None:
@@ -433,4 +516,7 @@ class SelectionMixin:
                     logging.info(f"Using fallback prefix '{try_prefix}' for year {year} (primary '{prefix}' not found)")
                 return var_files
 
+        compute_files = self._find_compute_dependency_files(dirx, year, datasource)
+        if compute_files:
+            return compute_files
         return first_matching_pattern_files or []

--- a/src/openbench/data/_processing_selection.py
+++ b/src/openbench/data/_processing_selection.py
@@ -371,7 +371,9 @@ class SelectionMixin:
             except Exception as exc:
                 logging.debug("Could not inspect compute dependency file %s: %s", file_path, exc)
         if selected and set(deps).issubset(found):
-            logging.info("Using %d files containing compute dependencies%s", len(selected), f" for year {year}" if year else "")
+            logging.info(
+                "Using %d files containing compute dependencies%s", len(selected), f" for year {year}" if year else ""
+            )
             return selected
         return []
 

--- a/src/openbench/data/_processing_station_core.py
+++ b/src/openbench/data/_processing_station_core.py
@@ -87,21 +87,28 @@ class StationProcessingCoreMixin:
         try:
             logging.debug("Processing station data")
             if not hasattr(self, "station_list") or self.station_list is None or self.station_list.empty:
-                logging.error("Station list is empty; cannot process station data.")
-                return
+                raise RuntimeError("Station list is empty; cannot process station data")
 
-            indices = range(len(self.station_list["ID"]))
+            indices = list(range(len(self.station_list["ID"])))
             try:
-                _parallel()(n_jobs=self.num_cores)(
+                results = _parallel()(n_jobs=self.num_cores)(
                     _delayed()(self._make_stn_parallel)(self.station_list, data_params["datasource"], i)
                     for i in indices
                 )
+                if len(results) != len(indices):
+                    raise OSError("parallel station processing returned incomplete results")
             except (PermissionError, OSError) as exc:
                 logging.warning(
                     "Parallel station processing unavailable (%s). Falling back to sequential execution.", exc
                 )
-                for i in indices:
-                    self._make_stn_parallel(self.station_list, data_params["datasource"], i)
+                results = [self._make_stn_parallel(self.station_list, data_params["datasource"], i) for i in indices]
+
+            failures = [r for r in results if isinstance(r, dict) and not r.get("ok")]
+            if failures:
+                failed_ids = ", ".join(str(r.get("station", "?")) for r in failures[:5])
+                raise RuntimeError(
+                    f"Station processing failed for {len(failures)}/{len(indices)} {data_params['datasource']} station(s): {failed_ids}"
+                )
         finally:
             gc.collect()
 
@@ -154,7 +161,9 @@ class StationProcessingCoreMixin:
                         break
 
                 # Priority 1: compute
-                computed = None if runtime_fallback_used else self._try_compute_from_profile(source_name, stn_data, datasource)
+                computed = (
+                    None if runtime_fallback_used else self._try_compute_from_profile(source_name, stn_data, datasource)
+                )
                 if computed is not None:
                     current_var_list = [getattr(self, "item", current_var_list[0])]
                     ds = computed
@@ -221,9 +230,12 @@ class StationProcessingCoreMixin:
                 logging.error("Time dimension not found in the station data.")
                 raise ValueError("Time dimension not found in the station data.")
 
-            # Ensure the time coordinate is datetime
+            # Ensure the time coordinate is datetime-like. Keep cftime indexes intact;
+            # xarray can slice them by ISO strings while pandas cannot parse noleap dates.
             if not np.issubdtype(ds.time.dtype, np.datetime64):
-                ds["time"] = pd.to_datetime(ds.time.values)
+                time_index = ds.indexes.get("time")
+                if not hasattr(time_index, "calendar"):
+                    ds["time"] = pd.to_datetime(ds.time.values)
 
             # Select the time range before resampling
             ds = ds.sel(time=slice(f"{start_year}-01-01", f"{end_year}-12-31"))
@@ -287,15 +299,15 @@ class StationProcessingCoreMixin:
                 stn_data = self._select_merged_station_data(stn_data, station, datasource)
                 processed_data = self.process_single_station_data(stn_data, start_year, end_year, datasource)
                 if processed_data is None:
-                    logging.info(f"Skipping station {station['ID']} ({datasource}) - no valid data after processing")
-                    return
+                    raise ValueError("no valid data after processing")
                 self.save_station_data(processed_data, station, datasource)
-        except (KeyError, FileNotFoundError, ValueError) as e:
-            # Skip individual stations that fail (missing variable, file, or bad data)
+                return {"ok": True, "station": station["ID"]}
+        except Exception as e:
             station_id = (
                 station_list.iloc[index].get("ID", f"index-{index}") if index < len(station_list) else f"index-{index}"
             )
-            logging.warning(f"Skipping station {station_id} ({datasource}): {e}")
+            logging.warning(f"Station {station_id} ({datasource}) failed: {e}")
+            return {"ok": False, "station": station_id, "error": str(e)}
         finally:
             gc.collect()
 

--- a/src/openbench/data/_processing_time_core.py
+++ b/src/openbench/data/_processing_time_core.py
@@ -198,7 +198,7 @@ class TimeCoreMixin:
         if datasource == "stat":
             ds["time"] = pd.DatetimeIndex(ds["time"].values)
         else:
-            if self.sim_data_type != "stn":
+            if getattr(self, f"{datasource}_data_type", "") != "stn":
                 ds = self.apply_model_specific_time_adjustment(ds, datasource, syear, eyear, tim_res)
         ds = self.make_time_integrity(ds, syear, eyear, tim_res, datasource)
         return ds

--- a/src/openbench/data/_processing_transforms.py
+++ b/src/openbench/data/_processing_transforms.py
@@ -76,33 +76,41 @@ class ProcessingTransformMixin:
         if not item:
             return None
 
+        # Inline namelist compute wins over catalog profiles.
+        compute_expr = getattr(self, f"{datasource}_compute", "")
+        compute_unit = getattr(self, f"{datasource}_varunit", "")
+
         # Check model profile first, then reference dataset.
         var_mapping = None
-        profile = mgr.get_model(source_name)
-        profile_key = get_mapping_key_case_insensitive(profile.variables, item) if profile else None
-        if profile and profile_key is not None and profile.variables[profile_key].compute:
-            var_mapping = profile.variables[profile_key]
+        if not compute_expr:
+            profile = mgr.get_model(source_name)
+            profile_key = get_mapping_key_case_insensitive(profile.variables, item) if profile else None
+            if profile and profile_key is not None and profile.variables[profile_key].compute:
+                var_mapping = profile.variables[profile_key]
 
-        if var_mapping is None:
+        if not compute_expr and var_mapping is None:
             ref = mgr.get_reference(source_name)
             ref_key = get_mapping_key_case_insensitive(ref.variables, item) if ref else None
             if ref and ref_key is not None and ref.variables[ref_key].compute:
                 var_mapping = ref.variables[ref_key]
 
-        if var_mapping is None:
+        if var_mapping is not None:
+            compute_expr = var_mapping.compute
+            compute_unit = var_mapping.varunit
+        if not compute_expr:
             return None
 
-        logging.info("Computing %s via catalog compute expression", item)
+        logging.info("Computing %s via compute expression", item)
         from openbench.data.compute import execute_compute
 
-        result = execute_compute(ds, var_mapping.compute, item)
+        result = execute_compute(ds, compute_expr, item)
 
         if hasattr(result, "name"):
             result.name = item
         result = self._reduce_patch_dimension(result, ds)
 
         setattr(self, f"{datasource}_varname", [item])
-        setattr(self, f"{datasource}_varunit", var_mapping.varunit)
+        setattr(self, f"{datasource}_varunit", compute_unit)
 
         return result
 

--- a/src/openbench/data/sim_scanner.py
+++ b/src/openbench/data/sim_scanner.py
@@ -178,6 +178,7 @@ def _build_case(
     station_layout: str | None = None,
 ) -> SimulationCase:
     info = _scan_nc_info(metadata_dir)
+    date_subdir_files = _date_subdir_files(case_dir, metadata_dir)
     multi_undated = _has_multiple_no_date_files(metadata_dir) and not station_layout
     if multi_undated:
         common_prefix, common_suffix = _common_stem_affixes(_glob_nc(metadata_dir))
@@ -185,6 +186,8 @@ def _build_case(
         info["suffix"] = common_suffix
     if station_layout:
         data_groupby, filename_years = "Single", _years_from_station_collection(case_dir)
+    elif date_subdir_files:
+        data_groupby, filename_years = _infer_date_subdir_grouping(date_subdir_files)
     else:
         data_groupby, filename_years = _infer_file_grouping(metadata_dir)
     if station_layout:
@@ -195,8 +198,8 @@ def _build_case(
             info=info,
         )
         time_coverage = _infer_time_coverage(
-            metadata_dir,
-            files=selected_files or None,
+            case_dir if date_subdir_files else metadata_dir,
+            files=date_subdir_files or selected_files or None,
             data_groupby=data_groupby,
         )
     temporal_kind, temporal_kind_candidate, temporal_source = _infer_temporal_kind(
@@ -271,7 +274,7 @@ def _build_case(
             "data_type": "nc" if info.get("detected_data_type") else "unknown",
             "tim_res": tim_res_source,
             "grid_res": "nc" if info.get("detected_grid_res") else "unknown",
-            "data_groupby": "filename",
+            "data_groupby": "directory" if date_subdir_files else "filename",
             "temporal_kind": temporal_source,
             "years": "filename" if filename_years else ("nc" if time_coverage.get("years") else "unknown"),
             "time_coverage": "nc" if time_coverage.get("time_start") else "unknown",
@@ -549,6 +552,9 @@ def _infer_variable_file_overrides(
 
     overrides: dict[str, dict[str, Any]] = {}
     for variable_name, mapping in profile.variables.items():
+        if getattr(mapping, "compute", None) and _compute_dependencies_span_file_patterns(files, mapping):
+            overrides[variable_name] = {"prefix": "", "suffix": ""}
+            continue
         matched = _match_profile_variable_file(files, mapping)
         if matched is None:
             continue
@@ -665,6 +671,18 @@ def _filename_pattern_for_file(file_path: Path) -> tuple[str, str]:
         return stem, ""
     return stem[: date_match.start("token")], stem[date_match.end("token") :]
 
+
+def _compute_dependencies_span_file_patterns(files: list[Path], mapping) -> bool:
+    deps = re.findall(r"ds\[['\"]([^'\"]+)['\"]\]", str(getattr(mapping, "compute", "")))
+    if len(deps) < 2:
+        return False
+    patterns = set()
+    for dep in deps:
+        matched = [path for path in files if _stem_contains_var_token(path.stem, dep)]
+        if not matched:
+            return True
+        patterns.update(_filename_pattern_for_file(path) for path in matched)
+    return len(patterns) > 1
 
 def _match_profile_variable_file(files: list[Path], mapping) -> tuple[Path, str] | None:
     candidates = _mapping_candidate_varnames(mapping)
@@ -815,7 +833,6 @@ def _per_bucket_variable_metadata(
     *,
     info: dict,
     station_layout: str | None,
-    max_buckets: int = 8,
 ) -> list[dict[str, Any]]:
     """Collect variable metadata across distinct prefix/suffix buckets.
 
@@ -837,8 +854,6 @@ def _per_bucket_variable_metadata(
     for file_path in files:
         key = _filename_pattern_for_file(file_path)
         buckets.setdefault(key, file_path)
-        if len(buckets) >= max_buckets:
-            break
     if len(buckets) <= 1:
         return base_metadata
 
@@ -902,7 +917,6 @@ def _time_info_from_file(file_path: Path) -> dict:
     raw = _raw_time_metadata_from_file(file_path)
     try:
         import numpy as np
-        import pandas as pd
         import xarray as xr
 
         with xr.open_dataset(file_path, decode_times=True, decode_timedelta=False) as ds:
@@ -913,10 +927,7 @@ def _time_info_from_file(file_path: Path) -> dict:
             units = raw.get("raw_time_units") or str(time_var.attrs.get("units", ""))
             if np.issubdtype(np.asarray(raw_values).dtype, np.number) and not units.strip():
                 return _raw_time_info_from_file(file_path)
-            timestamps = pd.to_datetime(raw_values)
-            if getattr(timestamps, "ndim", 1) == 0:
-                timestamps = [timestamps]
-            values = [ts.to_pydatetime().replace(tzinfo=None) for ts in timestamps if not pd.isna(ts)]
+            values = _datetime_values_from_time_values(raw_values)
             return {
                 "readable": True,
                 "has_time": True,
@@ -929,6 +940,23 @@ def _time_info_from_file(file_path: Path) -> dict:
     except Exception:
         return _raw_time_info_from_file(file_path)
 
+
+def _datetime_values_from_time_values(raw_values) -> list[datetime]:
+    import calendar
+
+    import pandas as pd
+
+    values = []
+    for value in getattr(raw_values, "reshape", lambda *_: raw_values)(-1):
+        if pd.isna(value):
+            continue
+        if all(hasattr(value, attr) for attr in ("year", "month", "day")):
+            year, month = int(value.year), int(value.month)
+            day = min(int(value.day), calendar.monthrange(year, month)[1])
+            values.append(datetime(year, month, day))
+        else:
+            values.append(pd.Timestamp(value).to_pydatetime().replace(tzinfo=None))
+    return values
 
 def _raw_time_metadata_from_file(file_path: Path) -> dict:
     try:
@@ -1358,8 +1386,6 @@ def materialize_station_cases(
             return_dropped=True,
         )
         time_coverage = _infer_station_dataframe_time_coverage(df)
-        if "sim_dir" in df.columns:
-            df["sim_dir"] = df["sim_dir"].apply(lambda value: _portable_sim_dir(value, case.source_root))
 
         fulllist = case_output_dir / f"{case_label}_stations.csv"
         df.to_csv(fulllist, index=False)
@@ -1404,20 +1430,6 @@ def _safe_path_label(label: str) -> str:
         return safe
     digest = blake2s(text.encode("utf-8"), digest_size=4).hexdigest()
     return f"case_{digest}"
-
-
-def _portable_sim_dir(value, source_root: Path | None) -> str:
-    """Replace the ``source_root`` prefix with ``${OPENBENCH_SIM_ROOT}`` when applicable."""
-    text = str(value)
-    if source_root is None:
-        return text
-    try:
-        target = Path(text).expanduser().resolve()
-        base = Path(source_root).expanduser().resolve()
-        rel = target.relative_to(base)
-    except (OSError, ValueError):
-        return text
-    return "${OPENBENCH_SIM_ROOT}/" + rel.as_posix()
 
 
 def _infer_station_dataframe_time_coverage(df) -> dict:
@@ -1494,6 +1506,26 @@ def _children_are_date_subdir_layout(children: list[Path]) -> bool:
         else:
             return False
     return found_with_nc
+
+
+def _date_subdir_files(case_dir: Path, metadata_dir: Path) -> list[Path]:
+    if metadata_dir.parent != case_dir:
+        return []
+    children = sorted(child for child in case_dir.iterdir() if child.is_dir())
+    if not _children_are_date_subdir_layout(children):
+        return []
+    return [file_path for child in children for file_path in _glob_nc(child)]
+
+
+def _infer_date_subdir_grouping(files: list[Path]) -> tuple[str, list[int]]:
+    names = {file_path.parent.name for file_path in files}
+    digit_counts = [len(re.sub(r"\D", "", name)) for name in names]
+    years = sorted({int(re.sub(r"\D", "", name)[:4]) for name in names})
+    if max(digit_counts) >= 8:
+        return "Day", years
+    if max(digit_counts) >= 6:
+        return "Month", years
+    return "Year", years
 
 
 def _iter_case_dirs(

--- a/src/openbench/data/sim_scanner.py
+++ b/src/openbench/data/sim_scanner.py
@@ -684,6 +684,7 @@ def _compute_dependencies_span_file_patterns(files: list[Path], mapping) -> bool
         patterns.update(_filename_pattern_for_file(path) for path in matched)
     return len(patterns) > 1
 
+
 def _match_profile_variable_file(files: list[Path], mapping) -> tuple[Path, str] | None:
     candidates = _mapping_candidate_varnames(mapping)
     if not candidates:
@@ -957,6 +958,7 @@ def _datetime_values_from_time_values(raw_values) -> list[datetime]:
         else:
             values.append(pd.Timestamp(value).to_pydatetime().replace(tzinfo=None))
     return values
+
 
 def _raw_time_metadata_from_file(file_path: Path) -> dict:
     try:

--- a/src/openbench/data/station_matcher.py
+++ b/src/openbench/data/station_matcher.py
@@ -58,8 +58,7 @@ def get_resolution_suffix(sim_grid_res: float) -> str:
     for res, suffix in res_map.items():
         if abs(float(sim_grid_res) - res) < 0.001:
             return suffix
-    logging.warning("Unknown resolution %s, defaulting to 03min", sim_grid_res)
-    return "03min"
+    raise ValueError(f"Unsupported CaMA station matching resolution: {sim_grid_res}")
 
 
 def _station_id_to_string(value) -> str:

--- a/src/openbench/data/station_scanner.py
+++ b/src/openbench/data/station_scanner.py
@@ -462,6 +462,7 @@ def _year_bounds(values) -> tuple[int, int]:
         raise ValueError("Empty time coordinate")
     return min(years), max(years)
 
+
 def _combined_year_range(nc_files: list[Path]) -> tuple[int, int]:
     ranges = [_read_year_range(path) for path in nc_files]
     return min(start for start, _ in ranges), max(end for _, end in ranges)

--- a/src/openbench/data/station_scanner.py
+++ b/src/openbench/data/station_scanner.py
@@ -24,6 +24,7 @@ from typing import Any
 import pandas as pd
 import xarray as xr
 
+from openbench.data.coordinates import glob_nc as _glob_nc
 from openbench.util.dataset_loader import open_mfdataset as _open_mfdataset_chunked
 from openbench.util.netcdf import write_netcdf_atomic as _write_netcdf_atomic
 
@@ -96,7 +97,7 @@ def _detect_layout(root: Path) -> str:
     Returns: "flat", "nested_single", "nested_multi", or "unknown".
     """
     # Check root for NC files directly
-    root_nc = list(root.glob("*.nc")) + list(root.glob("*.nc4"))
+    root_nc = _glob_nc(root)
     if root_nc:
         return "flat"
 
@@ -142,7 +143,7 @@ _PATTERN_ID_ONLY = re.compile(r"^(?:sim_)?([A-Za-z]{2}[-_][A-Za-z0-9]+)\.nc4?$")
 
 def _scan_flat(root: Path, *, metadata: pd.DataFrame | None = None) -> tuple[pd.DataFrame, list[str]]:
     """Scan flat directory of station NC files."""
-    nc_files = sorted(root.glob("*.nc")) + sorted(root.glob("*.nc4"))
+    nc_files = _glob_nc(root)
     logger.info("Scanning %d station files in flat directory", len(nc_files))
 
     records = []
@@ -340,9 +341,9 @@ def _station_nc_files(site_dir: Path) -> list[Path]:
 
     history = site_dir / "history"
     if history.is_dir():
-        nc_files = sorted(history.glob("*.nc")) + sorted(history.glob("*.nc4"))
+        nc_files = _glob_nc(history)
     else:
-        nc_files = sorted(site_dir.glob("*.nc")) + sorted(site_dir.glob("*.nc4"))
+        nc_files = _glob_nc(site_dir)
 
     if not nc_files:
         return []
@@ -400,9 +401,7 @@ def _merge_site(
             parallel=False,
         ) as ds:
             loaded = ds.load()
-            times = pd.to_datetime(ds.time.values)
-            syear = int(times.min().year)
-            eyear = int(times.max().year)
+            syear, eyear = _year_bounds(ds.time.values)
 
         merged_path = output_dir / f"sim_{site_id}_{syear}_{eyear}.nc"
         try:
@@ -451,9 +450,17 @@ def _read_year_range(nc_path: Path) -> tuple[int, int]:
         units = str(time_var.attrs.get("units", ""))
         if np.issubdtype(np.asarray(values).dtype, np.number) and not units.strip():
             raise ValueError(f"Numeric time coordinate has no units in {nc_path.name}")
-        times = pd.to_datetime(ds.time.values)
-        return int(times.min().year), int(times.max().year)
+        return _year_bounds(ds.time.values)
 
+
+def _year_bounds(values) -> tuple[int, int]:
+    years = []
+    for value in values:
+        year = getattr(value, "year", None)
+        years.append(int(year if year is not None else pd.Timestamp(value).year))
+    if not years:
+        raise ValueError("Empty time coordinate")
+    return min(years), max(years)
 
 def _combined_year_range(nc_files: list[Path]) -> tuple[int, int]:
     ranges = [_read_year_range(path) for path in nc_files]

--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -250,11 +250,14 @@ class ConfigManager:
                 continue
             entry = {**sim_defaults, **raw_entry}
             variables_override = {}
-            if isinstance(sim_defaults.get("variables"), dict) or isinstance(raw_entry.get("variables"), dict):
-                variables_override = {
-                    **(sim_defaults.get("variables") or {}),
-                    **(raw_entry.get("variables") or {}),
-                }
+            default_vars = sim_defaults.get("variables") if isinstance(sim_defaults.get("variables"), dict) else {}
+            entry_vars = raw_entry.get("variables") if isinstance(raw_entry.get("variables"), dict) else {}
+            for var_name in set(default_vars) | set(entry_vars):
+                base = default_vars.get(var_name) if isinstance(default_vars.get(var_name), dict) else {}
+                override = entry_vars.get(var_name) if isinstance(entry_vars.get(var_name), dict) else {}
+                merged = {**base, **override}
+                if merged:
+                    variables_override[var_name] = merged
             source_general: Dict[str, Any] = {
                 "model": entry.get("model", ""),
                 "model_namelist": entry.get("model", ""),
@@ -905,8 +908,11 @@ class ConfigManager:
             if isinstance(src_cfg.get("variables"), dict) and src_cfg["variables"]:
                 entry["variables"] = src_cfg["variables"]
 
-            # Use source_name as label, or derive a cleaner one
-            label = self._derive_label(source_name, entry.get("root_dir", ""))
+            # Preserve explicit GUI source labels; deriving from paths can collapse
+            # distinct cases (Case01/foo and Case01/bar) into one YAML entry.
+            label = source_name or self._derive_label(source_name, entry.get("root_dir", ""))
+            if label in sim_entries:
+                raise ValueError(f"Duplicate simulation label after export: {label}")
             sim_entries[label] = entry
 
         simulation = self._extract_sim_defaults(sim_entries)

--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -812,11 +812,22 @@ class ConfigManager:
                 override = overrides.setdefault(source_name, {})
                 general_cfg = source_cfg.get("general", {}) if isinstance(source_cfg.get("general"), dict) else {}
                 if general_cfg:
-                    for key in ("root_dir", "dir", "data_type", "tim_res", "data_groupby", "timezone", "grid_res", "fulllist"):
+                    for key in (
+                        "root_dir",
+                        "dir",
+                        "data_type",
+                        "tim_res",
+                        "data_groupby",
+                        "timezone",
+                        "grid_res",
+                        "fulllist",
+                    ):
                         value = general_cfg.get(key)
                         if value not in (None, ""):
                             out_key = "root_dir" if key == "dir" else key
-                            override[out_key] = _maybe_transform_path(value) if out_key in {"root_dir", "fulllist"} else value
+                            override[out_key] = (
+                                _maybe_transform_path(value) if out_key in {"root_dir", "fulllist"} else value
+                            )
                     syear = general_cfg.get("syear")
                     eyear = general_cfg.get("eyear")
                     if syear not in (None, "") or eyear not in (None, ""):

--- a/src/openbench/gui/pages/page_preview.py
+++ b/src/openbench/gui/pages/page_preview.py
@@ -801,13 +801,15 @@ class PagePreview(BasePage):
 
         # Handle Windows absolute paths (e.g., C:/Users/... or D:/...)
         # After to_posix_path, Windows paths become like "C:/Users/..."
-        if len(path) >= 2 and path[1] == ":":
+        if (len(path) >= 2 and path[1] == ":") or path.startswith("//"):
             # This is a Windows local path - extract relative part if contains /nml/
             if "/nml/" in path:
                 relative_path = "nml/" + path.split("/nml/", 1)[1]
                 return f"{openbench_root.rstrip('/')}/{relative_path}"
-            # Unknown Windows path - cannot convert to remote
-            return path
+            raise RemoteNamelistSyncError(
+                "Windows local path cannot be converted to a remote path: "
+                f"{path}. Choose or enter the corresponding remote server path."
+            )
 
         # If path is already an absolute Unix path
         if path.startswith("/"):

--- a/src/openbench/gui/pages/page_sim_data.py
+++ b/src/openbench/gui/pages/page_sim_data.py
@@ -199,11 +199,12 @@ def _remote_list_nc_files(ssh_manager, directory: str) -> list[str]:
     quoted = quote_remote_path(directory)
     cmd = (
         f"find {quoted} -maxdepth 1 -type f "
-        r"\( -name '*.nc' -o -name '*.nc4' \) | sort"
+        r"\( -name '*.nc' -o -name '*.nc4' -o -name '*.NC' -o -name '*.NC4' \) | sort"
     )
-    stdout, _, exit_code = execute_responsive(ssh_manager, cmd, timeout=30)
+    stdout, stderr, exit_code = execute_responsive(ssh_manager, cmd, timeout=30)
     if exit_code != 0:
-        return []
+        detail = (stderr or stdout or f"exit {exit_code}").strip()
+        raise RuntimeError(f"Remote NetCDF scan failed for {directory}: {detail}")
     return [line.strip() for line in stdout.splitlines() if line.strip()]
 
 
@@ -224,6 +225,8 @@ def _remote_find_nc_dir(ssh_manager, case_dir: str) -> str:
 def _remote_detect_case_pattern(ssh_manager, case_dir: str) -> tuple:
     """Remote case scan: (prefix, suffix, multi_stream, file_names)."""
     for sub in (f"{case_dir.rstrip('/')}/history", case_dir):
+        if not _remote_is_dir(ssh_manager, sub):
+            continue
         files = _remote_list_nc_files(ssh_manager, sub)
         if files:
             names = [os.path.basename(name) for name in files]
@@ -238,13 +241,14 @@ def _remote_detect_prefix(ssh_manager, case_dir: str) -> str:
 
 def _remote_list_dirs(ssh_manager, root: str, max_depth: int = 5) -> list[str]:
     quoted = quote_remote_path(root)
-    stdout, _, exit_code = execute_responsive(
+    stdout, stderr, exit_code = execute_responsive(
         ssh_manager,
         f"find {quoted} -mindepth 0 -maxdepth {int(max_depth)} -type d -print | sort",
         timeout=30,
     )
     if exit_code != 0:
-        return []
+        detail = (stderr or stdout or f"exit {exit_code}").strip()
+        raise RuntimeError(f"Remote directory scan failed for {root}: {detail}")
     return [line.strip() for line in stdout.splitlines() if line.strip()]
 
 
@@ -528,8 +532,17 @@ class PageSimData(BasePage):
             case_meta: Dict[str, Dict[str, Any]] = {}
             if is_remote:
                 seen_nc_dirs = set()
-                for full in _remote_list_dirs(ssh_manager, root):
-                    nc_dir = _remote_find_nc_dir(ssh_manager, full)
+                try:
+                    remote_dirs = _remote_list_dirs(ssh_manager, root)
+                except Exception as exc:
+                    QMessageBox.critical(self, "Error", f"Cannot scan remote directory:\n{exc}")
+                    return
+                for full in remote_dirs:
+                    try:
+                        nc_dir = _remote_find_nc_dir(ssh_manager, full)
+                    except Exception as exc:
+                        QMessageBox.critical(self, "Error", f"Cannot scan remote NetCDF files:\n{exc}")
+                        return
                     normalized_nc_dir = nc_dir.rstrip("/")
                     if not nc_dir or normalized_nc_dir in seen_nc_dirs:
                         continue
@@ -537,7 +550,11 @@ class PageSimData(BasePage):
                     nc_leaf = normalized_nc_dir.rsplit("/", 1)[-1].lower()
                     label_dir = normalized_nc_dir.rsplit("/", 1)[0] if nc_leaf == "history" else full
                     label = label_dir.rstrip("/").rsplit("/", 1)[-1]
-                    prefix, suffix, multi_stream, file_names = _remote_detect_case_pattern(ssh_manager, full)
+                    try:
+                        prefix, suffix, multi_stream, file_names = _remote_detect_case_pattern(ssh_manager, full)
+                    except Exception as exc:
+                        QMessageBox.critical(self, "Error", f"Cannot inspect remote NetCDF files:\n{exc}")
+                        return
                     discovered.append((label, nc_dir, prefix))
                     case_meta[label] = {
                         "files": file_names,
@@ -884,7 +901,6 @@ class PageSimData(BasePage):
 
     def save_to_config(self):
         cases = self.get_selected_cases()
-        case_labels = [c["label"] for c in cases]
         existing_sim_data = self.controller.config.get("sim_data", {})
         preserved = {
             key: value
@@ -956,7 +972,7 @@ class PageSimData(BasePage):
                     existing_source.pop("variables", None)
             source_configs[c["label"]] = existing_source
 
-        # For every selected evaluation variable, all selected cases are sources.
+        # For every selected evaluation variable, only compatible selected cases are sources.
         # Do not fall back to all model-profile variables: Evaluation Variables
         # is the user's source of truth, and an empty selection must stay empty.
         eval_items = self.controller.config.get("evaluation_items", {})
@@ -967,8 +983,23 @@ class PageSimData(BasePage):
         # Only the *_sim_source mappings are rewritten below.
         existing_inner_general = existing_sim_data.get("general", {}) or {}
         general: Dict[str, Any] = {k: v for k, v in existing_inner_general.items() if not k.endswith("_sim_source")}
+        model_vars_cache: Dict[str, Set[str]] = {}
         for var_name in selected_vars:
-            general[f"{var_name}_sim_source"] = list(case_labels)
+            sources = []
+            var_key = str(var_name).casefold()
+            for c in cases:
+                overrides = c.get("variables") if isinstance(c.get("variables"), dict) else {}
+                if var_key in {str(name).casefold() for name in overrides}:
+                    sources.append(c["label"])
+                    continue
+                model = c.get("model", "")
+                if model not in model_vars_cache:
+                    model_vars_cache[model] = (
+                        {str(name).casefold() for name in _get_model_variables(model)} if model else set()
+                    )
+                if var_key in model_vars_cache[model]:
+                    sources.append(c["label"])
+            general[f"{var_name}_sim_source"] = sources
 
         sim_data = {
             **preserved,
@@ -1128,7 +1159,6 @@ class PageSimData(BasePage):
         if not cases:
             QMessageBox.information(self, "Nothing to Validate", "No cases selected.")
             return
-        # Quick check: verify NC directories exist
         issues = []
         from openbench.remote.storage import RemoteStorage
 
@@ -1136,12 +1166,22 @@ class PageSimData(BasePage):
         ssh_manager = get_remote_ssh_manager(self.controller) if is_remote else None
         for c in cases:
             if is_remote:
-                ok = ssh_manager and ssh_manager.is_connected and _remote_is_dir(ssh_manager, c["nc_dir"])
+                if not ssh_manager or not ssh_manager.is_connected:
+                    issues.append(f"{c['label']}: remote server is not connected")
+                    continue
+                try:
+                    nc_dir = _remote_find_nc_dir(ssh_manager, c["nc_dir"])
+                except Exception as exc:
+                    issues.append(f"{c['label']}: {exc}")
+                    continue
+                if not nc_dir:
+                    issues.append(f"{c['label']}: no NetCDF files found ({c['nc_dir']})")
             else:
-                ok = os.path.isdir(c["nc_dir"])
-            if not ok:
-                issues.append(f"{c['label']}: directory not found ({c['nc_dir']})")
+                if not os.path.isdir(c["nc_dir"]):
+                    issues.append(f"{c['label']}: directory not found ({c['nc_dir']})")
+                elif not _find_nc_dir(c["nc_dir"]):
+                    issues.append(f"{c['label']}: no NetCDF files found ({c['nc_dir']})")
         if issues:
             QMessageBox.warning(self, "Validation Issues", "\n".join(issues))
         else:
-            QMessageBox.information(self, "Validation OK", f"All {len(cases)} case directories verified.")
+            QMessageBox.information(self, "Validation OK", f"All {len(cases)} case directories contain NetCDF files.")

--- a/src/openbench/gui/progress_parser.py
+++ b/src/openbench/gui/progress_parser.py
@@ -40,12 +40,20 @@ def parse_progress_line(
             event = json.loads(line.split(GUI_PROGRESS_PREFIX, 1)[1])
         except (json.JSONDecodeError, TypeError):
             event = {}
-        if event.get("event") == "evaluation_completed":
+        if event.get("event") in {"preprocessing_started", "preprocessing_completed", "evaluation_completed"}:
             state["current_variable"] = str(event.get("variable", ""))
             state["current_sim"] = str(event.get("sim", ""))
             state["current_ref"] = str(event.get("ref", ""))
             var = state["current_variable"]
-            stage = "Evaluation"
+            task_key = (state["current_variable"], state["current_ref"], state["current_sim"])
+            if event.get("event") in {"preprocessing_started", "preprocessing_completed"}:
+                if event.get("event") == "preprocessing_started":
+                    state.setdefault("started_preprocess_tasks", set()).add(task_key)
+                else:
+                    state.setdefault("completed_preprocess_tasks", set()).add(task_key)
+                stage = "Preprocessing"
+            else:
+                stage = "Evaluation"
 
     natural_line = "" if protocol_line else line
     natural_line_lower = natural_line.lower()
@@ -144,10 +152,19 @@ def parse_progress_line(
     P_INC = constants["PROGRESS_INCREMENT"]
 
     if total_tasks > 0:
+        completed_eval_tasks = state["completed_eval_tasks"]
+        preprocess_only = state.get("completed_preprocess_tasks", set()) - completed_eval_tasks
+        preprocess_started_only = (
+            state.get("started_preprocess_tasks", set())
+            - state.get("completed_preprocess_tasks", set())
+            - completed_eval_tasks
+        )
         total_completed = (
-            len(state["completed_eval_tasks"])
+            len(completed_eval_tasks)
             + len(state["completed_groupby_tasks"])
             + len(state["completed_comparison_tasks"])
+            + 0.4 * len(preprocess_only)
+            + 0.05 * len(preprocess_started_only)
         )
         task_progress = (total_completed / max(1, total_tasks)) * P_WORK
         current_progress = min(P_INIT + task_progress, P_MAX)

--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -119,6 +119,8 @@ class RemoteRunner(QThread):
         self._do_statistics = False
 
         # Track completed items to avoid double counting
+        self._started_preprocess_tasks = set()
+        self._completed_preprocess_tasks = set()
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()
@@ -462,6 +464,8 @@ class RemoteRunner(QThread):
             "current_variable": self._current_variable,
             "current_ref": self._current_ref,
             "current_sim": self._current_sim,
+            "started_preprocess_tasks": self._started_preprocess_tasks,
+            "completed_preprocess_tasks": self._completed_preprocess_tasks,
             "completed_eval_tasks": self._completed_eval_tasks,
             "completed_groupby_tasks": self._completed_groupby_tasks,
             "completed_comparison_tasks": self._completed_comparison_tasks,
@@ -535,6 +539,8 @@ class RemoteRunner(QThread):
 
         # Reset completion tracking
         self._completed_tasks = 0
+        self._started_preprocess_tasks = set()
+        self._completed_preprocess_tasks = set()
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()

--- a/src/openbench/gui/runner.py
+++ b/src/openbench/gui/runner.py
@@ -96,6 +96,8 @@ class EvaluationRunner(QThread):
         self._do_statistics = False
 
         # Track completed items to avoid double counting
+        self._started_preprocess_tasks = set()  # (var, ref, sim) tuples
+        self._completed_preprocess_tasks = set()  # (var, ref, sim) tuples
         self._completed_eval_tasks = set()  # (var, ref, sim) tuples
         self._completed_groupby_tasks = set()  # (var, groupby_type) tuples
         self._completed_comparison_tasks = set()  # comparison names
@@ -192,6 +194,8 @@ class EvaluationRunner(QThread):
                     self._current_variable = ""
                     self._current_ref = ""
                     self._current_sim = ""
+                    self._started_preprocess_tasks.clear()
+                    self._completed_preprocess_tasks.clear()
                     self._completed_eval_tasks.clear()
                     self._completed_groupby_tasks.clear()
                     self._completed_comparison_tasks.clear()
@@ -408,6 +412,8 @@ class EvaluationRunner(QThread):
             "current_variable": self._current_variable,
             "current_ref": self._current_ref,
             "current_sim": self._current_sim,
+            "started_preprocess_tasks": self._started_preprocess_tasks,
+            "completed_preprocess_tasks": self._completed_preprocess_tasks,
             "completed_eval_tasks": self._completed_eval_tasks,
             "completed_groupby_tasks": self._completed_groupby_tasks,
             "completed_comparison_tasks": self._completed_comparison_tasks,
@@ -498,6 +504,8 @@ class EvaluationRunner(QThread):
 
         # Reset completion tracking
         self._completed_tasks = 0
+        self._started_preprocess_tasks = set()
+        self._completed_preprocess_tasks = set()
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()

--- a/src/openbench/runner/hashing.py
+++ b/src/openbench/runner/hashing.py
@@ -102,9 +102,7 @@ def source_specific_section(
     """Return legacy namelist keys owned by one reference/simulation source."""
     prefix = f"{source}_"
     nested_prefixes = tuple(
-        f"{candidate}_"
-        for candidate in all_sources
-        if candidate != source and str(candidate).startswith(prefix)
+        f"{candidate}_" for candidate in all_sources if candidate != source and str(candidate).startswith(prefix)
     )
     return {
         key: value

--- a/src/openbench/runner/hashing.py
+++ b/src/openbench/runner/hashing.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 from dataclasses import asdict, is_dataclass
+from functools import lru_cache
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any, Callable
@@ -158,6 +159,7 @@ def openbench_version() -> str:
     return getattr(openbench, "__version__", "unknown")
 
 
+@lru_cache(maxsize=1)
 def algorithm_source_fingerprint() -> str:
     """Return a digest of source modules that define metric/score semantics."""
     digest = hashlib.sha256()
@@ -212,15 +214,18 @@ def configured_regrid_backend(cfg: OpenBenchConfig, general: dict[str, Any]) -> 
 
 
 def input_file_signature(section: dict[str, Any], source: str) -> dict[str, Any]:
-    """Return cheap file metadata for raw inputs referenced by one source."""
-    root = legacy_source_value(section, source, "dir")
+    """Return a current file signature for raw inputs referenced by one source."""
+    root = str(legacy_source_value(section, source, "dir") or "")
+    fulllist = str(legacy_source_value(section, source, "fulllist") or "")
+    prefix = str(legacy_source_value(section, source, "prefix", "") or "")
+    suffix = str(legacy_source_value(section, source, "suffix", "") or "")
+    varname = str(legacy_source_value(section, source, "varname", "") or "")
     if not root:
         return {"files": []}
 
     root_path = Path(os.path.expanduser(os.path.expandvars(str(root))))
     candidates: set[Path] = set()
 
-    fulllist = legacy_source_value(section, source, "fulllist")
     if fulllist:
         list_path = Path(os.path.expanduser(os.path.expandvars(str(fulllist))))
         if not list_path.is_absolute():
@@ -228,9 +233,6 @@ def input_file_signature(section: dict[str, Any], source: str) -> dict[str, Any]
         candidates.add(list_path)
 
     if root_path.exists():
-        prefix = str(legacy_source_value(section, source, "prefix", "") or "")
-        suffix = str(legacy_source_value(section, source, "suffix", "") or "")
-        varname = str(legacy_source_value(section, source, "varname", "") or "")
         escaped_prefix = glob.escape(prefix)
         escaped_varname = glob.escape(varname)
         escaped_suffix = glob.escape(suffix)
@@ -276,6 +278,11 @@ def input_file_signature(section: dict[str, Any], source: str) -> dict[str, Any]
     return {"files": files}
 
 
+def clear_hashing_caches() -> None:
+    """Reset process-stable hashing memoization before planning a new evaluation."""
+    algorithm_source_fingerprint.cache_clear()
+
+
 def stable_hash_data(value: Any) -> Any:
     """Convert dataclass-rich config objects into JSON-stable data."""
     if is_dataclass(value) and not isinstance(value, type):
@@ -293,6 +300,7 @@ def shared_mask_peer_payload(
     bindings: Any,
     var_name: str,
     ref_source: str,
+    input_file_signature_fn: Callable[[dict[str, Any], str], dict[str, Any]] = input_file_signature,
 ) -> dict[str, Any] | None:
     """Return peer simulation inputs that affect a shared unified mask."""
     alignment = getattr(cfg.project, "time_alignment", "intersection")
@@ -340,7 +348,7 @@ def shared_mask_peer_payload(
                 "namelist": stable_hash_data(
                     source_specific_section(sim_section, peer_source, all_sources=candidate_sources)
                 ),
-                "inputs": input_file_signature(sim_section, peer_source),
+                "inputs": input_file_signature_fn(sim_section, peer_source),
             }
         )
 
@@ -368,6 +376,7 @@ def task_hash_payload(
     statistic_vars: list[str],
     openbench_version_fn: Callable[[], str] = openbench_version,
     regrid_backend_signature_fn: Callable[[], dict[str, Any]] = regrid_backend_signature,
+    input_file_signature_fn: Callable[[dict[str, Any], str], dict[str, Any]] = input_file_signature,
 ) -> dict[str, Any]:
     """Build the runtime-sensitive payload used for one task's cache hash."""
     runner_cfg = bindings.runner_cfg
@@ -448,7 +457,7 @@ def task_hash_payload(
             "data_root": cfg.reference.data_root,
             "source": cfg.reference.sources.get(var_name),
             "namelist": ref_section,
-            "inputs": input_file_signature(
+            "inputs": input_file_signature_fn(
                 namelists.reference.get(var_name, {}) if namelists is not None else {},
                 ref_source,
             ),
@@ -456,7 +465,7 @@ def task_hash_payload(
         "simulation": {
             "config": stable_hash_data(sim_entry),
             "namelist": sim_section,
-            "inputs": input_file_signature(
+            "inputs": input_file_signature_fn(
                 namelists.simulation.get(var_name, {}) if namelists is not None else {},
                 sim_source,
             ),
@@ -466,5 +475,6 @@ def task_hash_payload(
             bindings=bindings,
             var_name=var_name,
             ref_source=ref_source,
+            input_file_signature_fn=input_file_signature_fn,
         ),
     }

--- a/src/openbench/runner/local.py
+++ b/src/openbench/runner/local.py
@@ -164,6 +164,18 @@ def _build_evaluation_tasks(
     only_drawing: bool,
 ) -> list[dict[str, Any]]:
     """Compatibility wrapper for task planning."""
+    _runner_hashing.clear_hashing_caches()
+    signature_cache: dict[tuple[int, str], dict[str, Any]] = {}
+
+    def cached_input_signature(section: dict[str, Any], source: str) -> dict[str, Any]:
+        key = (id(section), source)
+        if key not in signature_cache:
+            signature_cache[key] = _runner_hashing.input_file_signature(section, source)
+        return signature_cache[key]
+
+    def task_hash_payload(**kwargs) -> dict[str, Any]:
+        return _task_hash_payload(**kwargs, input_file_signature_fn=cached_input_signature)
+
     return _runner_task_planning.build_evaluation_tasks(
         cfg=cfg,
         bindings=bindings,
@@ -174,7 +186,7 @@ def _build_evaluation_tasks(
         statistic_vars=statistic_vars,
         use_cache=use_cache,
         only_drawing=only_drawing,
-        task_hash_payload_fn=_task_hash_payload,
+        task_hash_payload_fn=task_hash_payload,
     )
 
 
@@ -293,6 +305,7 @@ def _task_hash_payload(
     score_vars: list[str],
     comparison_vars: list[str],
     statistic_vars: list[str],
+    input_file_signature_fn=None,
 ) -> dict[str, Any]:
     return _runner_hashing.task_hash_payload(
         cfg=cfg,
@@ -306,6 +319,7 @@ def _task_hash_payload(
         statistic_vars=statistic_vars,
         openbench_version_fn=_local_attr("_openbench_version"),
         regrid_backend_signature_fn=_local_attr("_regrid_backend_signature"),
+        **({"input_file_signature_fn": input_file_signature_fn} if input_file_signature_fn else {}),
     )
 
 

--- a/src/openbench/runner/preprocessing.py
+++ b/src/openbench/runner/preprocessing.py
@@ -7,6 +7,7 @@ import os
 import shutil
 from typing import Any
 
+from openbench.runner.progress_events import emit_gui_preprocessing_completion, emit_gui_preprocessing_started
 from openbench.util.netcdf import write_file_atomic
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,7 @@ def preprocess_variable(
     #   - sim_source string: stn-involved prep writes a per-pair output
     #     dir (stn_<ref>_<sim>) and deletes the flat NC; cannot be shared
     preproc_done: set[tuple[str, str]] = set()
+    sim_preproc_done: set[tuple[str, str]] = set()
     # Track first-time-seen per ref_source for unified_mask accumulation
     # For stn×stn symlink optimization: first stn dir per ref_source
     ref_stn_data_dirs: dict[str, str] = {}
@@ -131,6 +133,7 @@ def preprocess_variable(
                 continue
             ref_source = task["ref_source"]
             sim_source = task["sim_source"]
+            emit_gui_preprocessing_started(task)
             try:
                 info = build_bridge_runtime_info_fn(task)
                 ref_dtype = info.get("ref_data_type", "grid")
@@ -205,24 +208,29 @@ def preprocess_variable(
                                 src = os.path.abspath(os.path.join(src_data_dir, ref_file))
                                 dst = os.path.join(this_data_dir, ref_file)
                                 if not os.path.exists(dst):
-                                    os.symlink(src, dst)
+                                    clone_or_link_ref_for_pair_fn(src, dst)
                 elif not is_stn_path:
                     _restore_flat_ref_if_missing(ref_source)
 
-                # Sim: each task
-                logger.info("Preprocessing sim: %s (%s)", var_name, sim_source)
-                if sim_dtype != "stn":
-                    sim_varname = info.get("sim_varname", "")
-                    sim_flat_paths[sim_source] = os.path.join(
-                        info["casedir"],
-                        "data",
-                        f"{var_name}_sim_{sim_source}_{sim_varname}.nc",
-                    )
-                    if is_stn_path:
+                # Pure grid simulation preprocessing is independent of the
+                # reference source and writes the same flat NC. Station-involved
+                # paths remain pair-specific because they write stn_<ref>_<sim>.
+                sim_prep_key = (sim_source, sim_source if not is_stn_path else ref_source)
+                if sim_prep_key not in sim_preproc_done:
+                    logger.info("Preprocessing sim: %s (%s)", var_name, sim_source)
+                    if sim_dtype != "stn":
+                        sim_varname = info.get("sim_varname", "")
+                        sim_flat_paths[sim_source] = os.path.join(
+                            info["casedir"],
+                            "data",
+                            f"{var_name}_sim_{sim_source}_{sim_varname}.nc",
+                        )
+                        if is_stn_path:
+                            _backup_flat_sim(sim_source)
+                    processor.prepare_source("sim")
+                    sim_preproc_done.add(sim_prep_key)
+                    if sim_dtype != "stn" and not is_stn_path:
                         _backup_flat_sim(sim_source)
-                processor.prepare_source("sim")
-                if sim_dtype != "stn" and not is_stn_path:
-                    _backup_flat_sim(sim_source)
 
                 # Unified mask: ensure evaluation only covers cells where both ref and sim are valid.
                 if unified_mask:
@@ -288,6 +296,8 @@ def preprocess_variable(
                     )
                 else:
                     logger.exception("Preprocessing failed: %s (sim=%s, ref=%s)", var_name, sim_source, ref_source)
+            else:
+                emit_gui_preprocessing_completion(task)
 
         # End-of-loop flat-NC restoration:
         # If a ref had any stn-involved prep AND any grid×grid task in this

--- a/src/openbench/runner/progress_events.py
+++ b/src/openbench/runner/progress_events.py
@@ -6,17 +6,46 @@ import os
 GUI_PROGRESS_PREFIX = "OPENBENCH_PROGRESS "
 
 
-def emit_gui_task_completion(result: dict) -> None:
-    if os.environ.get("OPENBENCH_GUI_PROGRESS") != "1" or result.get("status") not in {"success", "skipped"}:
+def _emit_gui_event(event: str, *, variable: str, sim: str, ref: str) -> None:
+    if os.environ.get("OPENBENCH_GUI_PROGRESS") != "1":
         return
     payload = json.dumps(
         {
-            "event": "evaluation_completed",
-            "variable": result["variable"],
-            "sim": result["sim"],
-            "ref": result["ref"],
+            "event": event,
+            "variable": variable,
+            "sim": sim,
+            "ref": ref,
         },
         ensure_ascii=False,
         separators=(",", ":"),
     )
     print(f"{GUI_PROGRESS_PREFIX}{payload}", flush=True)
+
+
+def emit_gui_task_completion(result: dict) -> None:
+    if result.get("status") not in {"success", "skipped"}:
+        return
+    _emit_gui_event(
+        "evaluation_completed",
+        variable=result["variable"],
+        sim=result["sim"],
+        ref=result["ref"],
+    )
+
+
+def emit_gui_preprocessing_completion(task: dict) -> None:
+    _emit_gui_event(
+        "preprocessing_completed",
+        variable=task["var_name"],
+        sim=task["sim_source"],
+        ref=task["ref_source"],
+    )
+
+
+def emit_gui_preprocessing_started(task: dict) -> None:
+    _emit_gui_event(
+        "preprocessing_started",
+        variable=task["var_name"],
+        sim=task["sim_source"],
+        ref=task["ref_source"],
+    )

--- a/tests/test_audit_bugfixes.py
+++ b/tests/test_audit_bugfixes.py
@@ -584,8 +584,9 @@ def test_selection_ref_fallbacks_and_upper_nc4(tmp_path, monkeypatch):
 
     path = tmp_path / "ALT_2000.NC4"
     (
-        xr.Dataset({"Q": ("time", np.array([1.0]))}, coords={"time": pd.date_range("2000-01-01", periods=1)})
-        .to_netcdf(path)
+        xr.Dataset({"Q": ("time", np.array([1.0]))}, coords={"time": pd.date_range("2000-01-01", periods=1)}).to_netcdf(
+            path
+        )
     )
     dummy = Dummy()
 

--- a/tests/test_cli_sim_scan.py
+++ b/tests/test_cli_sim_scan.py
@@ -762,6 +762,7 @@ def test_replace_directory_preserving_old_on_failure_restores_existing_output(tm
     monkeypatch.setattr(sim_module.os, "replace", flaky_replace)
 
     import pytest
+
     with pytest.raises(OSError):
         sim_module._replace_directory_preserving_old_on_failure(source, target)
 

--- a/tests/test_cli_sim_scan.py
+++ b/tests/test_cli_sim_scan.py
@@ -739,3 +739,32 @@ def test_rebase_station_artifacts_updates_fulllist_and_case_paths(tmp_path):
 
     assert case.merged_dir == new_root / "CaseA" / "merged"
     assert str(new_root / "CaseA" / "merged" / "S1.nc") in case.fulllist.read_text(encoding="utf-8")
+
+
+def test_replace_directory_preserving_old_on_failure_restores_existing_output(tmp_path, monkeypatch):
+    import openbench.cli.sim as sim_module
+
+    source = tmp_path / "new"
+    target = tmp_path / "station_output"
+    source.mkdir()
+    target.mkdir()
+    (source / "new.txt").write_text("new", encoding="utf-8")
+    (target / "old.txt").write_text("old", encoding="utf-8")
+    real_replace = sim_module.os.replace
+    calls = {"count": 0}
+
+    def flaky_replace(src, dst):
+        if Path(src) == source and Path(dst) == target:
+            calls["count"] += 1
+            raise OSError("disk full")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(sim_module.os, "replace", flaky_replace)
+
+    import pytest
+    with pytest.raises(OSError):
+        sim_module._replace_directory_preserving_old_on_failure(source, target)
+
+    assert (target / "old.txt").read_text(encoding="utf-8") == "old"
+    assert source.exists()
+    assert calls["count"] == 1

--- a/tests/test_config/test_adapter.py
+++ b/tests/test_config/test_adapter.py
@@ -1000,7 +1000,6 @@ def test_find_nc_dir_does_not_substitute_lowres(tmp_path):
     assert adapter_module._find_nc_dir(str(mid), str(tmp_path / "Grid" / "MidRes"), "Water/Runoff/Demo") == str(mid)
 
 
-
 def test_adapter_reference_data_root_still_overrides_catalog_root(monkeypatch):
     from openbench.data.registry.schema import ReferenceDataset, VariableMapping
 
@@ -1045,3 +1044,34 @@ def test_adapter_rejects_programmatic_unsafe_labels():
 
     with pytest.raises(ConfigError, match="path-safe"):
         adapter_module.build_runner_config(cfg)
+
+
+def test_build_namelists_preserves_inline_sim_variable_runtime_fields():
+    cfg = OpenBenchConfig(
+        project=ProjectConfig(name="case", output_dir="./out", years=[2000, 2000]),
+        evaluation=EvaluationConfig(variables=["Runoff"]),
+        reference=ReferenceConfig(sources={"Runoff": "GRDC"}),
+        simulation={
+            "CaseA": SimulationEntry(
+                model="UnknownModel",
+                root_dir="/sim",
+                variables={
+                    "Runoff": {
+                        "varname": "q",
+                        "sub_dir": "hydro",
+                        "compute": "ds['rain'] + ds['snow']",
+                        "fallbacks": [{"varname": "q_alt", "varunit": "mm"}],
+                        "prefix_fallback": ["_hydro_"],
+                    }
+                },
+            )
+        },
+    )
+
+    _, _, sim_nml = adapter_module.build_legacy_namelists(cfg)
+    section = sim_nml["Runoff"]
+
+    assert section["CaseA_dir"].replace("\\", "/") == "/sim/hydro"
+    assert section["CaseA_compute"] == "ds['rain'] + ds['snow']"
+    assert section["CaseA_fallbacks"] == [{"varname": "q_alt", "varunit": "mm"}]
+    assert section["CaseA_prefix_fallback"] == ["_hydro_"]

--- a/tests/test_config/test_loader.py
+++ b/tests/test_config/test_loader.py
@@ -712,7 +712,6 @@ def test_simulation_defaults_must_be_mapping():
         _build_config(raw)
 
 
-
 def test_reference_rejects_duplicate_sources(tmp_path):
     cfg = tmp_path / "openbench.yaml"
     cfg.write_text(

--- a/tests/test_gui_config_manager.py
+++ b/tests/test_gui_config_manager.py
@@ -599,3 +599,41 @@ def test_generate_config_yaml_can_export_groupby_without_comparison(tmp_path):
     assert data["project"]["IGBP_groupby"] is True
     assert "PFT_groupby" not in data["project"]
     assert "climate_zone_groupby" not in data["project"]
+
+def test_unified_to_gui_deep_merges_simulation_variable_defaults():
+    unified = {
+        "project": {"name": "demo"},
+        "evaluation": {"variables": ["Runoff"]},
+        "reference": {"Runoff": "RefA"},
+        "simulation": {
+            "_defaults": {
+                "model": "CoLM2024",
+                "variables": {"Runoff": {"varunit": "mm day-1", "prefix": "hist_"}},
+            },
+            "CaseA": {"root_dir": "/sim/a", "variables": {"Runoff": {"varname": "q"}}},
+        },
+    }
+
+    gui_config = ConfigManager().unified_to_gui_config(unified)
+
+    assert gui_config["sim_data"]["source_configs"]["CaseA"]["variables"]["Runoff"] == {
+        "varname": "q",
+        "varunit": "mm day-1",
+        "prefix": "hist_",
+    }
+
+
+def test_generate_config_yaml_preserves_explicit_simulation_source_labels():
+    config = _runnable_config(Path("/tmp"))
+    config["evaluation_items"] = {"Runoff": True}
+    config["sim_data"] = {
+        "general": {"Runoff_sim_source": ["RunA", "RunB"]},
+        "source_configs": {
+            "RunA": {"general": {"model_namelist": "CoLM2024", "root_dir": "/x/Case01/a"}},
+            "RunB": {"general": {"model_namelist": "CoLM2024", "root_dir": "/x/Case01/b"}},
+        },
+    }
+
+    data = yaml.safe_load(ConfigManager().generate_config_yaml(config))
+
+    assert {k for k in data["simulation"] if k != "_defaults"} == {"RunA", "RunB"}

--- a/tests/test_gui_config_manager.py
+++ b/tests/test_gui_config_manager.py
@@ -600,6 +600,7 @@ def test_generate_config_yaml_can_export_groupby_without_comparison(tmp_path):
     assert "PFT_groupby" not in data["project"]
     assert "climate_zone_groupby" not in data["project"]
 
+
 def test_unified_to_gui_deep_merges_simulation_variable_defaults():
     unified = {
         "project": {"name": "demo"},

--- a/tests/test_gui_page_preview_remote.py
+++ b/tests/test_gui_page_preview_remote.py
@@ -481,3 +481,13 @@ def test_remote_export_marks_direct_sftp_uploads_synced_in_remote_storage_cache(
     assert sync.get_sync_status("output/demo/nml/main-demo.yaml") is SyncStatus.SYNCED
     assert sync.read("output/demo/openbench.yaml") == "new config"
     assert sync.read("output/demo/nml/main-demo.yaml") == "new main"
+
+
+def test_resolve_path_for_remote_rejects_windows_local_data_path():
+    preview = _preview()
+
+    with pytest.raises(RemoteNamelistSyncError, match="Windows local path cannot be converted"):
+        preview._resolve_path_for_remote("C:/Users/me/sim/CaseA", "/remote/openbench")
+
+    with pytest.raises(RemoteNamelistSyncError, match="Windows local path cannot be converted"):
+        preview._resolve_path_for_remote(r"\\server\share\sim\CaseA", "/remote/openbench")

--- a/tests/test_gui_sim_data.py
+++ b/tests/test_gui_sim_data.py
@@ -142,3 +142,78 @@ def test_local_gui_sim_scan_runs_off_gui_thread(qapp, monkeypatch, tmp_path):
     page_sim_data.PageSimData._do_scan_flow(page)
 
     assert ran_on_gui_thread == [False]
+
+
+def test_remote_sim_scan_helpers_find_uppercase_nc4():
+    class FakeSSH:
+        def execute(self, command, timeout=30):
+            if "test -d" in command:
+                return "dir\n", "", 0
+            if "history" in command:
+                return "/remote/Case/history/HIST_2000.NC4\n", "", 0
+            return "", "", 0
+
+    assert page_sim_data._remote_find_nc_dir(FakeSSH(), "/remote/Case") == "/remote/Case/history"
+    assert page_sim_data._remote_detect_prefix(FakeSSH(), "/remote/Case") == "HIST_"
+
+
+def test_remote_sim_scan_helpers_raise_find_errors():
+    class FakeSSH:
+        def execute(self, command, timeout=30):
+            return "", "permission denied", 1
+
+    try:
+        page_sim_data._remote_list_nc_files(FakeSSH(), "/remote/private")
+    except RuntimeError as exc:
+        assert "permission denied" in str(exc)
+    else:
+        raise AssertionError("expected remote find failure to raise")
+
+
+def test_validate_data_requires_local_netcdf_files(monkeypatch, tmp_path):
+    warnings = []
+    monkeypatch.setattr(page_sim_data.QMessageBox, "warning", lambda *args: warnings.append(args))
+    page = SimpleNamespace(
+        controller=SimpleNamespace(storage=object()),
+        get_selected_cases=lambda: [{"label": "CaseA", "nc_dir": str(tmp_path), "model": "CoLM2024"}],
+    )
+
+    page_sim_data.PageSimData._validate_data(page)
+
+    assert "no NetCDF files found" in warnings[0][2]
+
+
+def test_save_to_config_only_assigns_variables_to_supporting_cases(monkeypatch):
+    controller = _Controller()
+    controller.config["evaluation_items"] = {"Runoff": True, "Latent_Heat": True}
+    monkeypatch.setattr(
+        page_sim_data,
+        "_get_model_variables",
+        lambda model: ["Runoff"] if model == "RunoffModel" else [],
+    )
+    page = SimpleNamespace(
+        controller=controller,
+        get_selected_cases=lambda: [
+            {"label": "RunoffCase", "model": "RunoffModel", "nc_dir": "/sim/r", "prefix": "", "variables": {}},
+            {
+                "label": "ManualHeatCase",
+                "model": "UnknownModel",
+                "nc_dir": "/sim/h",
+                "prefix": "",
+                "variables": {"Latent_Heat": {"varname": "lh"}},
+            },
+        ],
+        _prefix_input=_Text(""),
+        _data_type_combo=_Text("grid"),
+        _grid_res_input=_Text("0.5"),
+        _tim_res_combo=_Text("Month"),
+        _data_groupby_combo=_Text("Year"),
+        _suffix_input=_Text(".nc"),
+        _root_input=_Text("/sim"),
+    )
+
+    page_sim_data.PageSimData.save_to_config(page)
+
+    general = controller.updated[1]["general"]
+    assert general["Runoff_sim_source"] == ["RunoffCase"]
+    assert general["Latent_Heat_sim_source"] == ["ManualHeatCase"]

--- a/tests/test_processing_registry_cache.py
+++ b/tests/test_processing_registry_cache.py
@@ -456,3 +456,134 @@ def test_remap_data_fails_configured_backend_instead_of_falling_back():
     data = xr.Dataset({"v": (("lat", "lon"), np.array([[1.0]]))}, coords={"lat": [0.0], "lon": [0.0]})
     with pytest.raises(RuntimeError, match="Configured regrid backend 'cdo_remapcon' failed"):
         processing.GridDatasetProcessing.remap_data(processor, data)
+
+
+def test_find_data_files_finds_scanner_nested_date_dirs(tmp_path):
+    import openbench.data.processing as processing
+
+    nested = tmp_path / "2000" / "01"
+    nested.mkdir(parents=True)
+    path = nested / "Case_200001.nc"
+    xr.Dataset({"runoff": xr.DataArray(np.array([1.0]))}).to_netcdf(path)
+
+    processor = _make_processor(processing)
+    processor.SimA_prefix_fallback = None
+
+    result = processing.BaseDatasetProcessing._find_data_files(
+        processor,
+        str(tmp_path),
+        prefix="Case_",
+        year=2000,
+        suffix="",
+        datasource="sim",
+        varname=["runoff"],
+    )
+
+    assert result == [str(path)]
+
+
+def test_try_compute_from_inline_namelist_wins_over_catalog(monkeypatch):
+    import openbench.data.processing as processing
+    import openbench.data.registry.manager as registry_manager
+
+    processor = _make_processor(processing)
+    processor.sim_compute = "ds['rain'] + ds['snow']"
+    processor.sim_varunit = "mm d-1"
+    ds = xr.Dataset({"rain": ("time", [1.0]), "snow": ("time", [2.0])})
+    monkeypatch.setattr(registry_manager, "get_registry", lambda: _FakeRegistry(ModelProfile("Nope", "", {})))
+
+    result = processing.BaseDatasetProcessing._try_compute_from_profile(processor, "ModelA", ds, "sim")
+
+    assert float(result.values[0]) == 3.0
+    assert processor.sim_varunit == "mm d-1"
+
+
+def test_find_data_files_falls_back_to_compute_dependency_files(tmp_path):
+    import openbench.data.processing as processing
+
+    times = pd.date_range("2000-01-01", periods=1)
+    xr.Dataset({"rain": xr.DataArray([1.0], coords={"time": times})}).to_netcdf(tmp_path / "case_h0.RAIN.2000.nc")
+    xr.Dataset({"snow": xr.DataArray([2.0], coords={"time": times})}).to_netcdf(tmp_path / "case_h0.SNOW.2000.nc")
+
+    processor = _make_processor(processing)
+    processor.sim_compute = "ds['rain'] + ds['snow']"
+    processor.SimA_prefix_fallback = None
+
+    result = processing.BaseDatasetProcessing._find_data_files(
+        processor,
+        str(tmp_path),
+        prefix="",
+        year=2000,
+        suffix="",
+        datasource="sim",
+        varname=["Runoff"],
+    )
+
+    assert {Path(path).name for path in result} == {"case_h0.RAIN.2000.nc", "case_h0.SNOW.2000.nc"}
+
+
+def test_select_var_computes_from_dependency_files_found_by_lookup(tmp_path):
+    import openbench.data.processing as processing
+
+    times = pd.date_range("2000-01-01", periods=1)
+    rain = tmp_path / "case_h0.RAIN.2000.nc"
+    snow = tmp_path / "case_h0.SNOW.2000.nc"
+    xr.Dataset({"rain": xr.DataArray([1.0], coords={"time": times})}).to_netcdf(rain)
+    xr.Dataset({"snow": xr.DataArray([2.0], coords={"time": times})}).to_netcdf(snow)
+
+    processor = _make_processor(processing)
+    processor.sim_compute = "ds['rain'] + ds['snow']"
+    processor.sim_data_type = "grid"
+    processor.ref_data_type = "grid"
+    processor.sim_tim_res = "Day"
+    processor.compare_tim_res = "Day"
+    files = processing.BaseDatasetProcessing._find_data_files(processor, str(tmp_path), "", 2000, "", "sim", ["Runoff"])
+
+    result = processing.BaseDatasetProcessing.select_var(processor, 2000, 2000, "Day", files, ["Runoff"], "sim")
+
+    assert result.name == "Runoff"
+    assert float(result.values[0]) == 3.0
+
+
+def test_find_single_file_returns_all_undated_compute_dependencies(tmp_path):
+    import openbench.data.processing as processing
+
+    xr.Dataset({"rain": ("time", [1.0])}).to_netcdf(tmp_path / "RAIN.nc")
+    xr.Dataset({"snow": ("time", [2.0])}).to_netcdf(tmp_path / "SNOW.nc")
+    processor = _make_processor(processing)
+    processor.sim_compute = "ds['rain'] + ds['snow']"
+    processor.SimA_prefix_fallback = None
+
+    result = processing.BaseDatasetProcessing._find_single_file(
+        processor,
+        str(tmp_path),
+        prefix="",
+        suffix="",
+        datasource="sim",
+        varname=["Runoff"],
+    )
+
+    assert {Path(path).name for path in result} == {"RAIN.nc", "SNOW.nc"}
+
+
+def test_find_data_files_supports_undated_files_in_month_directories(tmp_path):
+    import openbench.data.processing as processing
+
+    for month in ("2000-01", "2000-02"):
+        directory = tmp_path / month
+        directory.mkdir()
+        xr.Dataset({"QFLX_EVAP_TOT": ("time", [1.0])}).to_netcdf(directory / "QFLX_EVAP_TOT.nc")
+    processor = _make_processor(processing)
+    processor.SimA_prefix_fallback = None
+
+    result = processing.BaseDatasetProcessing._find_data_files(
+        processor,
+        str(tmp_path),
+        prefix="QFLX_EVAP_TOT",
+        year=2000,
+        suffix="",
+        datasource="sim",
+        varname=["QFLX_EVAP_TOT"],
+    )
+
+    assert {Path(path).parent.name for path in result} == {"2000-01", "2000-02"}

--- a/tests/test_progress_parser.py
+++ b/tests/test_progress_parser.py
@@ -7,6 +7,8 @@ def _state(**overrides):
         "current_variable": "",
         "current_ref": "",
         "current_sim": "",
+        "started_preprocess_tasks": set(),
+        "completed_preprocess_tasks": set(),
         "completed_eval_tasks": set(),
         "completed_groupby_tasks": set(),
         "completed_comparison_tasks": set(),
@@ -71,6 +73,37 @@ def test_progress_parser_counts_structured_completed_evaluation_line():
     assert var == "Latent_Heat"
     assert stage == "Evaluation"
     assert ("Latent_Heat", "GLEAM_v4.2a", "CoLM2024") in state["completed_eval_tasks"]
+
+
+def test_progress_parser_advances_during_structured_preprocessing():
+    state = _state(total_tasks=2)
+
+    progress, variable, stage = parse_progress_line(
+        'OPENBENCH_PROGRESS {"event":"preprocessing_completed","variable":"Runoff","sim":"SimA","ref":"RefA"}',
+        5,
+        state,
+        CONSTANTS,
+    )
+
+    assert progress > 5
+    assert variable == "Runoff"
+    assert stage == "Preprocessing"
+    assert ("Runoff", "RefA", "SimA") in state["completed_preprocess_tasks"]
+
+
+def test_progress_parser_leaves_five_percent_when_preprocessing_starts():
+    state = _state(total_tasks=2)
+
+    progress, variable, stage = parse_progress_line(
+        'OPENBENCH_PROGRESS {"event":"preprocessing_started","variable":"Runoff","sim":"SimA","ref":"RefA"}',
+        5,
+        state,
+        CONSTANTS,
+    )
+
+    assert progress > 5
+    assert variable == "Runoff"
+    assert stage == "Preprocessing"
 
 
 def test_progress_parser_advances_report_stage_without_backtracking():

--- a/tests/test_runner/test_cache.py
+++ b/tests/test_runner/test_cache.py
@@ -140,6 +140,22 @@ def test_input_file_signature_includes_ctime_ns(tmp_path):
     assert "ctime_ns" in signature["files"][0]
 
 
+def test_input_file_signature_refreshes_after_input_changes(tmp_path):
+    from openbench.runner.hashing import input_file_signature
+
+    source_root = tmp_path / "input"
+    source_root.mkdir()
+    data_file = source_root / "sample.nc"
+    data_file.write_bytes(b"first")
+    section = {"Case_dir": str(source_root)}
+
+    first = input_file_signature(section, "Case")
+    data_file.write_bytes(b"second-version")
+    refreshed = input_file_signature(section, "Case")
+
+    assert refreshed != first
+
+
 def test_algorithm_source_fingerprint_tracks_runner_processing_and_comparisons():
     from openbench.runner.hashing import ALGORITHM_SOURCE_MODULES
 

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -5865,9 +5865,88 @@ def test_preprocess_runs_for_each_ref_source(tmp_path, monkeypatch):
     assert len([c for c in prepare_calls if c[0] == "ref" and c[1] == "RefA"]) == 1
     assert len([c for c in prepare_calls if c[0] == "ref" and c[1] == "RefB"]) == 1
 
-    # Sim should be preprocessed for every (sim, ref) task: 4 calls
+    # Pure grid simulation preprocessing is independent of the reference and
+    # should run once per simulation source.
     sim_calls = [c for c in prepare_calls if c[0] == "sim"]
-    assert len(sim_calls) == 4, f"expected 4 sim preprocess calls (2 sim × 2 ref), got {len(sim_calls)}"
+    assert len(sim_calls) == 2, f"expected one sim preprocess per source, got {len(sim_calls)}"
+
+
+def test_preprocessing_emits_gui_progress_marker(monkeypatch, capsys):
+    import openbench.data.processing as processing
+    import openbench.runner.local as local_runner
+
+    monkeypatch.setenv("OPENBENCH_GUI_PROGRESS", "1")
+    monkeypatch.setattr(
+        local_runner,
+        "_build_bridge_runtime_info",
+        lambda task: {
+            "casedir": "/tmp/case",
+            "ref_varname": "ref",
+            "sim_varname": "sim",
+            "ref_data_type": "grid",
+            "sim_data_type": "grid",
+            "ref_source": task["ref_source"],
+            "sim_source": task["sim_source"],
+        },
+    )
+
+    class Processor:
+        def __init__(self, info):
+            pass
+
+        def prepare_source(self, datasource):
+            pass
+
+    monkeypatch.setattr(processing, "DatasetProcessing", Processor)
+    task = {"var_name": "Runoff", "sim_source": "SimA", "ref_source": "RefA"}
+
+    local_runner._preprocess_variable_tasks(
+        "Runoff",
+        [task],
+        unified_mask=False,
+        time_alignment="intersection",
+    )
+
+    output = capsys.readouterr().out
+    assert 'OPENBENCH_PROGRESS {"event":"preprocessing_started"' in output
+    assert 'OPENBENCH_PROGRESS {"event":"preprocessing_completed"' in output
+
+
+def test_failed_preprocessing_does_not_emit_completion_marker(monkeypatch, capsys):
+    import openbench.data.processing as processing
+    import openbench.runner.local as local_runner
+
+    monkeypatch.setenv("OPENBENCH_GUI_PROGRESS", "1")
+    monkeypatch.setattr(
+        local_runner,
+        "_build_bridge_runtime_info",
+        lambda task: {
+            "casedir": "/tmp/case",
+            "ref_data_type": "grid",
+            "sim_data_type": "grid",
+            "ref_source": task["ref_source"],
+            "sim_source": task["sim_source"],
+        },
+    )
+
+    class Processor:
+        def __init__(self, info):
+            pass
+
+        def prepare_source(self, datasource):
+            raise ValueError("bad source")
+
+    monkeypatch.setattr(processing, "DatasetProcessing", Processor)
+    task = {"var_name": "Runoff", "sim_source": "SimA", "ref_source": "RefA"}
+
+    errors = local_runner._preprocess_variable_tasks(
+        "Runoff", [task], unified_mask=False, time_alignment="intersection"
+    )
+
+    output = capsys.readouterr().out
+    assert errors
+    assert 'OPENBENCH_PROGRESS {"event":"preprocessing_started"' in output
+    assert '"event":"preprocessing_completed"' not in output
 
 
 def test_preprocess_mixed_grid_and_stn_sims_with_same_grid_ref(tmp_path, monkeypatch):

--- a/tests/test_sim_scanner.py
+++ b/tests/test_sim_scanner.py
@@ -267,6 +267,9 @@ def test_materialize_station_cases_keeps_unicode_case_labels_distinct(tmp_path: 
     assert case_a.fulllist != case_b.fulllist
     assert case_a.fulllist.exists()
     assert case_b.fulllist.exists()
+    station_path = pd.read_csv(case_a.fulllist).loc[0, "sim_dir"]
+    assert Path(station_path).is_absolute()
+    assert "OPENBENCH_SIM_ROOT" not in station_path
 
 
 def test_scan_simulation_roots_infers_flat_station_tim_res_per_station_not_across_sites(tmp_path: Path):
@@ -801,3 +804,82 @@ def test_scan_simulation_roots_auto_model_prefers_strong_variable_match_over_gen
     case = result.cases[0]
     assert case.model == "CoLM2024"
     assert case.provenance["model"] == "variables"
+
+
+def test_runtime_expands_portable_station_sim_dir_env_vars(tmp_path: Path, monkeypatch):
+    from openbench.config.runtime_info import GeneralInfoReader
+
+    root = tmp_path / "simroot"
+    data = pd.DataFrame({"sim_dir": ["${OPENBENCH_SIM_ROOT}/CaseA/site.nc"]})
+    monkeypatch.setenv("OPENBENCH_SIM_ROOT", str(root))
+
+    GeneralInfoReader._resolve_relative_paths(data, "sim_dir", str(tmp_path / "stations.csv"))
+
+    assert data.loc[0, "sim_dir"].replace("\\", "/") == str(root / "CaseA" / "site.nc").replace("\\", "/")
+
+
+def test_scan_simulation_roots_keeps_month_date_subdirs_as_one_runnable_case(tmp_path: Path):
+    from openbench.data.sim_scanner import scan_simulation_roots
+
+    case_root = tmp_path / "simulations" / "CaseA"
+    _write_grid_nc(case_root / "2000-01" / "QFLX_EVAP_TOT.nc", periods=1)
+    _write_grid_nc(case_root / "2000-02" / "QFLX_EVAP_TOT.nc", periods=1, start="2000-02-01")
+
+    result = scan_simulation_roots([tmp_path / "simulations"], model_name="CoLM2024")
+
+    assert len(result.cases) == 1
+    assert result.cases[0].root_dir == case_root
+    assert result.cases[0].data_groupby == "Month"
+
+
+def test_sim_scanner_accepts_360_day_calendar_dates():
+    import cftime
+
+    from openbench.data.sim_scanner import _datetime_values_from_time_values
+
+    values = _datetime_values_from_time_values(np.array([cftime.Datetime360Day(2000, 2, 30)], dtype=object))
+
+    assert values == [pd.Timestamp("2000-02-29").to_pydatetime()]
+
+
+def test_scan_simulation_roots_collects_more_than_eight_variable_buckets(tmp_path: Path):
+    from openbench.data.sim_scanner import scan_simulation_roots
+
+    history = tmp_path / "simulations" / "CaseA" / "history"
+    for index in range(9):
+        _write_grid_nc(history / f"var{index}_2000.nc", var_name=f"var{index}")
+
+    result = scan_simulation_roots([tmp_path / "simulations"], model_name="auto")
+
+    assert set(result.cases[0].variables) >= {f"var{index}" for index in range(9)}
+
+
+def test_compute_variable_spanning_file_patterns_clears_single_dependency_prefix(tmp_path: Path):
+    from openbench.data.sim_scanner import scan_simulation_roots
+
+    history = tmp_path / "simulations" / "CaseA" / "history"
+    _write_grid_nc(history / "case_h0.FSR.2000.nc", var_name="FSR")
+    _write_grid_nc(history / "case_h0.FSDS.2000.nc", var_name="FSDS")
+
+    result = scan_simulation_roots([tmp_path / "simulations"], model_name="CoLM2024")
+
+    assert result.cases[0].variable_overrides["Surface_Albedo"] == {"prefix": "", "suffix": ""}
+
+
+def test_station_scanner_accepts_uppercase_nc4_and_noleap_time(tmp_path: Path):
+    from openbench.data.station_scanner import scan_station_sim_dir
+
+    path = tmp_path / "stations" / "US-AAA.NC4"
+    path.parent.mkdir(parents=True)
+    ds = xr.Dataset(
+        {"QFLX_EVAP_TOT": (["time"], np.zeros(2))},
+        coords={"time": np.array([0, 365]), "lon": -100.0, "lat": 40.0},
+    )
+    ds["time"].attrs["units"] = "days since 2000-01-01 00:00:00"
+    ds["time"].attrs["calendar"] = "noleap"
+    ds.to_netcdf(path)
+
+    df = scan_station_sim_dir(str(path.parent))
+
+    assert df.loc[0, "ID"] == "US-AAA"
+    assert (df.loc[0, "use_syear"], df.loc[0, "use_eyear"]) == (2000, 2001)

--- a/tests/test_station_matcher.py
+++ b/tests/test_station_matcher.py
@@ -314,3 +314,10 @@ def test_station_matching_jobs_default_is_conservative(monkeypatch):
     assert _station_matching_jobs(100) == 4
     assert _station_matching_jobs(2) == 2
     assert _station_matching_jobs(100, requested=8) == 8
+
+
+def test_cama_resolution_rejects_unknown_resolution():
+    from openbench.data.station_matcher import get_resolution_suffix
+
+    with pytest.raises(ValueError, match="Unsupported CaMA"):
+        get_resolution_suffix(0.07)

--- a/tests/test_station_scanner.py
+++ b/tests/test_station_scanner.py
@@ -545,9 +545,9 @@ def test_setup_output_directories_reuses_already_merged_station_fulllist(tmp_pat
     from openbench.data.processing import BaseDatasetProcessing
 
     combined = tmp_path / "combined.csv"
-    pd.DataFrame(
-        [{"ID": "A", "sim_dir": "sim.nc", "ref_dir": "ref.nc", "use_syear": 2002, "use_eyear": 2004}]
-    ).to_csv(combined, index=False)
+    pd.DataFrame([{"ID": "A", "sim_dir": "sim.nc", "ref_dir": "ref.nc", "use_syear": 2002, "use_eyear": 2004}]).to_csv(
+        combined, index=False
+    )
 
     proc = BaseDatasetProcessing.__new__(BaseDatasetProcessing)
     proc.ref_data_type = proc.sim_data_type = "stn"

--- a/tests/test_station_scanner.py
+++ b/tests/test_station_scanner.py
@@ -504,3 +504,122 @@ def test_nested_multi_station_rescan_rebuilds_stale_merged_year_range(tmp_path: 
     assert second.loc[0, "use_syear"] == 2000
     assert second.loc[0, "use_eyear"] == 2001
     assert Path(second.loc[0, "sim_dir"]).name == "sim_US-AAA_2000_2001.nc"
+
+
+def test_setup_output_directories_merges_ref_and_sim_fulllists_for_station_pairs(tmp_path):
+    from openbench.data.processing import BaseDatasetProcessing
+
+    sim_file = tmp_path / "sim.nc"
+    ref_file = tmp_path / "ref.nc"
+    sim_file.touch()
+    ref_file.touch()
+    sim_list = tmp_path / "sim.csv"
+    ref_list = tmp_path / "ref.csv"
+    pd.DataFrame(
+        [{"ID": "A", "sim_dir": sim_file.name, "sim_lon": 1, "sim_lat": 2, "use_syear": 2000, "use_eyear": 2005}]
+    ).to_csv(sim_list, index=False)
+    pd.DataFrame(
+        [{"ID": "A", "ref_dir": str(ref_file), "ref_lon": 1, "ref_lat": 2, "use_syear": 2002, "use_eyear": 2004}]
+    ).to_csv(ref_list, index=False)
+
+    proc = BaseDatasetProcessing.__new__(BaseDatasetProcessing)
+    proc.ref_data_type = "stn"
+    proc.sim_data_type = "stn"
+    proc.ref_source = "Ref"
+    proc.sim_source = "Sim"
+    proc.ref_fulllist = str(ref_list)
+    proc.sim_fulllist = str(sim_list)
+    proc.casedir = str(tmp_path / "case")
+
+    proc.setup_output_directories()
+
+    row = proc.station_list.iloc[0]
+    assert row["ID"] == "A"
+    assert row["sim_dir"] == str(sim_file)
+    assert row["ref_dir"] == str(ref_file)
+    assert int(row["use_syear"]) == 2002
+    assert int(row["use_eyear"]) == 2004
+
+
+def test_setup_output_directories_reuses_already_merged_station_fulllist(tmp_path):
+    from openbench.data.processing import BaseDatasetProcessing
+
+    combined = tmp_path / "combined.csv"
+    pd.DataFrame(
+        [{"ID": "A", "sim_dir": "sim.nc", "ref_dir": "ref.nc", "use_syear": 2002, "use_eyear": 2004}]
+    ).to_csv(combined, index=False)
+
+    proc = BaseDatasetProcessing.__new__(BaseDatasetProcessing)
+    proc.ref_data_type = proc.sim_data_type = "stn"
+    proc.ref_source, proc.sim_source = "Ref", "Sim"
+    proc.ref_fulllist = str(combined)
+    proc.sim_fulllist = str(tmp_path / "original_sim.csv")
+    proc.casedir = str(tmp_path / "case")
+
+    proc.setup_output_directories()
+
+    assert list(proc.station_list.columns) == ["ID", "sim_dir", "ref_dir", "use_syear", "use_eyear"]
+
+
+def test_process_station_data_hard_fails_partial_station_failures(tmp_path):
+    from openbench.data.processing import StationDatasetProcessing
+
+    proc = StationDatasetProcessing.__new__(StationDatasetProcessing)
+    proc.num_cores = 1
+    proc.station_list = pd.DataFrame(
+        {"ID": ["A", "B"], "use_syear": [2000, 2000], "use_eyear": [2000, 2000], "sim_dir": ["a.nc", "b.nc"]}
+    )
+    proc._make_stn_parallel = lambda station_list, datasource, i: {"ok": i == 0, "station": station_list.iloc[i]["ID"]}
+
+    with pytest.raises(RuntimeError, match="1/2 sim station"):
+        StationDatasetProcessing.process_station_data(proc, {"datasource": "sim"})
+
+
+def test_station_evaluation_hard_fails_when_any_station_skips(tmp_path, monkeypatch):
+    import openbench.core.evaluation as evaluation
+    from openbench.core.evaluation import Evaluation_stn
+
+    stnlist = tmp_path / "stn_Ref_Sim_list.txt"
+    pd.DataFrame(
+        [
+            {"ID": "A", "sim_lon": 0, "sim_lat": 0, "use_syear": 2000, "use_eyear": 2000},
+            {"ID": "B", "sim_lon": 0, "sim_lat": 0, "use_syear": 2000, "use_eyear": 2000},
+        ]
+    ).to_csv(stnlist, index=False)
+
+    ev = Evaluation_stn.__new__(Evaluation_stn)
+    ev.casedir = str(tmp_path)
+    ev.item = "Runoff"
+    ev.ref_source = "Ref"
+    ev.sim_source = "Sim"
+    ev.ref_fulllist = str(stnlist)
+    ev.num_cores = 1
+    ev.output_manager = None
+    ev.metrics = ["bias"]
+    ev.scores = []
+    ev.make_evaluation_parallel = lambda station_list, i: (
+        {"KGESS": 1.0, "RMSE": 0.0, "correlation": 1.0, "bias": 0.0} if i == 0 else None
+    )
+    monkeypatch.setattr(evaluation, "make_plot_index_stn", lambda self: None)
+
+    with pytest.raises(RuntimeError, match="1/2 station"):
+        ev.make_evaluation_P()
+
+
+def test_station_evaluation_hard_fails_when_all_results_are_nonfinite(tmp_path, monkeypatch):
+    import openbench.core.evaluation as evaluation
+    from openbench.core.evaluation import Evaluation_stn
+
+    stnlist = tmp_path / "stn_Ref_Sim_list.txt"
+    pd.DataFrame([{"ID": "A", "sim_lon": 0, "sim_lat": 0, "use_syear": 2000, "use_eyear": 2000}]).to_csv(
+        stnlist, index=False
+    )
+    ev = Evaluation_stn.__new__(Evaluation_stn)
+    ev.casedir, ev.item, ev.ref_source, ev.sim_source = str(tmp_path), "Runoff", "Ref", "Sim"
+    ev.ref_fulllist, ev.num_cores, ev.output_manager = str(stnlist), 1, None
+    ev.metrics, ev.scores = ["bias"], []
+    ev.make_evaluation_parallel = lambda station_list, i: {"bias": np.inf}
+    monkeypatch.setattr(evaluation, "make_plot_index_stn", lambda self: None)
+
+    with pytest.raises(RuntimeError, match="no finite"):
+        ev.make_evaluation_P()


### PR DESCRIPTION
## Summary
- keep scanned simulation layouts, compute mappings, and station lists runnable through the runtime
- make station preprocessing/evaluation and remote GUI scanning fail truthfully instead of silently dropping data
- report preprocessing progress and cache raw-input signatures once per planning run
- preserve simulation GUI labels/defaults and reject local Windows paths in remote exports

## Validation
- `pytest -q`: 1760 passed, 5 skipped
- targeted simulation/GUI/runner regressions: passed
- `ruff check` on modified Python files: passed
- `python -m compileall`: passed
- `git diff --check`: passed

## Remaining platform validation
- Native Windows GUI and live SSH integration were not available locally; cross-platform fallbacks and path handling are covered by unit tests.