### PR TITLE
Make Windows path checks deterministic

### DIFF
--- a/src/openbench/data/registry/scanner.py
+++ b/src/openbench/data/registry/scanner.py
@@ -843,7 +843,7 @@ def _matching_nc_files(directory: Path, pattern: str | list[str] | tuple[str, ..
         for file_path in search:
             if file_path.is_file() and file_path.suffix in NC_SUFFIXES and _casefold_match(file_path, pat):
                 files[file_path] = None
-    return sorted(files)
+    return sorted(files, key=lambda path: path.relative_to(directory).as_posix())
 
 
 def _profile_var_names(profile: dict, fallback: str) -> list[str]:

--- a/tests/test_cli_check_preflight.py
+++ b/tests/test_cli_check_preflight.py
@@ -926,8 +926,8 @@ def test_check_rejects_missing_requested_reference_resolution(tmp_path, monkeypa
     result = runner.invoke(cli, ["check", str(path)])
 
     assert result.exit_code == 1, result.output
-    assert "Grid/MidRes" in result.output
-    assert "Grid/LowRes" not in result.output
+    assert str(mid_root) in result.output
+    assert str(tmp_path / "Grid" / "LowRes") not in result.output
     assert "Reference data path does not exist" in result.output
 
 


### PR DESCRIPTION
## Summary
- make case-insensitive NetCDF glob results sort identically on Windows and POSIX
- make the reference-resolution CLI regression assert the native rendered path

## Evidence
This fixes the two failures reported by the Windows 3.10-3.12 CI matrix.

## Validation
- three targeted regressions passed
- `ruff check src/ tests/` passed
- `ruff format --check src/ tests/` passed
- `git diff --check` passed