### PR TITLE
Fix audited GUI workflows across local and remote execution

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - matplotlib-base >=3.4.0
     - cartopy >=0.20.0
     - dask >=2022.1.0
+    - distributed >=2022.1.0
     - joblib >=1.1.0
     - flox >=0.5.0
     - pyyaml >=6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "netCDF4>=1.5.7",
     "matplotlib>=3.4.0",
     "cartopy>=0.20.0",
-    "dask>=2022.1.0",
+    "dask[distributed]>=2022.1.0",
     "joblib>=1.1.0",
     "flox>=0.5.0",
     "PyYAML>=6.0",
@@ -118,7 +118,13 @@ dependencies = [
 # is in the base install. The report/migration/statistics/plot extras are kept
 # (empty) for backward compatibility so e.g. `pip install colm-openbench[report]`
 # still resolves and never errors.
-gui = ["PySide6>=6.5.0", "psutil>=5.9.0"]
+gui = [
+    "PySide6>=6.5.0",
+    "psutil>=5.9.0",
+    # The runtime page imports the remote widgets during GUI startup.
+    "paramiko>=3.0.0",
+    "cryptography>=41.0.0",
+]
 remote = ["paramiko>=3.0.0", "cryptography>=41.0.0"]
 # PDF reports need xhtml2pdf, which pulls pycairo (requires system cairo to
 # build), so it stays optional to keep the base `pip install` lightweight and

--- a/src/openbench/gui/config_manager.py
+++ b/src/openbench/gui/config_manager.py
@@ -598,11 +598,13 @@ class ConfigManager:
         if not selected_items:
             errors.append("At least one evaluation item must be selected")
 
-        # Check metrics
+        # Evaluation supports metrics, scores, or both.
         metrics = config.get("metrics", {})
         selected_metrics = [k for k, v in metrics.items() if v]
-        if not selected_metrics:
-            errors.append("At least one metric must be selected")
+        scores = config.get("scores", {})
+        selected_scores = [k for k, v in scores.items() if v]
+        if not selected_metrics and not selected_scores:
+            errors.append("At least one metric or score must be selected")
 
         # Check ref data if any items selected
         if selected_items:

--- a/src/openbench/gui/data_validator.py
+++ b/src/openbench/gui/data_validator.py
@@ -42,6 +42,65 @@ def safe_open(path: str):
         return xr.open_dataset(path, decode_times=False)
 
 
+def _longitude_range_covers(
+    data_min: float,
+    data_max: float,
+    required_min: float,
+    required_max: float,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Compare longitude intervals even when they use different 0/360 domains."""
+    metadata = metadata or {}
+    if metadata.get("lon_is_global"):
+        return True
+    coverage = metadata.get("lon_coverage")
+    if coverage and required_max >= required_min:
+        required_span = required_max - required_min
+        if required_span >= 359.999:
+            return False
+        required_start = required_min % 360.0
+        required_end = required_start + required_span
+        coverage_start, coverage_end = coverage
+        return any(
+            coverage_start <= required_start + shift and coverage_end >= required_end + shift
+            for shift in (-360.0, 0.0, 360.0)
+        )
+    return any(
+        data_min + data_shift <= required_min + required_shift
+        and data_max + data_shift >= required_max + required_shift
+        for data_shift in (-360.0, 0.0, 360.0)
+        for required_shift in (-360.0, 0.0, 360.0)
+    )
+
+
+def _longitude_metadata(values) -> Dict[str, Any]:
+    """Describe a one-dimensional longitude coordinate on a circular domain."""
+    try:
+        import numpy as np
+
+        array = np.asarray(values, dtype=float)
+        if array.ndim != 1:
+            return {}
+        normalized = np.unique(np.mod(array[np.isfinite(array)], 360.0))
+        if normalized.size < 2:
+            return {}
+        gaps = np.diff(np.concatenate((normalized, [normalized[0] + 360.0])))
+        largest_index = int(np.argmax(gaps))
+        smaller_gaps = np.delete(gaps, largest_index)
+        resolution = float(np.median(smaller_gaps[smaller_gaps > 0])) if np.any(smaller_gaps > 0) else 0.0
+        largest_gap = float(gaps[largest_index])
+        coverage_start = float(normalized[(largest_index + 1) % normalized.size])
+        coverage_end = float(normalized[largest_index])
+        if coverage_end < coverage_start:
+            coverage_end += 360.0
+        return {
+            "lon_is_global": bool(normalized.size >= 4 and resolution > 0 and largest_gap <= resolution * 1.5 + 1e-9),
+            "lon_coverage": [coverage_start, coverage_end],
+        }
+    except (ImportError, TypeError, ValueError):
+        return {}
+
+
 # String version of safe_open for embedding in remote scripts
 SAFE_OPEN_CODE = '''
 def safe_open(path):
@@ -272,24 +331,49 @@ class LocalNetCDFValidator:
         """Open dataset using safe_open."""
         return safe_open(path)
 
-    def check_variable(self, path: str, varname: str) -> ValidationCheck:
-        """Check if variable exists in NetCDF file."""
+    def inspect_file(self, path: str) -> Dict[str, Any]:
+        """Read all metadata needed by validation while opening the file once."""
         try:
-            import xarray as xr  # noqa: F401  feature detection
-        except ImportError:
-            return ValidationCheck("variable_exists", False, "xarray required: pip install xarray netCDF4")
+            import pandas as pd
 
-        try:
             with self._open_dataset(path) as ds:
-                available_vars = list(ds.data_vars)
+                result: Dict[str, Any] = {"success": True, "variables": list(ds.data_vars)}
+                time_dim = self._find_dim(ds, self.TIME_DIMS)
+                if time_dim is None:
+                    result["time_missing"] = True
+                else:
+                    try:
+                        time_years = pd.to_datetime(ds[time_dim].values).year
+                        result["time_range"] = [int(time_years.min()), int(time_years.max())]
+                    except (TypeError, ValueError) as exc:
+                        result["time_error"] = str(exc)
 
-            if varname in available_vars:
-                return ValidationCheck("variable_exists", True, f"Variable '{varname}' exists")
+                lat_dim = self._find_dim(ds, self.LAT_DIMS)
+                lon_dim = self._find_dim(ds, self.LON_DIMS)
+                if lat_dim is not None:
+                    lat_vals = ds[lat_dim].values
+                    result["lat_range"] = [float(lat_vals.min()), float(lat_vals.max())]
+                if lon_dim is not None:
+                    lon_vals = ds[lon_dim].values
+                    result["lon_range"] = [float(lon_vals.min()), float(lon_vals.max())]
+                    result.update(_longitude_metadata(lon_vals))
+                return result
+        except ImportError:
+            return {"success": False, "error": "xarray required: pip install xarray netCDF4"}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    def check_variable(self, path: str, varname: str, inspection: Optional[Dict[str, Any]] = None) -> ValidationCheck:
+        """Check if variable exists in NetCDF file."""
+        result = inspection if inspection is not None else self.inspect_file(path)
+        if not result.get("success"):
             return ValidationCheck(
-                "variable_exists", False, f"Variable '{varname}' not found, available: {available_vars}"
+                "variable_exists", False, f"Cannot read file: {result.get('error', 'Unknown error')}"
             )
-        except Exception as e:
-            return ValidationCheck("variable_exists", False, f"Cannot read file: {e}")
+        available_vars = result.get("variables", [])
+        if varname in available_vars:
+            return ValidationCheck("variable_exists", True, f"Variable '{varname}' exists")
+        return ValidationCheck("variable_exists", False, f"Variable '{varname}' not found, available: {available_vars}")
 
     def _find_dim(self, ds, candidates: List[str]) -> Optional[str]:
         """Find a dimension by trying common names."""
@@ -298,87 +382,69 @@ class LocalNetCDFValidator:
                 return name
         return None
 
-    def check_time_range(self, path: str, syear: int, eyear: int) -> ValidationCheck:
+    def check_time_range(
+        self, path: str, syear: int, eyear: int, inspection: Optional[Dict[str, Any]] = None
+    ) -> ValidationCheck:
         """Check if data time range covers required period."""
-        try:
-            import xarray as xr  # noqa: F401  feature detection
-            import pandas as pd  # noqa: F401  feature detection
-        except ImportError:
-            return ValidationCheck("time_range", False, "xarray required: pip install xarray netCDF4")
-
-        try:
-            with self._open_dataset(path) as ds:
-                time_dim = self._find_dim(ds, self.TIME_DIMS)
-
-                if time_dim is None:
-                    return ValidationCheck("time_range", False, f"Time dimension not found, tried: {self.TIME_DIMS}")
-
-                time_vals = ds[time_dim].values
-
-            # Convert to years - handle cftime objects
-            try:
-                time_years = pd.to_datetime(time_vals).year
-            except (TypeError, ValueError):
-                # cftime or other non-standard calendar - skip time check
-                return ValidationCheck("time_range", True, "Time check skipped (non-standard calendar)")
-
-            data_syear = int(time_years.min())
-            data_eyear = int(time_years.max())
-
-            if data_syear <= syear and data_eyear >= eyear:
-                return ValidationCheck(
-                    "time_range", True, f"Time range OK: data {data_syear}-{data_eyear}, required {syear}-{eyear}"
-                )
+        result = inspection if inspection is not None else self.inspect_file(path)
+        if not result.get("success"):
+            return ValidationCheck("time_range", False, f"Time check failed: {result.get('error', 'Unknown error')}")
+        if result.get("time_missing"):
+            return ValidationCheck("time_range", False, f"Time dimension not found, tried: {self.TIME_DIMS}")
+        if "time_error" in result:
+            return ValidationCheck("time_range", True, "Time check skipped (non-standard calendar)")
+        time_range = result.get("time_range")
+        if time_range is None:
+            return ValidationCheck("time_range", False, "Time check failed: no time range")
+        data_syear, data_eyear = time_range
+        if data_syear <= syear and data_eyear >= eyear:
             return ValidationCheck(
-                "time_range",
-                False,
-                f"Time range insufficient: data {data_syear}-{data_eyear}, required {syear}-{eyear}",
+                "time_range", True, f"Time range OK: data {data_syear}-{data_eyear}, required {syear}-{eyear}"
             )
-        except Exception as e:
-            return ValidationCheck("time_range", False, f"Time check failed: {e}")
+        return ValidationCheck(
+            "time_range",
+            False,
+            f"Time range insufficient: data {data_syear}-{data_eyear}, required {syear}-{eyear}",
+        )
 
     def check_spatial_range(
-        self, path: str, min_lat: float, max_lat: float, min_lon: float, max_lon: float
+        self,
+        path: str,
+        min_lat: float,
+        max_lat: float,
+        min_lon: float,
+        max_lon: float,
+        inspection: Optional[Dict[str, Any]] = None,
     ) -> ValidationCheck:
         """Check if data spatial range covers required area."""
-        try:
-            import xarray as xr  # noqa: F401  feature detection
-        except ImportError:
-            return ValidationCheck("spatial_range", False, "xarray required: pip install xarray netCDF4")
+        result = inspection if inspection is not None else self.inspect_file(path)
+        if not result.get("success"):
+            return ValidationCheck(
+                "spatial_range", False, f"Spatial check failed: {result.get('error', 'Unknown error')}"
+            )
+        lat_range = result.get("lat_range")
+        lon_range = result.get("lon_range")
+        if lat_range is None or lon_range is None:
+            return ValidationCheck("spatial_range", False, "Lat/lon dimensions not found")
+        data_min_lat, data_max_lat = lat_range
+        data_min_lon, data_max_lon = lon_range
+        lat_ok = data_min_lat <= min_lat and data_max_lat >= max_lat
+        lon_ok = _longitude_range_covers(
+            data_min_lon,
+            data_max_lon,
+            min_lon,
+            max_lon,
+            result,
+        )
+        if lat_ok and lon_ok:
+            return ValidationCheck("spatial_range", True, "Spatial range OK")
 
-        try:
-            with self._open_dataset(path) as ds:
-                lat_dim = self._find_dim(ds, self.LAT_DIMS)
-                lon_dim = self._find_dim(ds, self.LON_DIMS)
-
-                if lat_dim is None or lon_dim is None:
-                    return ValidationCheck("spatial_range", False, "Lat/lon dimensions not found")
-
-                lat_vals = ds[lat_dim].values
-                lon_vals = ds[lon_dim].values
-
-            data_min_lat, data_max_lat = float(lat_vals.min()), float(lat_vals.max())
-            data_min_lon, data_max_lon = float(lon_vals.min()), float(lon_vals.max())
-
-            lat_ok = data_min_lat <= min_lat and data_max_lat >= max_lat
-            lon_ok = data_min_lon <= min_lon and data_max_lon >= max_lon
-
-            if lat_ok and lon_ok:
-                return ValidationCheck("spatial_range", True, "Spatial range OK")
-
-            msg_parts = []
-            if not lat_ok:
-                msg_parts.append(
-                    f"Lat: data {data_min_lat:.1f}~{data_max_lat:.1f}, required {min_lat:.1f}~{max_lat:.1f}"
-                )
-            if not lon_ok:
-                msg_parts.append(
-                    f"Lon: data {data_min_lon:.1f}~{data_max_lon:.1f}, required {min_lon:.1f}~{max_lon:.1f}"
-                )
-
-            return ValidationCheck("spatial_range", False, "Spatial range insufficient: " + "; ".join(msg_parts))
-        except Exception as e:
-            return ValidationCheck("spatial_range", False, f"Spatial check failed: {e}")
+        msg_parts = []
+        if not lat_ok:
+            msg_parts.append(f"Lat: data {data_min_lat:.1f}~{data_max_lat:.1f}, required {min_lat:.1f}~{max_lat:.1f}")
+        if not lon_ok:
+            msg_parts.append(f"Lon: data {data_min_lon:.1f}~{data_max_lon:.1f}, required {min_lon:.1f}~{max_lon:.1f}")
+        return ValidationCheck("spatial_range", False, "Spatial range insufficient: " + "; ".join(msg_parts))
 
 
 class RemoteNetCDFValidator:
@@ -425,7 +491,31 @@ try:
             break
     for ld in lon_dims:
         if ld in ds.dims or ld in ds.coords:
-            result["lon_range"] = [float(ds[ld].values.min()), float(ds[ld].values.max())]
+            lon_values = ds[ld].values
+            result["lon_range"] = [float(lon_values.min()), float(lon_values.max())]
+            try:
+                import numpy as np
+                array = np.asarray(lon_values, dtype=float)
+                if array.ndim == 1:
+                    normalized = np.unique(np.mod(array[np.isfinite(array)], 360.0))
+                    if normalized.size > 1:
+                        gaps = np.diff(np.concatenate((normalized, [normalized[0] + 360.0])))
+                        largest_index = int(np.argmax(gaps))
+                        smaller_gaps = np.delete(gaps, largest_index)
+                        positive_gaps = smaller_gaps[smaller_gaps > 0]
+                        resolution = float(np.median(positive_gaps)) if positive_gaps.size else 0.0
+                        coverage_start = float(normalized[(largest_index + 1) % normalized.size])
+                        coverage_end = float(normalized[largest_index])
+                        if coverage_end < coverage_start:
+                            coverage_end += 360.0
+                        result["lon_is_global"] = bool(
+                            normalized.size >= 4
+                            and resolution > 0
+                            and float(gaps[largest_index]) <= resolution * 1.5 + 1e-9
+                        )
+                        result["lon_coverage"] = [coverage_start, coverage_end]
+            except Exception:
+                pass
             break
 
     ds.close()
@@ -473,12 +563,14 @@ except Exception as e:
             pass
         return None
 
-    def check_variable(self, path: str, varname: str) -> ValidationCheck:
-        """Check if variable exists in remote NetCDF file."""
+    def inspect_file(self, path: str) -> Dict[str, Any]:
+        """Return all remotely inspected metadata in one SSH round trip."""
         result = self._run_inspect_script(path)
+        return result if result is not None else {"success": False, "error": "Remote check failed"}
 
-        if result is None:
-            return ValidationCheck("variable_exists", False, "Remote check failed")
+    def check_variable(self, path: str, varname: str, inspection: Optional[Dict[str, Any]] = None) -> ValidationCheck:
+        """Check if variable exists in remote NetCDF file."""
+        result = inspection if inspection is not None else self.inspect_file(path)
 
         if not result.get("success"):
             error = result.get("error", "Unknown error")
@@ -489,11 +581,13 @@ except Exception as e:
             return ValidationCheck("variable_exists", True, f"Variable '{varname}' exists")
         return ValidationCheck("variable_exists", False, f"Variable '{varname}' not found, available: {variables}")
 
-    def check_time_range(self, path: str, syear: int, eyear: int) -> ValidationCheck:
+    def check_time_range(
+        self, path: str, syear: int, eyear: int, inspection: Optional[Dict[str, Any]] = None
+    ) -> ValidationCheck:
         """Check time range on remote file."""
-        result = self._run_inspect_script(path)
+        result = inspection if inspection is not None else self.inspect_file(path)
 
-        if result is None or not result.get("success"):
+        if not result.get("success"):
             return ValidationCheck("time_range", False, "Remote time check failed")
 
         # Check for time conversion error
@@ -512,12 +606,18 @@ except Exception as e:
         )
 
     def check_spatial_range(
-        self, path: str, min_lat: float, max_lat: float, min_lon: float, max_lon: float
+        self,
+        path: str,
+        min_lat: float,
+        max_lat: float,
+        min_lon: float,
+        max_lon: float,
+        inspection: Optional[Dict[str, Any]] = None,
     ) -> ValidationCheck:
         """Check spatial range on remote file."""
-        result = self._run_inspect_script(path)
+        result = inspection if inspection is not None else self.inspect_file(path)
 
-        if result is None or not result.get("success"):
+        if not result.get("success"):
             return ValidationCheck("spatial_range", False, "Remote spatial check failed")
 
         lat_range = result.get("lat_range")
@@ -530,7 +630,13 @@ except Exception as e:
         data_min_lon, data_max_lon = lon_range
 
         lat_ok = data_min_lat <= min_lat and data_max_lat >= max_lat
-        lon_ok = data_min_lon <= min_lon and data_max_lon >= max_lon
+        lon_ok = _longitude_range_covers(
+            data_min_lon,
+            data_max_lon,
+            min_lon,
+            max_lon,
+            result,
+        )
 
         if lat_ok and lon_ok:
             return ValidationCheck("spatial_range", True, "Spatial range OK")
@@ -695,18 +801,28 @@ class DataValidator:
         if first_existing_path is None:
             return SourceValidationResult(var_name, source_name, checks)
 
+        needs_time_check = data_type == "grid" and str(data_groupby).lower() == "single"
+        needs_spatial_check = data_type == "grid" and all(
+            key in general_config for key in ("min_lat", "max_lat", "min_lon", "max_lon")
+        )
+        inspection = (
+            self._validator.inspect_file(first_existing_path)
+            if varname or needs_time_check or needs_spatial_check
+            else None
+        )
+
         # Check variable name
         if varname:
-            check = self._validator.check_variable(first_existing_path, varname)
+            check = self._validator.check_variable(first_existing_path, varname, inspection)
             checks.append(check)
 
         # Check time range (only for grid data with Single groupby)
         # For Year/Month/Day groupby, each file only contains partial data
-        if data_type == "grid" and str(data_groupby).lower() == "single":
-            check = self._validator.check_time_range(first_existing_path, int(syear), int(eyear))
+        if needs_time_check:
+            check = self._validator.check_time_range(first_existing_path, int(syear), int(eyear), inspection)
             checks.append(check)
 
-        if data_type == "grid" and all(k in general_config for k in ("min_lat", "max_lat", "min_lon", "max_lon")):
+        if needs_spatial_check:
             checks.append(
                 self._validator.check_spatial_range(
                     first_existing_path,
@@ -714,6 +830,7 @@ class DataValidator:
                     float(general_config["max_lat"]),
                     float(general_config["min_lon"]),
                     float(general_config["max_lon"]),
+                    inspection,
                 )
             )
 

--- a/src/openbench/gui/main_window.py
+++ b/src/openbench/gui/main_window.py
@@ -442,10 +442,26 @@ class MainWindow(QMainWindow):
                 # QThread.wait expects ms; runner.stop sets a flag and the
                 # subprocess loop in run() should exit on the next poll.
                 if hasattr(runner, "wait"):
-                    runner.wait(self._RUNNER_SHUTDOWN_TIMEOUT_MS)
+                    if not runner.wait(self._RUNNER_SHUTDOWN_TIMEOUT_MS):
+                        QMessageBox.warning(
+                            self, "Evaluation Stopping", "The evaluation is still stopping. Try closing again."
+                        )
+                        event.ignore()
+                        return
             except Exception as e:
                 logger.warning("Error during runner shutdown on close: %s", e)
 
+        download_worker = getattr(run_monitor, "_download_worker", None) if run_monitor is not None else None
+        if download_worker is not None and download_worker.isRunning():
+            download_worker.stop()
+            if not download_worker.wait(self._RUNNER_SHUTDOWN_TIMEOUT_MS):
+                QMessageBox.warning(
+                    self, "Download Stopping", "The remote download is still stopping. Try closing again."
+                )
+                event.ignore()
+                return
+
+        self._cleanup_remote_storage(sync_pending=True, disconnect_ssh=True)
         super().closeEvent(event)
 
     def _runner_is_active(self) -> bool:
@@ -540,11 +556,11 @@ class MainWindow(QMainWindow):
             if not trigger_sync:
                 old_auto_sync = self.controller.auto_sync_enabled
                 self.controller.auto_sync_enabled = False
-
-            current_page.save_to_config()
-
-            if not trigger_sync:
-                self.controller.auto_sync_enabled = old_auto_sync
+            try:
+                current_page.save_to_config()
+            finally:
+                if not trigger_sync:
+                    self.controller.auto_sync_enabled = old_auto_sync
 
     def _on_page_changed(self, page_id: str):
         """Handle page change."""
@@ -1017,13 +1033,22 @@ class MainWindow(QMainWindow):
 
         current = start_dir
         for _ in range(10):  # Max 10 levels up
-            # Check if this looks like OpenBench root
+            # Check if this looks like an OpenBench v3 root. The old
+            # `openbench/openbench.py` marker is gone; accept editable/source
+            # layouts and generated project roots with nml/.
             stdout, stderr, exit_code = execute_responsive(
                 ssh_manager,
-                f"ls -d {quote_remote_path(current + '/openbench')} {quote_remote_path(current + '/nml')} 2>/dev/null | head -1",
+                (
+                    f"test -f {quote_remote_path(current + '/src/openbench/cli/main.py')} "
+                    f"|| grep -Eq 'name = [\"'\"''](colm-openbench|openbench)[\"'\"'']' "
+                    f"{quote_remote_path(current + '/pyproject.toml')} 2>/dev/null "
+                    f"|| (test -f {quote_remote_path(current + '/openbench/cli/main.py')} "
+                    f"&& test -d {quote_remote_path(current + '/openbench/data/registry')}) "
+                    f"|| test -d {quote_remote_path(current + '/nml')}"
+                ),
                 timeout=10,
             )
-            if exit_code == 0 and stdout.strip():
+            if exit_code == 0:
                 return current
 
             # Go up one directory
@@ -1113,6 +1138,47 @@ class MainWindow(QMainWindow):
 
         # Don't load existing project config - start fresh each time
 
+    def _current_sync_engine(self):
+        """Return the active RemoteStorage sync engine, if any."""
+        storage = getattr(self.controller, "storage", None)
+        if not isinstance(storage, RemoteStorage):
+            return None
+        sync_engine = getattr(storage, "sync_engine", None)
+        if sync_engine is not None:
+            return sync_engine
+        return getattr(storage, "_sync", None) or getattr(storage, "_sync_engine", None)
+
+    def _cleanup_remote_storage(self, *, sync_pending: bool, disconnect_ssh: bool) -> None:
+        """Flush and stop active remote storage before replacing/closing it."""
+        sync_engine = self._current_sync_engine()
+        if sync_engine is not None:
+            try:
+                sync_engine._on_status_changed = None
+            except Exception:
+                pass
+            if sync_pending:
+                try:
+                    if not sync_engine.sync_all():
+                        logger.warning("Remote sync_all reported pending sync failures during cleanup")
+                except Exception as exc:
+                    logger.warning("Remote sync_all failed during cleanup: %s", exc)
+            try:
+                sync_engine.stop_background_sync()
+            except Exception as exc:
+                logger.warning("Remote background sync stop failed during cleanup: %s", exc)
+
+        if disconnect_ssh:
+            ssh_manager = getattr(self.controller, "ssh_manager", None)
+            if ssh_manager is None and sync_engine is not None:
+                ssh_manager = getattr(sync_engine, "_ssh", None)
+            if ssh_manager is not None:
+                try:
+                    ssh_manager.disconnect()
+                except Exception as exc:
+                    logger.warning("Remote SSH disconnect failed during cleanup: %s", exc)
+            if hasattr(self.controller, "ssh_manager"):
+                self.controller.ssh_manager = None
+
     def setup_remote_storage(self, ssh_manager, remote_project_dir: str):
         """Setup remote storage when user connects via Runtime Environment page.
 
@@ -1123,6 +1189,17 @@ class MainWindow(QMainWindow):
             remote_project_dir: Remote project directory path
         """
         from openbench.remote.sync import SyncEngine
+
+        # Reconnecting/changing remote roots must not leave the old background
+        # sync thread or a replaced SSH manager alive against a stale path.
+        old_sync_engine = self._current_sync_engine()
+        old_ssh_manager = getattr(old_sync_engine, "_ssh", None) if old_sync_engine is not None else None
+        self._cleanup_remote_storage(sync_pending=True, disconnect_ssh=False)
+        if old_ssh_manager is not None and old_ssh_manager is not ssh_manager:
+            try:
+                old_ssh_manager.disconnect()
+            except Exception as exc:
+                logger.warning("Previous remote SSH disconnect failed during replacement: %s", exc)
 
         # Create sync engine and remote storage
         sync_engine = SyncEngine(ssh_manager, remote_project_dir)
@@ -1143,15 +1220,7 @@ class MainWindow(QMainWindow):
         Args:
             project_dir: Local project directory path
         """
-        # Stop and cleanup old sync engine if exists (from previous remote mode)
-        old_storage = self.controller.storage
-        if old_storage and hasattr(old_storage, "_sync_engine"):
-            sync_engine = old_storage._sync_engine
-            if sync_engine:
-                # Clear the callback first to prevent crashes
-                sync_engine._on_status_changed = None
-                # Stop background sync thread
-                sync_engine.stop_background_sync()
+        self._cleanup_remote_storage(sync_pending=True, disconnect_ssh=True)
 
         self.controller.storage = LocalStorage(project_dir)
         self.controller.project_root = project_dir

--- a/src/openbench/gui/pages/page_general.py
+++ b/src/openbench/gui/pages/page_general.py
@@ -542,103 +542,135 @@ class PageGeneral(BasePage):
         general = self.controller.config.get("general", {})
         basename = general.get("basename", "")
 
-        # Block signals to prevent save_to_config from being called during load
-        self.basename_input.blockSignals(True)
-        self.basename_input.setText(basename)
-        self.basename_input.blockSignals(False)
+        # Block signals to prevent save_to_config from being called during load.
+        # Loading must be a pure render operation; otherwise early widgets can
+        # save stale defaults for fields that are populated later in this method.
+        widgets_to_block = [
+            self.basename_input,
+            self.basedir_input,
+            self.syear_spin,
+            self.eyear_spin,
+            self.min_year_spin,
+            self.min_lat_spin,
+            self.max_lat_spin,
+            self.min_lon_spin,
+            self.max_lon_spin,
+            self.tim_res_combo,
+            self.grid_res_spin,
+            self.time_alignment_combo,
+            self.timezone_spin,
+            self.weight_combo,
+            self.cb_evaluation,
+            self.cb_comparison,
+            self.cb_statistics,
+            self.cb_debug,
+            self.cb_report,
+            self.cb_only_drawing,
+            self.cb_unified_mask,
+            self.cb_igbp,
+            self.cb_pft,
+            self.cb_climate,
+            self.num_cores_spin,
+        ]
+        previous_signal_states = [widget.blockSignals(True) for widget in widgets_to_block]
+        try:
+            self.basename_input.setText(basename)
 
-        # Get basedir and convert to absolute path (without appending project name)
-        basedir = general.get("basedir", "")
+            # Get basedir and convert to absolute path (without appending project name)
+            basedir = general.get("basedir", "")
 
-        # Check if in remote mode using storage type
-        from openbench.remote.storage import RemoteStorage
+            # Check if in remote mode using storage type
+            from openbench.remote.storage import RemoteStorage
 
-        is_remote = isinstance(self.controller.storage, RemoteStorage)
+            is_remote = isinstance(self.controller.storage, RemoteStorage)
 
-        if is_remote:
-            # Remote mode: use remote OpenBench path for defaults
-            remote_openbench = self.controller.remote_settings().get("openbench_path", "")
+            if is_remote:
+                # Remote mode: use remote OpenBench path for defaults
+                remote_openbench = self.controller.remote_settings().get("openbench_path", "")
 
-            if not basedir or basedir == "./output":
-                # Set default to remote OpenBench/output
-                if remote_openbench:
-                    basedir = f"{remote_openbench.rstrip('/')}/output"
-                else:
-                    basedir = "./output"
-            elif not basedir.startswith("/"):
-                # Convert relative path to absolute using remote root
-                if basedir.startswith("./"):
-                    basedir = basedir[2:]
-                if remote_openbench:
-                    basedir = f"{remote_openbench.rstrip('/')}/{basedir}"
-            # Normalize slashes for remote paths
-            basedir = basedir.replace("\\", "/")
-        else:
-            # Local mode: use local OpenBench root
-            openbench_root = self._get_openbench_root()
+                if not basedir or basedir == "./output":
+                    # Set default to remote OpenBench/output
+                    if remote_openbench:
+                        basedir = f"{remote_openbench.rstrip('/')}/output"
+                    else:
+                        basedir = "./output"
+                elif not basedir.startswith("/"):
+                    # Convert relative path to absolute using remote root
+                    if basedir.startswith("./"):
+                        basedir = basedir[2:]
+                    if remote_openbench:
+                        basedir = f"{remote_openbench.rstrip('/')}/{basedir}"
+                # Normalize slashes for remote paths
+                basedir = basedir.replace("\\", "/")
+            else:
+                # Local mode: use local OpenBench root
+                openbench_root = self._get_openbench_root()
 
-            if not basedir or basedir == "./output":
-                # Set default to OpenBench/output (without project name)
-                basedir = os.path.join(openbench_root, "output")
-            elif not os.path.isabs(basedir):
-                # Convert relative path to absolute
-                if basedir.startswith("./"):
-                    basedir = basedir[2:]
-                basedir = os.path.normpath(os.path.join(openbench_root, basedir))
+                if not basedir or basedir == "./output":
+                    # Set default to OpenBench/output (without project name)
+                    basedir = os.path.join(openbench_root, "output")
+                elif not os.path.isabs(basedir):
+                    # Convert relative path to absolute
+                    if basedir.startswith("./"):
+                        basedir = basedir[2:]
+                    basedir = os.path.normpath(os.path.join(openbench_root, basedir))
 
-        # Set path without emitting signal to prevent save_to_config loop
-        self.basedir_input.set_path(basedir, emit_signal=False)
+            # Set path without emitting signal to prevent save_to_config loop
+            self.basedir_input.set_path(basedir, emit_signal=False)
 
-        # Skip local path validation in remote mode (remote paths won't exist locally)
-        self.basedir_input.set_skip_validation(is_remote)
+            # Skip local path validation in remote mode (remote paths won't exist locally)
+            self.basedir_input.set_skip_validation(is_remote)
 
-        self.syear_spin.setValue(general.get("syear", 2000))
-        self.eyear_spin.setValue(general.get("eyear", 2020))
-        self.min_year_spin.setValue(general.get("min_year", 1.0))
-        self.min_lat_spin.setValue(general.get("min_lat", -90.0))
-        self.max_lat_spin.setValue(general.get("max_lat", 90.0))
-        self.min_lon_spin.setValue(general.get("min_lon", -180.0))
-        self.max_lon_spin.setValue(general.get("max_lon", 180.0))
+            self.syear_spin.setValue(general.get("syear", 2000))
+            self.eyear_spin.setValue(general.get("eyear", 2020))
+            self.min_year_spin.setValue(general.get("min_year", 1.0))
+            self.min_lat_spin.setValue(general.get("min_lat", -90.0))
+            self.max_lat_spin.setValue(general.get("max_lat", 90.0))
+            self.min_lon_spin.setValue(general.get("min_lon", -180.0))
+            self.max_lon_spin.setValue(general.get("max_lon", 180.0))
 
-        tim_res = general.get("compare_tim_res", "month")
-        idx = self.tim_res_combo.findText(tim_res)
-        if idx >= 0:
-            self.tim_res_combo.setCurrentIndex(idx)
+            tim_res = general.get("compare_tim_res", "month")
+            idx = self.tim_res_combo.findText(tim_res)
+            if idx >= 0:
+                self.tim_res_combo.setCurrentIndex(idx)
 
-        self.grid_res_spin.setValue(general.get("compare_grid_res", 2.0))
-        self.timezone_spin.setValue(general.get("compare_tzone", 0.0))
+            self.grid_res_spin.setValue(general.get("compare_grid_res", 2.0))
+            self.timezone_spin.setValue(general.get("compare_tzone", 0.0))
 
-        # Time alignment
-        time_align = general.get("time_alignment", "intersection")
-        for i in range(self.time_alignment_combo.count()):
-            if self.time_alignment_combo.itemData(i) == time_align:
-                self.time_alignment_combo.setCurrentIndex(i)
-                break
+            # Time alignment
+            time_align = general.get("time_alignment", "intersection")
+            for i in range(self.time_alignment_combo.count()):
+                if self.time_alignment_combo.itemData(i) == time_align:
+                    self.time_alignment_combo.setCurrentIndex(i)
+                    break
 
-        self.cb_evaluation.setChecked(general.get("evaluation", True))
-        self.cb_comparison.setChecked(general.get("comparison", True))
-        self.cb_statistics.setChecked(general.get("statistics", False))
-        self.cb_debug.setChecked(general.get("debug_mode", False))
-        self.cb_report.setChecked(general.get("generate_report", True))
-        self.cb_only_drawing.setChecked(general.get("only_drawing", False))
+            self.cb_evaluation.setChecked(general.get("evaluation", True))
+            self.cb_comparison.setChecked(general.get("comparison", True))
+            self.cb_statistics.setChecked(general.get("statistics", False))
+            self.cb_debug.setChecked(general.get("debug_mode", False))
+            self.cb_report.setChecked(general.get("generate_report", True))
+            self.cb_only_drawing.setChecked(general.get("only_drawing", False))
 
-        self.cb_igbp.setChecked(general.get("IGBP_groupby", True))
-        self.cb_pft.setChecked(general.get("PFT_groupby", True))
-        self.cb_climate.setChecked(general.get("Climate_zone_groupby", True))
-        self.cb_unified_mask.setChecked(general.get("unified_mask", True))
+            self.cb_igbp.setChecked(general.get("IGBP_groupby", True))
+            self.cb_pft.setChecked(general.get("PFT_groupby", True))
+            self.cb_climate.setChecked(general.get("Climate_zone_groupby", True))
+            self.cb_unified_mask.setChecked(general.get("unified_mask", True))
 
-        self.num_cores_spin.setValue(general.get("num_cores", DEFAULT_NUM_CORES))
-        self._load_performance_settings(general)
+            self.num_cores_spin.setValue(general.get("num_cores", DEFAULT_NUM_CORES))
+            self._load_performance_settings(general)
 
-        weight = general.get("weight", "none")
-        if weight is None:
-            weight = "none"
-        # Map lowercase to display text
-        weight_map = {"none": "None", "area": "area", "mass": "mass"}
-        display_weight = weight_map.get(str(weight).lower(), "None")
-        idx = self.weight_combo.findText(display_weight)
-        if idx >= 0:
-            self.weight_combo.setCurrentIndex(idx)
+            weight = general.get("weight", "none")
+            if weight is None:
+                weight = "none"
+            # Map lowercase to display text
+            weight_map = {"none": "None", "area": "area", "mass": "mass"}
+            display_weight = weight_map.get(str(weight).lower(), "None")
+            idx = self.weight_combo.findText(display_weight)
+            if idx >= 0:
+                self.weight_combo.setCurrentIndex(idx)
+        finally:
+            for widget, state in zip(widgets_to_block, previous_signal_states):
+                widget.blockSignals(state)
 
         # Note: Runtime Environment settings (execution_mode, remote config, python_path, conda_env)
         # are now handled by PageRuntime

--- a/src/openbench/gui/pages/page_preview.py
+++ b/src/openbench/gui/pages/page_preview.py
@@ -189,12 +189,21 @@ class PagePreview(BasePage):
             QMessageBox.warning(self, "Validation Failed", error_msg)
             return False
 
-        # Check if in remote mode using storage type
+        # Execution mode is authoritative. Storage can still be local while a
+        # saved remote config is disconnected; silently running locally would
+        # execute on the wrong machine.
         from openbench.remote.storage import RemoteStorage
 
-        is_remote = isinstance(self.controller.storage, RemoteStorage)
+        is_remote = self.controller.config.get("general", {}).get("execution_mode") == "remote"
 
         if is_remote:
+            if not isinstance(self.controller.storage, RemoteStorage):
+                QMessageBox.warning(
+                    self,
+                    "Remote Connection Required",
+                    "Remote execution is selected, but no remote project connection is active.",
+                )
+                return False
             # TODO: Refactor to use ProjectStorage interface for unified export
             # Currently uses direct SSH/SFTP operations
             return self._export_and_run_remote(output_dir)

--- a/src/openbench/gui/pages/page_run_monitor.py
+++ b/src/openbench/gui/pages/page_run_monitor.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import platform
 
+from PySide6.QtCore import QThread, Signal
 from PySide6.QtWidgets import QMessageBox, QFileDialog
 
 from openbench.gui.remote_python import quote_remote_path
@@ -57,6 +58,80 @@ def count_evaluation_tasks(config: dict, selected_variables: list[str]) -> int:
     return total
 
 
+class _RemoteDownloadCanceled(Exception):
+    """Internal sentinel for user-canceled remote folder downloads."""
+
+
+class RemoteFolderDownloadWorker(QThread):
+    """Download a remote output folder without blocking the GUI thread."""
+
+    progress_updated = Signal(int, int, str)
+    finished_signal = Signal(bool, bool, str, str)  # success, canceled, message, local_target
+
+    def __init__(self, ssh_manager, remote_dir: str, local_target: str, parent=None):
+        super().__init__(parent)
+        self._ssh_manager = ssh_manager
+        self._remote_dir = remote_dir
+        self._local_target = local_target
+        self._stop_requested = False
+
+    def stop(self):
+        self._stop_requested = True
+
+    def _raise_if_canceled(self):
+        if self._stop_requested:
+            raise _RemoteDownloadCanceled()
+
+    def run(self):
+        try:
+            self._raise_if_canceled()
+            stdout, stderr, exit_code = self._ssh_manager.execute(
+                f"find {quote_remote_path(self._remote_dir)} -type f",
+                timeout=60,
+                should_abort=lambda: self._stop_requested,
+            )
+            if exit_code != 0:
+                self.finished_signal.emit(False, False, f"Failed to list remote files:\n{stderr}", self._local_target)
+                return
+
+            files = [f.strip() for f in stdout.strip().split("\n") if f.strip()]
+            if not files:
+                self.finished_signal.emit(True, False, "No files found in the remote directory.", self._local_target)
+                return
+
+            total_files = len(files)
+            sftp = self._ssh_manager.open_sftp()
+            for index, remote_file in enumerate(files):
+                self._raise_if_canceled()
+                rel_path = PageRunMonitor._remote_download_relpath(remote_file, self._remote_dir)
+                if rel_path is None:
+                    raise ValueError(f"Remote file is outside the requested directory: {remote_file}")
+                local_file = os.path.join(self._local_target, rel_path)
+                os.makedirs(os.path.dirname(local_file), exist_ok=True)
+                self.progress_updated.emit(index, total_files, rel_path)
+
+                def _copy_progress(_transferred, _total):
+                    self._raise_if_canceled()
+
+                try:
+                    sftp.get(remote_file, local_file, callback=_copy_progress)
+                except TypeError:
+                    # Some tests/fakes implement a minimal Paramiko-like get()
+                    # without callback support. Cancellation remains checked
+                    # between files in that compatibility path.
+                    sftp.get(remote_file, local_file)
+                self.progress_updated.emit(index + 1, total_files, rel_path)
+
+            self.finished_signal.emit(True, False, "Download complete", self._local_target)
+        except _RemoteDownloadCanceled:
+            self.finished_signal.emit(False, True, "Download canceled", self._local_target)
+        except Exception as exc:
+            if self._stop_requested:
+                self.finished_signal.emit(False, True, "Download canceled", self._local_target)
+            else:
+                self.finished_signal.emit(False, False, f"Failed to download files:\n{exc}", self._local_target)
+
+
 class PageRunMonitor(BasePage):
     """Run and Monitor page."""
 
@@ -66,6 +141,7 @@ class PageRunMonitor(BasePage):
 
     def __init__(self, controller, parent=None):
         self._runner = None
+        self._download_worker = None
         self._last_ssh_manager_error = ""
         super().__init__(controller, parent)
         # Remove the trailing stretch added by BasePage so dashboard can expand
@@ -107,6 +183,17 @@ class PageRunMonitor(BasePage):
         eval_items = config.get("evaluation_items", {})
         selected = [k for k, v in eval_items.items() if v]
         general = config.get("general", {})
+
+        from openbench.remote.storage import RemoteStorage
+
+        is_remote = general.get("execution_mode") == "remote"
+        if is_remote and not isinstance(self.controller.storage, RemoteStorage):
+            QMessageBox.critical(
+                self,
+                "Remote Connection Required",
+                "Remote execution is selected, but no remote project connection is active.",
+            )
+            return
 
         tasks = []
         for item in selected:
@@ -170,12 +257,12 @@ class PageRunMonitor(BasePage):
         comparisons = config.get("comparisons", {})
         num_comparisons = len([k for k, v in comparisons.items() if v])
 
-        # Check if in remote mode using storage type
-        from openbench.remote.storage import RemoteStorage
-
-        is_remote = isinstance(self.controller.storage, RemoteStorage)
+        # Count statistics independently from comparison tasks.
+        statistics = config.get("statistics", {})
+        num_statistics = len([k for k, v in statistics.items() if v])
 
         if is_remote:
+            self.dashboard.show_resource_unavailable("Resources (remote not monitored)")
             # Remote execution mode
             self._runner = self._create_remote_runner(config_path, general)
             if self._runner is None:
@@ -187,6 +274,7 @@ class PageRunMonitor(BasePage):
             # Local execution mode (default)
             python_path = general.get("python_path", "")
             self._runner = EvaluationRunner(config_path, python_path, self)
+            self.dashboard.monitor_process_tree(lambda: self._runner.get_process_pid() if self._runner else None)
 
         # Configure task counts for accurate progress tracking
         self._runner.set_task_counts(
@@ -201,6 +289,7 @@ class PageRunMonitor(BasePage):
             do_comparison=general.get("comparison", False),
             do_statistics=general.get("statistics", False),
             num_evaluation_tasks=count_evaluation_tasks(config, selected),
+            num_statistics=num_statistics,
         )
 
         # Connect signals - same interface for both runners
@@ -312,6 +401,10 @@ class PageRunMonitor(BasePage):
                 self._last_ssh_manager_error = "remote config widget is not available"
                 return None
 
+            if not remote_config_widget.is_connected():
+                self._last_ssh_manager_error = "configured remote execution target is not connected"
+                return None
+
             # Get the SSH manager from the remote config widget
             return remote_config_widget.get_ssh_manager()
         except Exception as exc:
@@ -321,7 +414,7 @@ class PageRunMonitor(BasePage):
 
     def _on_progress(self, progress):
         """Handle progress update."""
-        self.dashboard.set_progress(int(progress.progress))
+        self.dashboard.set_progress(progress.progress)
 
         # Update task statuses based on progress
         if progress.current_variable and progress.current_stage:
@@ -341,6 +434,9 @@ class PageRunMonitor(BasePage):
             self.dashboard.set_progress(100)
             QMessageBox.information(self, "Complete", message)
         else:
+            if message == "Stopped by user":
+                QMessageBox.information(self, "Stopped", "Evaluation stopped by user.")
+                return
             # Check if it's an OpenBench not found error
             if "Could not find OpenBench" in message:
                 self._prompt_openbench_location()
@@ -546,74 +642,58 @@ class PageRunMonitor(BasePage):
         folder_name = os.path.basename(remote_dir.rstrip("/"))
         local_target = os.path.join(local_dir, folder_name)
 
-        # Create progress dialog
         progress = QProgressDialog("Downloading files from remote server...", "Cancel", 0, 100, parent_dialog)
         progress.setWindowTitle("Downloading")
         progress.setWindowModality(Qt.WindowModal)
         progress.setMinimumDuration(0)
         progress.setValue(0)
+        progress.show()
 
-        try:
-            # Get list of files to download
-            stdout, stderr, exit_code = execute_responsive(
-                ssh_manager, f"find {quote_remote_path(remote_dir)} -type f", timeout=60
-            )
-            if exit_code != 0:
-                QMessageBox.warning(parent_dialog, "Error", f"Failed to list remote files:\n{stderr}")
+        worker = RemoteFolderDownloadWorker(ssh_manager, remote_dir, local_target)
+        self._download_worker = worker
+        progress.canceled.connect(worker.stop)
+        worker.finished.connect(worker.deleteLater)
+
+        def _on_progress(done: int, total: int, rel_path: str):
+            import shiboken6
+
+            if not shiboken6.isValid(progress):
                 return
+            progress.setMaximum(max(1, total))
+            progress.setLabelText(f"Downloading: {rel_path}")
+            progress.setValue(done)
 
-            files = [f.strip() for f in stdout.strip().split("\n") if f.strip()]
-            if not files:
-                QMessageBox.information(parent_dialog, "Empty Directory", "No files found in the remote directory.")
+        def _on_finished(success: bool, canceled: bool, message: str, target: str):
+            if getattr(self, "_download_worker", None) is worker:
+                self._download_worker = None
+            import shiboken6
+
+            if not shiboken6.isValid(progress) or not shiboken6.isValid(parent_dialog):
                 return
+            progress.close()
+            if canceled:
+                QMessageBox.information(parent_dialog, "Download Canceled", "Remote folder download was canceled.")
+                return
+            if not success:
+                QMessageBox.warning(parent_dialog, "Download Error", message)
+                return
+            if message.startswith("No files"):
+                QMessageBox.information(parent_dialog, "Empty Directory", message)
+                return
+            QMessageBox.information(parent_dialog, "Download Complete", f"Successfully downloaded files to:\n{target}")
+            try:
+                if platform.system() == "Darwin":
+                    subprocess.run(["open", target], check=False)
+                elif platform.system() == "Windows":
+                    os.startfile(target)
+                else:
+                    subprocess.run(["xdg-open", target], check=False)
+            except Exception as e:
+                logger.debug("Failed to open downloaded folder: %s", e)
 
-            total_files = len(files)
-            progress.setMaximum(total_files)
-
-            # Open SFTP connection. The sftp client is owned by SSHManager
-            # (cached, reused), so we must NOT close it here.
-            sftp = ssh_manager.open_sftp()
-            for i, remote_file in enumerate(files):
-                if progress.wasCanceled():
-                    break
-
-                # Calculate relative path, validating that remote output did
-                # not escape the requested directory before writing locally.
-                rel_path = self._remote_download_relpath(remote_file, remote_dir)
-                if rel_path is None:
-                    raise ValueError(f"Remote file is outside the requested directory: {remote_file}")
-                local_file = os.path.join(local_target, rel_path)
-
-                # Create local directory if needed
-                local_file_dir = os.path.dirname(local_file)
-                os.makedirs(local_file_dir, exist_ok=True)
-
-                # Download file
-                progress.setLabelText(f"Downloading: {rel_path}")
-                sftp.get(remote_file, local_file)
-
-                progress.setValue(i + 1)
-
-            if not progress.wasCanceled():
-                QMessageBox.information(
-                    parent_dialog,
-                    "Download Complete",
-                    f"Successfully downloaded {total_files} files to:\n{local_target}",
-                )
-
-                # Open the downloaded folder
-                try:
-                    if platform.system() == "Darwin":
-                        subprocess.run(["open", local_target], check=False)
-                    elif platform.system() == "Windows":
-                        os.startfile(local_target)
-                    else:
-                        subprocess.run(["xdg-open", local_target], check=False)
-                except Exception as e:
-                    logger.debug("Failed to open downloaded folder: %s", e)
-
-        except Exception as e:
-            QMessageBox.warning(parent_dialog, "Download Error", f"Failed to download files:\n{str(e)}")
+        worker.progress_updated.connect(_on_progress)
+        worker.finished_signal.connect(_on_finished)
+        worker.start()
 
     def load_from_config(self):
         """Called when page becomes visible."""

--- a/src/openbench/gui/pages/page_runtime.py
+++ b/src/openbench/gui/pages/page_runtime.py
@@ -40,7 +40,7 @@ class _LocalInstallWorker(QThread):
 
     def __init__(self, cmd, parent=None):
         super().__init__(parent)
-        self._cmd = cmd
+        self._cmds = cmd if cmd and isinstance(cmd[0], list) else [cmd]
         self._process = None
 
     def stop(self) -> None:
@@ -58,16 +58,26 @@ class _LocalInstallWorker(QThread):
         import subprocess
 
         try:
-            self._process = subprocess.Popen(
-                self._cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
-            )
-            for line in self._process.stdout:
+            for cmd in self._cmds:
                 if self.isInterruptionRequested():
-                    self._process.terminate()
-                    break
-                self.line.emit(line.rstrip())
-            self._process.wait()
-            self.finished_with_result.emit(self._process.returncode)
+                    self.finished_with_result.emit(1)
+                    return
+                self.line.emit(f"$ {' '.join(cmd)}")
+                self._process = subprocess.Popen(
+                    cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
+                )
+                for line in self._process.stdout:
+                    if self.isInterruptionRequested():
+                        self._process.terminate()
+                        break
+                    self.line.emit(line.rstrip())
+                self._process.wait()
+                returncode = self._process.returncode
+                self._process = None
+                if returncode != 0:
+                    self.finished_with_result.emit(returncode)
+                    return
+            self.finished_with_result.emit(0)
         except Exception as exc:
             self.failed.emit(f"{type(exc).__name__}: {exc}")
         finally:
@@ -78,6 +88,16 @@ from openbench.gui.widgets.no_scroll_widgets import NoScrollSpinBox, NoScrollCom
 from openbench.gui.path_utils import is_cross_platform_path
 
 logger = logging.getLogger(__name__)
+
+
+def _conda_python_path(env_path: str) -> str:
+    """Return the Python executable path for a conda environment path."""
+    env_path = (env_path or "").strip()
+    if not env_path:
+        return ""
+    if sys.platform == "win32":
+        return os.path.join(env_path, "python.exe")
+    return os.path.join(env_path, "bin", "python")
 
 
 def get_default_runtime_settings_path() -> str:
@@ -249,15 +269,13 @@ class PageRuntime(BasePage):
             # Reset CPU available label to local
             self.cpu_available_label.setText(f"(Available: {os.cpu_count() or 'N/A'})")
 
-            # Disconnect remote connection when switching to local mode
-            if self.remote_config_widget.is_connected():
+            # Flush pending remote writes before disconnecting the SSH session.
+            self._switch_to_local_storage()
+            if self.remote_config_widget.get_ssh_manager() is not None:
                 self.remote_config_widget.disconnect()
 
             # Clear remote config when switching to local
             self.remote_config_widget.reset_to_defaults()
-
-            # Switch to local storage
-            self._switch_to_local_storage()
         else:
             self.parallel_group.hide()  # Parallel Processing is inside RemoteConfigWidget
             self.local_env_group.hide()
@@ -344,11 +362,66 @@ class PageRuntime(BasePage):
 
     def _on_conda_changed(self, text):
         """Handle conda environment change."""
+        self._sync_python_combo_to_conda_selection()
         self._on_config_changed()
+
+    def _add_python_choice(self, path: str, label: str | None = None) -> None:
+        """Add a Python interpreter option while storing the real path in itemData."""
+        path = (path or "").strip()
+        if not path:
+            return
+        display = f"{path} ({label})" if label else path
+        self.python_combo.addItem(display, path)
+
+    def _python_path_from_combo(self) -> str:
+        """Read the selected/typed Python path without splitting on spaces."""
+        text = self.python_combo.currentText().strip()
+        idx = self.python_combo.currentIndex()
+        if idx >= 0 and text == self.python_combo.itemText(idx):
+            data = self.python_combo.currentData()
+            if isinstance(data, str) and data.strip():
+                return data.strip()
+
+        # Compatibility with older saved/display strings such as
+        # "C:\\Program Files\\Python\\python.exe (PATH)"; strip only the
+        # display suffix rather than splitting the path itself on spaces.
+        if text.endswith(")") and " (" in text:
+            return text.rsplit(" (", 1)[0].strip()
+        return text
+
+    def _selected_conda_python_path(self) -> str:
+        """Return the Python executable implied by the selected conda env."""
+        if self.conda_combo.currentIndex() <= 0:
+            return ""
+        env_path = self.conda_combo.currentData()
+        if isinstance(env_path, str) and env_path.strip():
+            return _conda_python_path(env_path)
+        return ""
+
+    def _sync_python_combo_to_conda_selection(self) -> None:
+        """Make the conda selector authoritative for the saved local Python."""
+        python_path = self._selected_conda_python_path()
+        if not python_path:
+            return
+
+        self.python_combo.blockSignals(True)
+        try:
+            found = False
+            for i in range(self.python_combo.count()):
+                if self.python_combo.itemData(i) == python_path or self.python_combo.itemText(i) == python_path:
+                    self.python_combo.setCurrentIndex(i)
+                    found = True
+                    break
+            if not found:
+                self._add_python_choice(python_path, self.conda_combo.currentText())
+                self.python_combo.setCurrentIndex(self.python_combo.count() - 1)
+        finally:
+            self.python_combo.blockSignals(False)
 
     def _detect_python(self):
         """Auto-detect available Python interpreters."""
         detected = []
+        detected_paths = set()
         is_windows = sys.platform == "win32"
         user_home = os.path.expanduser("~")
 
@@ -360,7 +433,8 @@ class PageRuntime(BasePage):
             else:
                 conda_python = os.path.join(conda_prefix, "bin", "python")
             if os.path.exists(conda_python):
-                detected.append(f"{conda_python} (active conda)")
+                detected.append((conda_python, "active conda"))
+                detected_paths.add(conda_python)
 
         # PRIORITY 2: Check common conda/miniforge locations
         if is_windows:
@@ -379,30 +453,40 @@ class PageRuntime(BasePage):
             ]
 
         for path, label in conda_paths:
-            if os.path.exists(path) and path not in [d.split(" ")[0] for d in detected]:
-                detected.append(f"{path} ({label})")
+            if os.path.exists(path) and path not in detected_paths:
+                detected.append((path, label))
+                detected_paths.add(path)
 
         # PRIORITY 3: Check PATH
         python_names = ["python3", "python"] if not is_windows else ["python", "python3"]
         for name in python_names:
             path = shutil.which(name)
-            if path and path not in [d.split(" ")[0] for d in detected]:
+            if path and path not in detected_paths:
                 if path == "/usr/bin/python3":
-                    detected.append(f"{path} (system)")
+                    detected.append((path, "system"))
                 else:
-                    detected.append(f"{path} (PATH)")
+                    detected.append((path, "PATH"))
+                detected_paths.add(path)
 
         # Update combo box
         current_text = self.python_combo.currentText()
         self.python_combo.blockSignals(True)
         self.python_combo.clear()
 
-        for item in detected:
-            self.python_combo.addItem(item)
+        for path, label in detected:
+            self._add_python_choice(path, label)
 
         # Restore previous selection if valid
         if current_text:
-            idx = self.python_combo.findText(current_text)
+            current_path = (
+                current_text.rsplit(" (", 1)[0].strip() if current_text.endswith(")") else current_text.strip()
+            )
+            for idx in range(self.python_combo.count()):
+                if self.python_combo.itemText(idx) == current_text or self.python_combo.itemData(idx) == current_path:
+                    self.python_combo.setCurrentIndex(idx)
+                    break
+            else:
+                idx = -1
             if idx >= 0:
                 self.python_combo.setCurrentIndex(idx)
 
@@ -424,6 +508,26 @@ class PageRuntime(BasePage):
 
         if path:
             self.python_combo.setCurrentText(path)
+
+    def _build_local_install_commands(
+        self, install_path: str, repo_url: str, is_update: bool
+    ) -> tuple[list[list[str]], str]:
+        """Build git + editable pip install commands for local OpenBench setup."""
+        if is_update:
+            git_cmd = ["git", "-C", install_path, "pull", "--ff-only"]
+            starting = "Running git pull..."
+        else:
+            parent_dir = os.path.dirname(install_path)
+            if parent_dir and not os.path.exists(parent_dir):
+                os.makedirs(parent_dir, exist_ok=True)
+            git_cmd = ["git", "clone", "--progress", repo_url, install_path]
+            starting = f"Cloning from {repo_url}..."
+
+        python_exe = self._selected_conda_python_path() or self._python_path_from_combo()
+        if not python_exe:
+            python_exe = sys.executable
+        pip_cmd = [python_exe, "-m", "pip", "install", "-e", install_path]
+        return [git_cmd, pip_cmd], starting
 
     def _browse_openbench(self):
         """Browse for OpenBench installation directory."""
@@ -551,16 +655,9 @@ class PageRuntime(BasePage):
             if radio_ssh.isChecked():
                 repo_url = "git@github.com:zhongwangwei/OpenBench.git"
 
-        # Build the git command up front so failures surface before the dialog.
-        if is_update:
-            cmd = ["git", "-C", install_path, "pull", "--ff-only"]
-            starting = "Running git pull..."
-        else:
-            parent_dir = os.path.dirname(install_path)
-            if parent_dir and not os.path.exists(parent_dir):
-                os.makedirs(parent_dir, exist_ok=True)
-            cmd = ["git", "clone", "--progress", repo_url, install_path]
-            starting = f"Cloning from {repo_url}..."
+        # Build the git + editable install commands up front so failures
+        # surface before the dialog. Success is reported only after both pass.
+        commands, starting = self._build_local_install_commands(install_path, repo_url, is_update)
 
         # Progress dialog (Esc/close stays blocked until the worker finishes).
         progress_dialog = _InstallProgressDialog(self)
@@ -581,14 +678,13 @@ class PageRuntime(BasePage):
         close_btn.clicked.connect(progress_dialog.accept)
         progress_layout.addWidget(close_btn)
 
-        output_text.append(f"$ {' '.join(cmd)}\n")
         self.btn_install_openbench.setEnabled(False)
 
         def finish(returncode: int):
             if returncode == 0:
                 status_label.setText("✓ Installation successful!" if not is_update else "✓ Update successful!")
                 status_label.setStyleSheet("color: green; font-weight: bold;")
-                output_text.append("\n\nOpenBench installed successfully!")
+                output_text.append("\n\nOpenBench installed and registered in the selected Python environment.")
             else:
                 status_label.setText("✗ Installation failed!" if not is_update else "✗ Update failed!")
                 status_label.setStyleSheet("color: red; font-weight: bold;")
@@ -606,7 +702,7 @@ class PageRuntime(BasePage):
             progress_dialog.allow_close = True
             self._local_install_worker = None
 
-        worker = _LocalInstallWorker(cmd)
+        worker = _LocalInstallWorker(commands)
         self._local_install_worker = worker
         if not getattr(self, "_install_destroy_hooked", False):
             # Embedded pages don't get closeEvent on app quit; destroyed does fire.
@@ -644,7 +740,7 @@ class PageRuntime(BasePage):
     def _refresh_conda(self):
         """Refresh the list of available conda environments."""
 
-        current_python = self.python_combo.currentText().split(" ")[0]
+        current_python = self._python_path_from_combo()
         envs = self._get_conda_envs(current_python)
 
         current_env = self.conda_combo.currentText()
@@ -662,6 +758,7 @@ class PageRuntime(BasePage):
                 self.conda_combo.setCurrentIndex(idx)
 
         self.conda_combo.blockSignals(False)
+        self._sync_python_combo_to_conda_selection()
 
     def _get_conda_envs(self, python_path: str) -> list:
         """Get list of conda environments."""
@@ -745,7 +842,7 @@ class PageRuntime(BasePage):
             self.python_combo.blockSignals(True)
             found = False
             for i in range(self.python_combo.count()):
-                if self.python_combo.itemText(i).startswith(python_path):
+                if self.python_combo.itemData(i) == python_path or self.python_combo.itemText(i) == python_path:
                     self.python_combo.setCurrentIndex(i)
                     found = True
                     break
@@ -760,6 +857,7 @@ class PageRuntime(BasePage):
             idx = self.conda_combo.findText(conda_env)
             if idx >= 0:
                 self.conda_combo.setCurrentIndex(idx)
+                self._sync_python_combo_to_conda_selection()
             self.conda_combo.blockSignals(False)
 
         # Load local OpenBench path
@@ -782,11 +880,8 @@ class PageRuntime(BasePage):
         # Save execution mode
         general["execution_mode"] = "local" if self.radio_local.isChecked() else "remote"
 
-        # Save num_cores
-        general["num_cores"] = self.num_cores_spin.value()
-
         # Save Python path, conda env, and OpenBench path for local mode
-        general["python_path"] = self.python_combo.currentText().split(" ")[0]
+        general["python_path"] = self._selected_conda_python_path() or self._python_path_from_combo()
         general["conda_env"] = self.conda_combo.currentText() if self.conda_combo.currentIndex() > 0 else ""
         general["local_openbench_path"] = self.local_openbench_input.text().strip()
 
@@ -794,22 +889,20 @@ class PageRuntime(BasePage):
         if self.radio_remote.isChecked():
             remote_config = self.remote_config_widget.get_config()
             general["remote"] = remote_config
+            general["num_cores"] = int(remote_config.get("num_cores") or self.num_cores_spin.value())
+        else:
+            general["num_cores"] = self.num_cores_spin.value()
 
     def validate(self) -> bool:
         """Validate the page configuration."""
         if self.radio_remote.isChecked():
-            # Check if remote server is configured
             if not self.remote_config_widget.is_connected():
-                from PySide6.QtWidgets import QMessageBox
-
-                reply = QMessageBox.question(
+                QMessageBox.warning(
                     self,
-                    "Not Connected",
-                    "You haven't connected to the remote server yet.\n\nDo you want to continue anyway?",
-                    QMessageBox.Yes | QMessageBox.No,
-                    QMessageBox.No,
+                    "Remote Connection Required",
+                    "Connect to the configured remote execution target before continuing.",
                 )
-                return reply == QMessageBox.Yes
+                return False
         return True
 
     def get_remote_config_widget(self):
@@ -866,15 +959,18 @@ class PageRuntime(BasePage):
         """Collect current runtime settings into a dictionary."""
         settings = {
             "execution_mode": "local" if self.radio_local.isChecked() else "remote",
-            "num_cores": self.num_cores_spin.value(),
-            "python_path": self.python_combo.currentText().split(" ")[0],
+            "python_path": self._selected_conda_python_path() or self._python_path_from_combo(),
             "conda_env": self.conda_combo.currentText() if self.conda_combo.currentIndex() > 0 else "",
             "local_openbench_path": self.local_openbench_input.text().strip(),
         }
 
         # Include remote config if in remote mode
         if self.radio_remote.isChecked():
-            settings["remote"] = self.remote_config_widget.get_config()
+            remote_config = self.remote_config_widget.get_config()
+            settings["remote"] = remote_config
+            settings["num_cores"] = int(remote_config.get("num_cores") or self.num_cores_spin.value())
+        else:
+            settings["num_cores"] = self.num_cores_spin.value()
 
         return settings
 
@@ -896,7 +992,7 @@ class PageRuntime(BasePage):
             self.python_combo.blockSignals(True)
             found = False
             for i in range(self.python_combo.count()):
-                if self.python_combo.itemText(i).startswith(python_path):
+                if self.python_combo.itemData(i) == python_path or self.python_combo.itemText(i) == python_path:
                     self.python_combo.setCurrentIndex(i)
                     found = True
                     break
@@ -911,6 +1007,7 @@ class PageRuntime(BasePage):
             idx = self.conda_combo.findText(conda_env)
             if idx >= 0:
                 self.conda_combo.setCurrentIndex(idx)
+                self._sync_python_combo_to_conda_selection()
             self.conda_combo.blockSignals(False)
 
         # Apply local OpenBench path

--- a/src/openbench/gui/path_utils.py
+++ b/src/openbench/gui/path_utils.py
@@ -355,7 +355,13 @@ def get_remote_ssh_manager(controller):
 
     if not isinstance(controller.storage, RemoteStorage):
         return None
-    return controller.ssh_manager
+    manager = controller.ssh_manager
+    if manager is None or not getattr(manager, "is_connected", False):
+        return None
+    get_active_client = getattr(manager, "get_active_client", None)
+    if callable(get_active_client) and get_active_client() is None:
+        return None
+    return manager
 
 
 def _remote_directory_exists(ssh_manager, path: str) -> bool:

--- a/src/openbench/gui/progress_parser.py
+++ b/src/openbench/gui/progress_parser.py
@@ -32,6 +32,13 @@ def parse_progress_line(
     var = state.get("current_variable", "")
     stage = ""
 
+    state.setdefault("started_preprocess_tasks", set())
+    state.setdefault("completed_preprocess_tasks", set())
+    state.setdefault("completed_eval_tasks", set())
+    state.setdefault("completed_groupby_tasks", set())
+    state.setdefault("completed_comparison_tasks", set())
+    state.setdefault("completed_statistics_tasks", set())
+
     line_lower = line.lower()
 
     protocol_line = GUI_PROGRESS_PREFIX in line
@@ -104,17 +111,23 @@ def parse_progress_line(
         var = state["current_variable"]
         stage = "Evaluation"
 
+    statistics_done = re.search(r"\bcompleted\s+([^:]+?)\s+analysis\b", natural_line, re.IGNORECASE)
+    statistics_running = re.search(r"\brunning\s+([^:]+?)\s+analysis\b", natural_line, re.IGNORECASE)
+    if statistics_done or statistics_running:
+        state["current_statistic"] = (statistics_done or statistics_running).group(1).strip()
+        stage = "Statistics"
+
     # Detect stage
     if not stage and "evaluation" in natural_line_lower and "item" not in natural_line_lower:
         stage = "Evaluation"
-    elif "comparison" in natural_line_lower or "groupby" in natural_line_lower:
+    elif not stage and ("comparison" in natural_line_lower or "groupby" in natural_line_lower):
         stage = "Comparison"
         comparison_done = re.search(r"(?:done running|completed)\s+([\w-]+)\s+comparison", natural_line_lower)
         if comparison_done:
             state["completed_comparison_tasks"].add(comparison_done.group(1))
-    elif "statistic" in natural_line_lower:
+    elif not stage and "statistic" in natural_line_lower:
         stage = "Statistics"
-    elif "report" in natural_line_lower:
+    elif not stage and "report" in natural_line_lower:
         stage = "Report"
 
     # Detect task completions
@@ -130,20 +143,21 @@ def parse_progress_line(
         if groupby_type in natural_line_lower and (
             "complete" in natural_line_lower or "finished" in natural_line_lower or "done" in natural_line_lower
         ):
-            task_key = (state.get("current_variable", ""), groupby_type)
+            task_key = groupby_type
             if task_key not in state["completed_groupby_tasks"]:
                 state["completed_groupby_tasks"].add(task_key)
                 task_completed = True
 
     if stage == "Statistics" and ("completed" in line_lower or "finished" in line_lower):
-        comp_name = state.get("current_variable") or "comparison"
-        if comp_name not in state["completed_comparison_tasks"]:
-            state["completed_comparison_tasks"].add(comp_name)
+        stat_name = state.get("current_statistic") or "statistics"
+        if stat_name not in state["completed_statistics_tasks"]:
+            state["completed_statistics_tasks"].add(stat_name)
             task_completed = True
 
     # Calculate progress
     total_tasks = state.get("total_tasks", 0)
     num_comparisons = state.get("num_comparisons", 0)
+    num_statistics = state.get("num_statistics", 0)
     num_variables = state.get("num_variables", 0)
 
     P_INIT = constants["PROGRESS_INIT"]
@@ -163,13 +177,18 @@ def parse_progress_line(
             len(completed_eval_tasks)
             + len(state["completed_groupby_tasks"])
             + len(state["completed_comparison_tasks"])
+            + len(state["completed_statistics_tasks"])
             + 0.4 * len(preprocess_only)
             + 0.05 * len(preprocess_started_only)
         )
         task_progress = (total_completed / max(1, total_tasks)) * P_WORK
         current_progress = min(P_INIT + task_progress, P_MAX)
-    elif num_comparisons > 0 and len(state["completed_comparison_tasks"]) > 0:
-        comparison_progress = (len(state["completed_comparison_tasks"]) / max(1, num_comparisons)) * P_WORK
+    elif (num_comparisons + num_statistics) > 0 and (
+        len(state["completed_comparison_tasks"]) + len(state["completed_statistics_tasks"])
+    ) > 0:
+        post_completed = len(state["completed_comparison_tasks"]) + len(state["completed_statistics_tasks"])
+        post_total = num_comparisons + num_statistics
+        comparison_progress = (post_completed / max(1, post_total)) * P_WORK
         current_progress = min(P_INIT + comparison_progress, P_MAX)
     elif num_variables > 0:
         completed_vars = len(set(t[0] for t in state["completed_eval_tasks"] if t[0]))

--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -7,6 +7,7 @@ remotely using SSHManager for file transfer and command execution.
 """
 
 import os
+import json
 import re
 import shlex
 import threading
@@ -117,6 +118,8 @@ class RemoteRunner(QThread):
         self._do_evaluation = True
         self._do_comparison = False
         self._do_statistics = False
+        self._num_statistics = 0
+        self._last_progress = 0.0
 
         # Track completed items to avoid double counting
         self._started_preprocess_tasks = set()
@@ -124,6 +127,7 @@ class RemoteRunner(QThread):
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()
+        self._completed_statistics_tasks = set()
 
     def run(self):
         """Run the evaluation on the remote server."""
@@ -190,6 +194,9 @@ class RemoteRunner(QThread):
                 self._handle_stop()
                 return
 
+            if not self._apply_remote_num_cores_override():
+                return
+
             # Step 3: Execute OpenBench on remote server
             self._emit_progress(
                 RunnerStatus.RUNNING, self.PROGRESS_INIT, "Executing", "", "Running", "Starting OpenBench execution..."
@@ -203,10 +210,14 @@ class RemoteRunner(QThread):
                 )
                 self.finished_signal.emit(True, "Evaluation completed successfully")
             else:
-                if _looks_like_partial_completion([message]):
-                    self._emit_progress(RunnerStatus.PARTIAL, self.PROGRESS_MAX, "Partial", "", "", message)
+                if message == "Stopped by user":
+                    self._emit_progress(
+                        RunnerStatus.STOPPED, self._last_progress, "Stopped", "", "", "Evaluation stopped by user"
+                    )
+                elif _looks_like_partial_completion([message]):
+                    self._emit_progress(RunnerStatus.PARTIAL, self._last_progress, "Partial", "", "", message)
                 else:
-                    self._emit_progress(RunnerStatus.FAILED, self.PROGRESS_MAX, "Failed", "", "", message)
+                    self._emit_progress(RunnerStatus.FAILED, self._last_progress, "Failed", "", "", message)
                 self.finished_signal.emit(False, message)
 
         except SSHConnectionError as e:
@@ -341,6 +352,58 @@ class RemoteRunner(QThread):
         """Append the remote command to unexpected execution errors."""
         return f"{message}\n\nCommand: {command}"
 
+    def _apply_remote_num_cores_override(self) -> bool:
+        """Persist the remote runtime core count into the uploaded config."""
+        raw_num_cores = self._remote_config.get("num_cores")
+        if raw_num_cores in (None, ""):
+            return True
+        try:
+            num_cores = int(raw_num_cores)
+        except (TypeError, ValueError):
+            self.finished_signal.emit(False, f"Invalid remote CPU core count: {raw_num_cores!r}")
+            return False
+        if num_cores <= 0:
+            self.finished_signal.emit(False, f"Invalid remote CPU core count: {num_cores}")
+            return False
+        if not self._remote_config_path:
+            return True
+
+        try:
+            from openbench.gui.remote_python import build_remote_python_command
+
+            script = f"""
+import pathlib
+import yaml
+
+path = pathlib.Path({json.dumps(self._remote_config_path)})
+data = yaml.safe_load(path.read_text(encoding="utf-8")) or {{}}
+if not isinstance(data, dict):
+    raise TypeError("OpenBench config root must be a mapping")
+project = data.setdefault("project", {{}})
+if not isinstance(project, dict):
+    raise TypeError("OpenBench config project section must be a mapping")
+project["num_cores"] = {num_cores}
+general = data.get("general")
+if isinstance(general, dict):
+    general["num_cores"] = {num_cores}
+path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+"""
+            command = build_remote_python_command(
+                script,
+                python_path=self._remote_config.get("python_path", "python3"),
+                conda_env=self._remote_config.get("conda_env", ""),
+            )
+            stdout, stderr, exit_code = self._ssh_manager.execute(command, timeout=30)
+            if exit_code != 0:
+                detail = stderr or stdout or "unknown error"
+                self.finished_signal.emit(False, f"Failed to apply remote CPU core count to config: {detail}")
+                return False
+            self.log_message.emit(f"Using {num_cores} CPU cores on remote server.")
+            return True
+        except Exception as exc:
+            self.finished_signal.emit(False, f"Failed to apply remote CPU core count to config: {exc}")
+            return False
+
     def _execute_remote_openbench(self) -> tuple:
         """Execute OpenBench on the remote server.
 
@@ -366,7 +429,7 @@ class RemoteRunner(QThread):
             # code. We need to capture the StopIteration.value to know
             # whether the remote process succeeded; iterating with `for`
             # discards the return value, so drive the generator manually.
-            stream = self._ssh_manager.execute_stream(cmd)
+            stream = self._ssh_manager.execute_stream(cmd, should_abort=self._is_stop_requested)
             exit_code = 0
             stopped_by_user = False
             try:
@@ -418,6 +481,9 @@ class RemoteRunner(QThread):
             return (False, message)
 
         except SSHConnectionError as e:
+            if self._is_stop_requested():
+                self._kill_remote_process()
+                return (False, "Stopped by user")
             return (False, self._format_command_context(f"SSH error while running remote command: {e}", cmd))
         except Exception as e:
             return (False, self._format_command_context(f"Execution error while running remote command: {e}", cmd))
@@ -469,8 +535,10 @@ class RemoteRunner(QThread):
             "completed_eval_tasks": self._completed_eval_tasks,
             "completed_groupby_tasks": self._completed_groupby_tasks,
             "completed_comparison_tasks": self._completed_comparison_tasks,
+            "completed_statistics_tasks": self._completed_statistics_tasks,
             "total_tasks": self._total_tasks,
             "num_comparisons": self._num_comparisons,
+            "num_statistics": self._num_statistics,
             "num_variables": self._num_variables,
         }
         constants = {
@@ -502,6 +570,7 @@ class RemoteRunner(QThread):
         do_comparison: bool = False,
         do_statistics: bool = False,
         num_evaluation_tasks: int | None = None,
+        num_statistics: int = 0,
     ):
         """Set detailed task counts for accurate progress calculation.
 
@@ -517,6 +586,7 @@ class RemoteRunner(QThread):
         self._do_evaluation = do_evaluation
         self._do_comparison = do_comparison
         self._do_statistics = do_statistics
+        self._num_statistics = max(0, int(num_statistics or 0))
 
         # Calculate total tasks
         self._total_tasks = 0
@@ -532,8 +602,8 @@ class RemoteRunner(QThread):
         if num_groupby > 0:
             self._total_tasks += num_groupby
 
-        if do_statistics and num_comparisons > 0:
-            self._total_tasks += num_comparisons
+        if do_statistics:
+            self._total_tasks += self._num_statistics
 
         self._total_tasks = max(1, self._total_tasks)
 
@@ -544,9 +614,11 @@ class RemoteRunner(QThread):
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()
+        self._completed_statistics_tasks = set()
 
     def _emit_progress(self, status: RunnerStatus, progress: float, task: str, variable: str, stage: str, message: str):
         """Emit progress signal."""
+        self._last_progress = progress
         self.progress_updated.emit(
             RunnerProgress(
                 status=status,

--- a/src/openbench/gui/runner.py
+++ b/src/openbench/gui/runner.py
@@ -94,13 +94,16 @@ class EvaluationRunner(QThread):
         self._do_evaluation = True
         self._do_comparison = False
         self._do_statistics = False
+        self._num_statistics = 0
+        self._last_progress = 0.0
 
         # Track completed items to avoid double counting
         self._started_preprocess_tasks = set()  # (var, ref, sim) tuples
         self._completed_preprocess_tasks = set()  # (var, ref, sim) tuples
         self._completed_eval_tasks = set()  # (var, ref, sim) tuples
-        self._completed_groupby_tasks = set()  # (var, groupby_type) tuples
+        self._completed_groupby_tasks = set()  # groupby type names
         self._completed_comparison_tasks = set()  # comparison names
+        self._completed_statistics_tasks = set()  # statistics names
 
     @staticmethod
     def _format_failure_with_tail(message: str, output_tail) -> str:
@@ -116,6 +119,18 @@ class EvaluationRunner(QThread):
         if not cmd:
             return message
         return f"{message}\n\nCommand: {' '.join(cmd)}"
+
+    def get_process_pid(self) -> int | None:
+        """Return the active OpenBench subprocess pid, if one is running."""
+        process = self._process
+        if process is None:
+            return None
+        try:
+            if process.poll() is not None:
+                return None
+            return getattr(process, "pid", None)
+        except Exception:
+            return None
 
     def _cleanup_process(self):
         """Safely cleanup the subprocess. Idempotent; called from the
@@ -199,6 +214,7 @@ class EvaluationRunner(QThread):
                     self._completed_eval_tasks.clear()
                     self._completed_groupby_tasks.clear()
                     self._completed_comparison_tasks.clear()
+                    self._completed_statistics_tasks.clear()
                     self._emit_progress(
                         RunnerStatus.RUNNING,
                         0,
@@ -417,8 +433,10 @@ class EvaluationRunner(QThread):
             "completed_eval_tasks": self._completed_eval_tasks,
             "completed_groupby_tasks": self._completed_groupby_tasks,
             "completed_comparison_tasks": self._completed_comparison_tasks,
+            "completed_statistics_tasks": self._completed_statistics_tasks,
             "total_tasks": self._total_tasks,
             "num_comparisons": self._num_comparisons,
+            "num_statistics": self._num_statistics,
             "num_variables": self._num_variables,
         }
         constants = {
@@ -450,14 +468,16 @@ class EvaluationRunner(QThread):
         do_comparison: bool = False,
         do_statistics: bool = False,
         num_evaluation_tasks: int | None = None,
+        num_statistics: int = 0,
     ):
         """
         Set detailed task counts for accurate progress calculation.
 
         Total tasks formula:
         - Evaluation: variables × ref_sources × sim_sources
-        - Groupby: variables × groupby_count × (metrics + scores)
+        - Groupby: one task per enabled global groupby phase
         - Comparisons: num_comparisons
+        - Statistics: num_statistics
 
         Args:
             num_variables: Number of evaluation variables (e.g., GPP, ET, etc.)
@@ -481,6 +501,7 @@ class EvaluationRunner(QThread):
         self._do_evaluation = do_evaluation
         self._do_comparison = do_comparison
         self._do_statistics = do_statistics
+        self._num_statistics = max(0, int(num_statistics or 0))
 
         # Calculate total tasks
         self._total_tasks = 0
@@ -496,8 +517,8 @@ class EvaluationRunner(QThread):
         if num_groupby > 0:
             self._total_tasks += num_groupby
 
-        if do_statistics and num_comparisons > 0:
-            self._total_tasks += num_comparisons
+        if do_statistics:
+            self._total_tasks += self._num_statistics
 
         # Ensure at least 1 task
         self._total_tasks = max(1, self._total_tasks)
@@ -509,9 +530,11 @@ class EvaluationRunner(QThread):
         self._completed_eval_tasks = set()
         self._completed_groupby_tasks = set()
         self._completed_comparison_tasks = set()
+        self._completed_statistics_tasks = set()
 
     def _emit_progress(self, status: RunnerStatus, progress: float, task: str, variable: str, stage: str, message: str):
         """Emit progress signal."""
+        self._last_progress = progress
         self.progress_updated.emit(
             RunnerProgress(
                 status=status,

--- a/src/openbench/gui/widgets/checkbox_group.py
+++ b/src/openbench/gui/widgets/checkbox_group.py
@@ -167,11 +167,10 @@ class CheckboxGroup(QWidget):
 
     def set_selection(self, selection: Dict[str, bool]):
         """Set selection state."""
-        for item_id, checked in selection.items():
-            if item_id in self._checkboxes:
-                self._checkboxes[item_id].blockSignals(True)
-                self._checkboxes[item_id].setChecked(checked)
-                self._checkboxes[item_id].blockSignals(False)
+        for item_id, cb in self._checkboxes.items():
+            cb.blockSignals(True)
+            cb.setChecked(bool(selection.get(item_id, False)))
+            cb.blockSignals(False)
         self._update_count()
 
     def get_selected_items(self) -> List[str]:

--- a/src/openbench/gui/widgets/progress_dashboard.py
+++ b/src/openbench/gui/widgets/progress_dashboard.py
@@ -3,7 +3,7 @@
 Progress dashboard widget for displaying evaluation progress.
 """
 
-from typing import List, Optional
+from typing import Callable, List, Optional
 from dataclasses import dataclass
 from enum import Enum
 
@@ -48,6 +48,9 @@ class ProgressDashboard(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._tasks: List[TaskInfo] = []
+        self._progress_value = 0.0
+        self._resource_mode = "system"
+        self._resource_pid_provider: Optional[Callable[[], int | None]] = None
         self._setup_ui()
 
         # Timer for updating resource usage
@@ -72,7 +75,7 @@ class ProgressDashboard(QWidget):
         # Progress bar
         self.progress_bar = QProgressBar()
         self.progress_bar.setMinimum(0)
-        self.progress_bar.setMaximum(100)
+        self.progress_bar.setMaximum(1000)
         self.progress_bar.setValue(0)
         self.progress_bar.setTextVisible(True)
         self.progress_bar.setFixedHeight(20)
@@ -92,8 +95,8 @@ class ProgressDashboard(QWidget):
         top_row.addWidget(progress_group, 3)
 
         # Resource usage section
-        resource_group = QGroupBox("Resources")
-        resource_layout = QHBoxLayout(resource_group)
+        self.resource_group = QGroupBox("Resources")
+        resource_layout = QHBoxLayout(self.resource_group)
         resource_layout.setSpacing(15)
 
         # CPU
@@ -103,7 +106,7 @@ class ProgressDashboard(QWidget):
         self.cpu_bar.setFixedWidth(80)
         resource_layout.addWidget(self.cpu_bar)
         self.cpu_label = QLabel("0%")
-        self.cpu_label.setFixedWidth(35)
+        self.cpu_label.setFixedWidth(65)
         resource_layout.addWidget(self.cpu_label)
 
         # Memory
@@ -113,10 +116,10 @@ class ProgressDashboard(QWidget):
         self.mem_bar.setFixedWidth(80)
         resource_layout.addWidget(self.mem_bar)
         self.mem_label = QLabel("0%")
-        self.mem_label.setFixedWidth(35)
+        self.mem_label.setFixedWidth(65)
         resource_layout.addWidget(self.mem_label)
 
-        top_row.addWidget(resource_group, 2)
+        top_row.addWidget(self.resource_group, 2)
 
         layout.addLayout(top_row)
 
@@ -169,11 +172,16 @@ class ProgressDashboard(QWidget):
                 break
         self._update_overall_progress()
 
-    def set_progress(self, value: int, eta_seconds: Optional[int] = None):
-        """Set overall progress."""
-        value = max(0, min(100, int(value)))
-        self.progress_bar.setValue(value)
-        self.progress_label.setText(f"{value}%")
+    def set_progress(self, value: float, eta_seconds: Optional[int] = None):
+        """Set overall progress with one-decimal precision for large task sets."""
+        value = max(0.0, min(100.0, float(value)))
+        self._progress_value = value
+        self.progress_bar.setValue(int(round(value * 10)))
+        if abs(value - round(value)) < 0.05:
+            label = f"{int(round(value))}%"
+        else:
+            label = f"{value:.1f}%"
+        self.progress_label.setText(label)
 
         if eta_seconds is not None:
             if eta_seconds < 60:
@@ -200,14 +208,103 @@ class ProgressDashboard(QWidget):
 
         completed = sum(1 for t in self._tasks if t.status == TaskStatus.COMPLETED)
         total = len(self._tasks)
-        progress = int(completed / total * 100)
-        if progress >= self.progress_bar.value():
+        progress = completed / total * 100
+        if progress >= self._progress_value:
             self.set_progress(progress)
+
+    def monitor_system_resources(self):
+        """Show host-wide resources (legacy/default standalone behavior)."""
+        self._resource_mode = "system"
+        self._resource_pid_provider = None
+        self.resource_group.setTitle("Resources")
+
+    def monitor_process_tree(self, pid_provider: Callable[[], int | None]):
+        """Show resources used by the local OpenBench subprocess tree."""
+        self._resource_mode = "process"
+        self._resource_pid_provider = pid_provider
+        self.resource_group.setTitle("Resources (OpenBench local)")
+
+    def show_resource_unavailable(self, title: str = "Resources (remote N/A)"):
+        """Make resource labels explicit when the GUI is not measuring the run host."""
+        self._resource_mode = "unavailable"
+        self._resource_pid_provider = None
+        self.resource_group.setTitle(title)
+        self._set_resource_labels_unavailable()
+
+    def _set_resource_labels_unavailable(self):
+        self.cpu_bar.setValue(0)
+        self.mem_bar.setValue(0)
+        self.cpu_label.setText("N/A")
+        self.mem_label.setText("N/A")
+
+    @staticmethod
+    def _psutil_process_errors(psutil):
+        return tuple(
+            exc
+            for exc in (
+                getattr(psutil, "NoSuchProcess", None),
+                getattr(psutil, "AccessDenied", None),
+                getattr(psutil, "ZombieProcess", None),
+            )
+            if exc is not None
+        ) or (Exception,)
+
+    def _update_process_tree_usage(self, psutil):
+        provider = self._resource_pid_provider
+        pid = provider() if provider is not None else None
+        if not pid:
+            self._set_resource_labels_unavailable()
+            return
+
+        errors = self._psutil_process_errors(psutil)
+        try:
+            root = psutil.Process(pid)
+            processes = [root] + list(root.children(recursive=True))
+        except errors:
+            self._set_resource_labels_unavailable()
+            return
+
+        cpu_percent = 0.0
+        rss_bytes = 0
+        for process in processes:
+            try:
+                cpu_percent += float(process.cpu_percent(interval=None))
+                rss_bytes += int(process.memory_info().rss)
+            except errors + (OSError, AttributeError, TypeError, ValueError):
+                continue
+
+        # psutil's per-process percentage can exceed 100 on multi-core hosts.
+        # Normalize it to a whole-machine 0..100 scale to match the progress bar.
+        try:
+            logical_cpus = max(1, int(psutil.cpu_count() or 1))
+        except (AttributeError, TypeError, ValueError):
+            logical_cpus = 1
+        cpu_percent /= logical_cpus
+
+        try:
+            total_memory = int(psutil.virtual_memory().total)
+            mem_percent = (rss_bytes / total_memory * 100) if total_memory > 0 else 0.0
+        except (OSError, AttributeError, TypeError, ValueError):
+            mem_percent = 0.0
+
+        cpu_value = max(0, min(100, int(round(cpu_percent))))
+        mem_value = max(0, min(100, int(round(mem_percent))))
+        self.cpu_bar.setValue(cpu_value)
+        self.mem_bar.setValue(mem_value)
+        self.cpu_label.setText(f"{cpu_value}%")
+        self.mem_label.setText(f"{mem_value}%")
 
     def _update_resource_usage(self):
         """Update resource usage display."""
+        if self._resource_mode == "unavailable":
+            self._set_resource_labels_unavailable()
+            return
         try:
             import psutil
+
+            if self._resource_mode == "process":
+                self._update_process_tree_usage(psutil)
+                return
 
             cpu_percent = int(psutil.cpu_percent())
             self.cpu_bar.setValue(cpu_percent)
@@ -218,10 +315,7 @@ class ProgressDashboard(QWidget):
             self.mem_bar.setValue(mem_percent)
             self.mem_label.setText(f"{mem_percent}%")
         except (ImportError, AttributeError, OSError):
-            self.cpu_bar.setValue(0)
-            self.mem_bar.setValue(0)
-            self.cpu_label.setText("N/A")
-            self.mem_label.setText("N/A")
+            self._set_resource_labels_unavailable()
 
     def start_monitoring(self):
         """Start resource monitoring."""
@@ -235,6 +329,7 @@ class ProgressDashboard(QWidget):
         """Reset dashboard to initial state."""
         self._tasks.clear()
         self.log_output.clear()
+        self.monitor_system_resources()
         self.set_progress(0)
         self.cpu_bar.setValue(0)
         self.mem_bar.setValue(0)

--- a/src/openbench/gui/widgets/remote_config.py
+++ b/src/openbench/gui/widgets/remote_config.py
@@ -116,7 +116,7 @@ def parse_ssh_config() -> List[Dict[str, str]]:
 
         try:
             with open(config_path, "r", encoding="utf-8") as f:
-                current_host = None
+                current_hosts = []
 
                 for line in f:
                     line = line.strip()
@@ -134,23 +134,36 @@ def parse_ssh_config() -> List[Dict[str, str]]:
                     value = match.group(2).strip()
 
                     if key == "host":
-                        # Skip wildcard hosts
-                        if "*" in value or "?" in value:
-                            current_host = None
-                            continue
-                        # New host block
-                        current_host = {"name": value, "hostname": "", "user": "", "port": "22", "identity_file": ""}
-                        hosts.append(current_host)
-                    elif current_host is not None:
-                        if key == "hostname":
-                            current_host["hostname"] = value
-                        elif key == "user":
-                            current_host["user"] = value
-                        elif key == "port":
-                            current_host["port"] = value
-                        elif key == "identityfile":
-                            # Expand ~ in path
-                            current_host["identity_file"] = os.path.expanduser(value)
+                        current_hosts = []
+                        try:
+                            aliases = shlex.split(value)
+                        except ValueError:
+                            aliases = value.split()
+                        for alias in aliases:
+                            # OpenSSH lets one Host line define multiple aliases.
+                            # Wildcards are templates, not directly-connectable menu entries.
+                            if "*" in alias or "?" in alias:
+                                continue
+                            current_host = {
+                                "name": alias,
+                                "hostname": "",
+                                "user": "",
+                                "port": "22",
+                                "identity_file": "",
+                            }
+                            hosts.append(current_host)
+                            current_hosts.append(current_host)
+                    elif current_hosts:
+                        for current_host in current_hosts:
+                            if key == "hostname":
+                                current_host["hostname"] = value
+                            elif key == "user":
+                                current_host["user"] = value
+                            elif key == "port":
+                                current_host["port"] = value
+                            elif key == "identityfile":
+                                # Expand ~ in path
+                                current_host["identity_file"] = os.path.expanduser(value)
         except Exception:
             continue
 
@@ -968,6 +981,22 @@ class RemoteConfigWidget(QWidget):
         self.node_key_widget.setVisible(self.radio_node_key.isChecked())
         self._on_config_changed()
 
+    def _node_auth_type(self) -> str:
+        """Return the selected compute-node authentication mode."""
+        if self.radio_node_password.isChecked():
+            return "password"
+        if self.radio_node_key.isChecked():
+            return "key"
+        return "none"
+
+    def _node_credentials(self) -> tuple[Optional[str], Optional[str]]:
+        """Return password/key-file values for the selected compute-node auth."""
+        if self.radio_node_password.isChecked():
+            return self.node_password_input.text(), None
+        if self.radio_node_key.isChecked():
+            return None, os.path.expanduser(self.node_key_input.text().strip())
+        return None, None
+
     def _browse_node_key(self):
         """Open file dialog to browse for node SSH key file."""
         start_path = os.path.expanduser("~/.ssh")
@@ -1044,11 +1073,19 @@ class RemoteConfigWidget(QWidget):
 
             if not shiboken6.isValid(self):
                 return  # widget destroyed while the handshake event loop ran
+            if self._ssh_manager and not self._ssh_manager.is_connected:
+                self.status_label.setText("Not connected")
+                self.status_label.setStyleSheet("color: #999;")
+                self.btn_test.setEnabled(True)
+                self.btn_disconnect.setEnabled(False)
+                self.connection_status_changed.emit(False)
             self.node_status_label.setText(f"✗ {str(e)[:50]}")
             self.node_status_label.setStyleSheet("color: red;")
             self.btn_confirm_node.setEnabled(True)
             QMessageBox.warning(self, "Connection Failed", str(e))
         finally:
+            if self._ssh_manager is None or not getattr(self._ssh_manager, "is_jump_connected", False):
+                self.btn_confirm_node.setEnabled(True)
             self._handshake_active = False
 
     def _on_config_changed(self):
@@ -1123,7 +1160,13 @@ class RemoteConfigWidget(QWidget):
                 self._ssh_manager, "nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null", timeout=10
             )
             if exit_code == 0 and stdout.strip():
-                cpu_count = int(stdout.strip())
+                cpu_count = None
+                for line in stdout.splitlines():
+                    value = line.strip()
+                    if value.isdigit():
+                        cpu_count = int(value)
+                if cpu_count is None:
+                    raise ValueError(f"No numeric CPU count in remote output: {stdout!r}")
                 self.cpu_available_label.setText(f"(Available on remote: {cpu_count})")
                 # Update the max range
                 self.num_cores_spin.setRange(1, max(128, cpu_count))
@@ -1182,6 +1225,22 @@ class RemoteConfigWidget(QWidget):
         if getattr(self, "_handshake_active", False):
             return  # another handshake is mid-auth; don't race it
 
+        node = ""
+        node_password = None
+        node_key_file = None
+        if self.node_group.isChecked():
+            node = self.node_input.text().strip()
+            if not node:
+                QMessageBox.warning(self, "Compute Node Required", "Enter the compute node name.")
+                return
+            node_password, node_key_file = self._node_credentials()
+            if self.radio_node_password.isChecked() and not node_password:
+                QMessageBox.warning(self, "Authentication Required", "Enter the compute node password.")
+                return
+            if self.radio_node_key.isChecked() and not node_key_file:
+                QMessageBox.warning(self, "Authentication Required", "Select the compute node SSH key.")
+                return
+
         # Update status
         self.status_label.setText("Connecting...")
         self.status_label.setStyleSheet("color: #f39c12;")  # Orange
@@ -1203,13 +1262,14 @@ class RemoteConfigWidget(QWidget):
                 call_responsive(lambda: manager.connect(host, key_file=key_file))
 
             # Test jump connection if enabled
-            if self.node_group.isChecked():
-                node = self.node_input.text().strip()
-                if node:
-                    node_password = None
-                    if self.radio_node_password.isChecked():
-                        node_password = self.node_password_input.text()
-                    call_responsive(lambda: manager.connect_with_jump(main_host=node, main_password=node_password))
+            if node:
+                call_responsive(
+                    lambda: manager.connect_with_jump(
+                        main_host=node,
+                        main_password=node_password,
+                        main_key_file=node_key_file,
+                    )
+                )
 
             import shiboken6
 
@@ -1239,20 +1299,34 @@ class RemoteConfigWidget(QWidget):
 
             if not shiboken6.isValid(self):
                 return
+            if self._ssh_manager:
+                try:
+                    self._ssh_manager.disconnect()
+                except Exception as exc:
+                    logger.warning("Error disconnecting after failed SSH handshake: %s", exc)
+                self._ssh_manager = None
             self.status_label.setText("Connection failed")
             self.status_label.setStyleSheet("color: #e74c3c;")  # Red
             self.connection_status_changed.emit(False)
             self.btn_test.setEnabled(True)
+            self.btn_disconnect.setEnabled(False)
             QMessageBox.critical(self, "Connection Failed", str(e))
         except Exception as e:
             import shiboken6
 
             if not shiboken6.isValid(self):
                 return
+            if self._ssh_manager:
+                try:
+                    self._ssh_manager.disconnect()
+                except Exception as exc:
+                    logger.warning("Error disconnecting after failed SSH handshake: %s", exc)
+                self._ssh_manager = None
             self.status_label.setText("Error")
             self.status_label.setStyleSheet("color: #e74c3c;")  # Red
             self.connection_status_changed.emit(False)
             self.btn_test.setEnabled(True)
+            self.btn_disconnect.setEnabled(False)
             QMessageBox.critical(self, "Error", f"Unexpected error: {e}")
         finally:
             self._handshake_active = False
@@ -1312,17 +1386,24 @@ class RemoteConfigWidget(QWidget):
         password = self.password_input.text() if self.radio_password.isChecked() else None
         key_file = self.key_input.text().strip() if self.radio_key.isChecked() else None
         jump_node = self.node_input.text().strip() if self.node_group.isChecked() else None
-        jump_auth = "password" if self.radio_node_password.isChecked() else "none"
+        jump_auth = self._node_auth_type() if jump_node else "none"
+        node_password = self.node_password_input.text() if jump_auth == "password" else None
+        node_key_file = self.node_key_input.text().strip() if jump_auth == "key" else None
 
         try:
-            self._credential_manager.save_credential(
-                host=host,
-                auth_type=auth_type,
-                password=password,
-                key_file=key_file,
-                jump_node=jump_node,
-                jump_auth=jump_auth,
-            )
+            kwargs = {
+                "host": host,
+                "auth_type": auth_type,
+                "password": password,
+                "key_file": key_file,
+                "jump_node": jump_node,
+                "jump_auth": jump_auth,
+            }
+            if node_key_file:
+                kwargs["node_key_file"] = node_key_file
+            if node_password:
+                kwargs["node_password"] = node_password
+            self._credential_manager.save_credential(**kwargs)
         except CredentialStorageError as exc:
             QMessageBox.warning(self, "Credential Save Failed", str(exc))
             return
@@ -1358,23 +1439,6 @@ class RemoteConfigWidget(QWidget):
         try:
             self.btn_detect_python.setEnabled(False)
 
-            # Debug: Also run which python directly and show result
-            debug_info = []
-            try:
-                stdout, _, _ = execute_responsive(
-                    self._ssh_manager, "bash -i -l -c 'which python3' 2>/dev/null", timeout=15
-                )
-                debug_info.append(f"bash -i -l python3: {stdout.strip()}")
-            except Exception as e:
-                logger.debug("Failed to detect python3 via bash: %s", e)
-            try:
-                stdout, _, _ = execute_responsive(
-                    self._ssh_manager, "bash -i -l -c 'which python' 2>/dev/null", timeout=15
-                )
-                debug_info.append(f"bash -i -l python: {stdout.strip()}")
-            except Exception as e:
-                logger.debug("Failed to detect python via bash: %s", e)
-
             pythons = call_responsive(self._ssh_manager.detect_python_interpreters)
             detection_errors = list(getattr(self._ssh_manager, "last_detection_errors", ()))
             self.python_combo.clear()
@@ -1383,12 +1447,11 @@ class RemoteConfigWidget(QWidget):
                     self.python_combo.addItem(p)
                 msg = f"Found {len(pythons)} Python interpreter(s):\n"
                 msg += "\n".join(pythons)
-                msg += "\n\nDebug info:\n" + "\n".join(debug_info)
                 if detection_errors:
                     msg += "\n\nSome discovery probes failed:\n" + "\n".join(detection_errors)
                 QMessageBox.information(self, "Detection Complete", msg)
             else:
-                msg = "No Python interpreters found.\n\nDebug info:\n" + "\n".join(debug_info)
+                msg = "No Python interpreters found."
                 if detection_errors:
                     msg += "\n\nDiscovery errors:\n" + "\n".join(detection_errors)
                     QMessageBox.warning(self, "Detection Failed", msg)
@@ -1984,7 +2047,11 @@ class RemoteConfigWidget(QWidget):
         Returns:
             True if connected
         """
-        return self._ssh_manager is not None and self._ssh_manager.is_connected
+        if self._ssh_manager is None or not self._ssh_manager.is_connected:
+            return False
+        if self.node_group.isChecked() and self.node_input.text().strip():
+            return self._ssh_manager.is_jump_connected
+        return True
 
     def get_config(self) -> Dict[str, Any]:
         """Get current configuration as dictionary.
@@ -2004,7 +2071,8 @@ class RemoteConfigWidget(QWidget):
             "key_file": self.key_input.text().strip(),
             "use_jump": self.node_group.isChecked(),
             "jump_node": self.node_input.text().strip(),
-            "jump_auth": "password" if self.radio_node_password.isChecked() else "none",
+            "jump_auth": self._node_auth_type() if self.node_group.isChecked() else "none",
+            "node_key_file": self.node_key_input.text().strip() if self.node_group.isChecked() else "",
             "num_cores": self.num_cores_spin.value(),
             "python_path": self.python_combo.currentText().strip(),
             "conda_env": conda_env,
@@ -2038,8 +2106,11 @@ class RemoteConfigWidget(QWidget):
 
         if config.get("jump_auth") == "password":
             self.radio_node_password.setChecked(True)
+        elif config.get("jump_auth") == "key":
+            self.radio_node_key.setChecked(True)
         else:
             self.radio_node_none.setChecked(True)
+        self.node_key_input.setText(config.get("node_key_file", ""))
 
         # Set num_cores
         self.num_cores_spin.setValue(config.get("num_cores", DEFAULT_NUM_CORES))
@@ -2079,17 +2150,6 @@ class RemoteConfigWidget(QWidget):
         Args:
             host: Host string to load credentials for
         """
-        # Clear credential-derived fields first so switching to a host with
-        # no saved credentials cannot leave a stale password/key visible.
-        self.password_input.clear()
-        self.cb_save_password.setChecked(False)
-        self.key_input.clear()
-        self.node_group.setChecked(False)
-        self.node_input.clear()
-        self.node_password_input.clear()
-        self.node_key_input.clear()
-        self.radio_node_none.setChecked(True)
-
         try:
             cred = self._credential_manager.get_credential(host)
         except CredentialStorageError as exc:
@@ -2097,7 +2157,16 @@ class RemoteConfigWidget(QWidget):
             return
 
         if not cred:
+            self.password_input.clear()
+            self.cb_save_password.setChecked(False)
             return
+
+        # Clear credential-derived fields only after we know credentials exist.
+        # Otherwise a config file that explicitly contains key/jump settings is
+        # silently wiped just because this machine has no saved secret for host.
+        self.password_input.clear()
+        self.cb_save_password.setChecked(False)
+        self.node_password_input.clear()
 
         auth_type = cred.get("auth_type")
         if auth_type == "key":
@@ -2118,6 +2187,14 @@ class RemoteConfigWidget(QWidget):
             self.node_input.setText(cred["jump_node"])
             if cred.get("jump_auth") == "password":
                 self.radio_node_password.setChecked(True)
+                if cred.get("node_password"):
+                    self.node_password_input.setText(cred["node_password"])
+            elif cred.get("jump_auth") == "key":
+                self.radio_node_key.setChecked(True)
+                if cred.get("node_key_file"):
+                    self.node_key_input.setText(cred["node_key_file"])
+            else:
+                self.radio_node_none.setChecked(True)
 
     def disconnect(self):
         """Disconnect from remote server."""
@@ -2159,7 +2236,7 @@ class RemoteConfigWidget(QWidget):
         self.node_input.clear()
         self.node_password_input.clear()
         self.node_key_input.clear()
-        self.radio_node_password.setChecked(True)
+        self.radio_node_none.setChecked(True)
 
         # Environment
         self.num_cores_spin.setValue(DEFAULT_NUM_CORES)

--- a/src/openbench/gui/widgets/validation_dialog.py
+++ b/src/openbench/gui/widgets/validation_dialog.py
@@ -29,7 +29,8 @@ class ValidationWorker(QThread):
     """Worker thread for running validation."""
 
     progress = Signal(int, int, str, str)  # current, total, var_name, source_name
-    finished = Signal(object)  # DataValidationReport
+    result_ready = Signal(object)  # DataValidationReport
+    cancelled = Signal()
     error = Signal(str)
 
     def __init__(self, validator: DataValidator, sources: dict, general_config: dict, parent=None):
@@ -52,9 +53,9 @@ class ValidationWorker(QThread):
                 self.progress.emit(current, total, var_name, source_name)
 
             report = self._validator.validate_all(self._sources, self._general_config, progress_callback)
-            self.finished.emit(report)
+            self.result_ready.emit(report)
         except InterruptedError:
-            pass
+            self.cancelled.emit()
         except Exception as e:
             self.error.emit(str(e))
 
@@ -66,6 +67,8 @@ class ValidationWorker(QThread):
 class ValidationProgressDialog(QDialog):
     """Dialog showing validation progress."""
 
+    _active_workers = set()
+
     def __init__(self, validator: DataValidator, sources: dict, general_config: dict, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Validating Data...")
@@ -75,14 +78,19 @@ class ValidationProgressDialog(QDialog):
 
         self._report: Optional[DataValidationReport] = None
         self._closing = False
+        self._cancel_requested = False
         self._worker: Optional[ValidationWorker] = None
         self._setup_ui()
 
         # Start worker - don't set parent to avoid Qt destruction issues
         self._worker = ValidationWorker(validator, sources, general_config, None)
+        self._active_workers.add(self._worker)
         self._worker.progress.connect(self._on_progress, Qt.QueuedConnection)
-        self._worker.finished.connect(self._on_finished, Qt.QueuedConnection)
+        self._worker.result_ready.connect(self._on_finished, Qt.QueuedConnection)
+        self._worker.cancelled.connect(self._on_cancelled, Qt.QueuedConnection)
         self._worker.error.connect(self._on_error, Qt.QueuedConnection)
+        self._worker.finished.connect(self._worker.deleteLater)
+        self._worker.finished.connect(lambda worker=self._worker: self._active_workers.discard(worker))
         self._worker.start()
 
     def _setup_ui(self):
@@ -115,7 +123,7 @@ class ValidationProgressDialog(QDialog):
 
     def _on_progress(self, current: int, total: int, var_name: str, source_name: str):
         """Handle progress update."""
-        if self._closing:
+        if self._closing or getattr(self, "_cancel_requested", False):
             return
 
         total = max(0, int(total))
@@ -149,6 +157,17 @@ class ValidationProgressDialog(QDialog):
 
     def _on_cancel(self):
         """Handle cancel button."""
+        if self._worker is None or not self._worker.isRunning():
+            self._closing = True
+            self.reject()
+            return
+        self._cancel_requested = True
+        self.cancel_btn.setEnabled(False)
+        self.progress_label.setText("Cancelling...")
+        self._worker.cancel()
+
+    def _on_cancelled(self):
+        """Close after the worker reaches a safe cancellation point."""
         self._closing = True
         self._cleanup_worker()
         self.reject()
@@ -159,26 +178,20 @@ class ValidationProgressDialog(QDialog):
             # Disconnect signals first to prevent any more callbacks
             try:
                 self._worker.progress.disconnect()
-                self._worker.finished.disconnect()
+                self._worker.result_ready.disconnect()
+                self._worker.cancelled.disconnect()
                 self._worker.error.disconnect()
             except RuntimeError:
                 pass  # Already disconnected
 
-            # Request cancellation and wait for thread to finish
-            self._worker.cancel()
-            if self._worker.isRunning():
-                self._worker.wait(3000)
-                if self._worker.isRunning():
-                    # Force terminate if still running
-                    self._worker.terminate()
-                    self._worker.wait(1000)
-
-            # Schedule deletion to ensure all events are processed
-            self._worker.deleteLater()
             self._worker = None
 
     def closeEvent(self, event):
         """Handle dialog close event."""
+        if not self._closing and self._worker is not None and self._worker.isRunning():
+            self._on_cancel()
+            event.ignore()
+            return
         self._closing = True
         self._cleanup_worker()
         super().closeEvent(event)

--- a/src/openbench/remote/credentials.py
+++ b/src/openbench/remote/credentials.py
@@ -207,6 +207,8 @@ class CredentialManager:
         key_file: Optional[str] = None,
         jump_node: Optional[str] = None,
         jump_auth: str = "none",
+        node_password: Optional[str] = None,
+        node_key_file: Optional[str] = None,
     ) -> None:
         """Save credential for a host."""
         data = self._load_credentials_for_update()
@@ -214,6 +216,9 @@ class CredentialManager:
         encrypted_password = None
         if password:
             encrypted_password = self._fernet.encrypt(password.encode()).decode()
+        encrypted_node_password = None
+        if node_password:
+            encrypted_node_password = self._fernet.encrypt(node_password.encode()).decode()
 
         data["servers"][host] = {
             "auth_type": auth_type,
@@ -221,6 +226,8 @@ class CredentialManager:
             "key_file": key_file,
             "jump_node": jump_node,
             "jump_auth": jump_auth,
+            "node_password": encrypted_node_password,
+            "node_key_file": node_key_file,
         }
 
         self._save_credentials(data)
@@ -248,6 +255,20 @@ class CredentialManager:
                     e,
                 )
                 cred["password"] = None
+
+        if cred.get("node_password"):
+            try:
+                decrypted = self._fernet.decrypt(cred["node_password"].encode()).decode()
+                cred["node_password"] = decrypted
+            except Exception as e:
+                logger.warning(
+                    "Failed to decrypt saved node password for host %r (%s). "
+                    "Re-save the credential to regenerate it under the "
+                    "current machine identity.",
+                    host,
+                    e,
+                )
+                cred["node_password"] = None
 
         return cred
 

--- a/src/openbench/remote/ssh.py
+++ b/src/openbench/remote/ssh.py
@@ -229,6 +229,7 @@ class SSHManager:
         # Multi-hop connection attributes
         self._jump_client: Optional[SSHClient] = None
         self._jump_channel = None
+        self._jump_required = False
         self._last_detection_errors: list[str] = []
         # Reentrant lock guarding mutations of self._client / self._sftp /
         # self._jump_* and short reads of the active client. Held only across
@@ -246,6 +247,19 @@ class SSHManager:
         detail = f"{message}: {exc}"
         self._last_detection_errors.append(detail)
         logger.debug(detail)
+
+    @staticmethod
+    def _last_absolute_path(stdout: str, *, basename: Optional[str] = None) -> str:
+        """Return the last absolute path line from noisy shell output."""
+        path = ""
+        for line in stdout.splitlines():
+            candidate = line.strip()
+            if not candidate.startswith("/"):
+                continue
+            if basename and posixpath.basename(candidate) != basename:
+                continue
+            path = candidate
+        return path
 
     @property
     def is_connected(self) -> bool:
@@ -305,6 +319,7 @@ class SSHManager:
             SSHConnectionError: If connection fails
         """
         user, host, port = self._parse_host_string(host_string)
+        self._jump_required = False
 
         if user is None:
             raise SSHConnectionError("Username is required (format: user@host)")
@@ -379,6 +394,7 @@ class SSHManager:
         with self._state_lock:
             # First disconnect jump connection if present
             self.disconnect_jump()
+            self._jump_required = False
 
             if self._sftp:
                 try:
@@ -458,6 +474,8 @@ class SSHManager:
         if not self.is_connected:
             raise SSHConnectionError("Must connect to main server first")
 
+        self._jump_required = True
+
         if self._jump_client is not None or self._jump_channel is not None or self._jump_sftp is not None:
             self.disconnect_jump()
 
@@ -523,6 +541,14 @@ class SSHManager:
                 pass
             self._jump_client = None
             self._jump_channel = None
+            # A requested compute-node connection is the execution target. If
+            # it fails, keeping the login-node client alive lets later
+            # execute()/SFTP calls silently run on the wrong machine. Tear down
+            # the main connection as well so callers must reconnect deliberately.
+            try:
+                self.disconnect()
+            except Exception:
+                pass
             raise SSHConnectionError(f"Jump connection failed: {e}") from e
 
     def disconnect_jump(self) -> None:
@@ -556,6 +582,8 @@ class SSHManager:
         """
         if self.is_jump_connected:
             return self._jump_client
+        if self._jump_required:
+            return None
         return self._client
 
     @staticmethod
@@ -988,11 +1016,7 @@ class SSHManager:
                     # `cd` notices before our `which python` output. Pick
                     # the last line that actually looks like an absolute
                     # path instead of blindly taking `[0]`.
-                    path = ""
-                    for line in stdout.splitlines():
-                        line = line.strip()
-                        if line.startswith("/"):
-                            path = line
+                    path = self._last_absolute_path(stdout)
                     if path and path not in pythons and not is_system_path(path):
                         pythons.append(path)
             except Exception as exc:
@@ -1030,7 +1054,7 @@ class SSHManager:
             cmd = f"ls -d {home}/miniconda*/bin/conda {home}/miniforge*/bin/conda {home}/anaconda*/bin/conda {home}/mambaforge*/bin/conda 2>/dev/null | head -1"
             stdout, _, exit_code = self.execute(cmd, timeout=10)
             if exit_code == 0 and stdout.strip():
-                conda_exe = stdout.strip().split("\n")[0]
+                conda_exe = self._last_absolute_path(stdout, basename="conda")
         except Exception as exc:
             self._record_detection_error("Conda discovery command failed", exc)
 
@@ -1039,7 +1063,7 @@ class SSHManager:
             try:
                 stdout, _, exit_code = self.execute("bash -i -l -c 'which conda' 2>/dev/null", timeout=15)
                 if exit_code == 0 and stdout.strip():
-                    conda_exe = stdout.strip().split("\n")[0]
+                    conda_exe = self._last_absolute_path(stdout, basename="conda")
             except Exception as exc:
                 self._record_detection_error("Conda discovery command failed", exc)
 

--- a/src/openbench/remote/sync.py
+++ b/src/openbench/remote/sync.py
@@ -388,7 +388,10 @@ class SyncEngine:
         )
         stdout, stderr, exit_code = self._ssh.execute(f"bash -c {shlex.quote(inner)}", timeout=30)
         if exit_code != 0:
-            return []
+            raise IOError(
+                f"glob({pattern!r}) under {base_dir!r} failed (exit {exit_code}): "
+                f"{stderr.strip() or stdout.strip() or 'glob produced no diagnostics'}"
+            )
         return [line.strip() for line in stdout.strip().split("\n") if line.strip()]
 
     def mkdir(self, path: str) -> None:

--- a/tests/test_architecture_cleanup.py
+++ b/tests/test_architecture_cleanup.py
@@ -27,6 +27,16 @@ def test_runtime_dependencies_declare_direct_imports_without_unused_platformdirs
     assert "platformdirs" not in conda_reqs
 
 
+def test_gui_and_dask_runtime_dependencies_are_installable_from_declared_extras():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = "\n".join(pyproject["project"]["dependencies"]).lower()
+    gui_dependencies = "\n".join(pyproject["project"]["optional-dependencies"]["gui"]).lower()
+
+    assert "distributed" in dependencies
+    assert "paramiko" in gui_dependencies
+    assert "cryptography" in gui_dependencies
+
+
 def test_core_public_api_does_not_export_unwired_evaluation_engine():
     import openbench
     import openbench.core as core

--- a/tests/test_gui_async_lifecycle.py
+++ b/tests/test_gui_async_lifecycle.py
@@ -122,3 +122,209 @@ def test_progress_parser_comparison_stage_uses_specific_increment():
 
     assert stage == "Comparison"
     assert progress == 7
+
+
+def test_save_current_page_restores_auto_sync_after_save_failure():
+    class Controller:
+        current_page = "general"
+        auto_sync_enabled = True
+
+    class Page:
+        def save_to_config(self):
+            raise RuntimeError("boom")
+
+    window = MainWindow.__new__(MainWindow)
+    window.controller = Controller()
+    window.pages = {"general": Page()}
+
+    with pytest.raises(RuntimeError, match="boom"):
+        window._save_current_page(trigger_sync=False)
+
+    assert window.controller.auto_sync_enabled is True
+
+
+def test_setup_local_storage_flushes_stops_and_disconnects_remote_storage(tmp_path):
+    from openbench.remote.storage import RemoteStorage
+
+    events = []
+
+    class Sync:
+        def __init__(self):
+            self._on_status_changed = lambda *args: None
+            self._ssh = None
+
+        def sync_all(self):
+            events.append("sync_all")
+            return True
+
+        def stop_background_sync(self):
+            events.append("stop")
+
+    class SSH:
+        def disconnect(self):
+            events.append("disconnect")
+
+    class Controller:
+        storage = RemoteStorage("/remote/project", Sync())
+        ssh_manager = SSH()
+        project_root = ""
+
+    window = MainWindow.__new__(MainWindow)
+    window.controller = Controller()
+    window._sync_status = None
+
+    window.setup_local_storage(str(tmp_path))
+
+    assert events == ["sync_all", "stop", "disconnect"]
+    assert window.controller.ssh_manager is None
+    assert window.controller.project_root == str(tmp_path)
+
+
+def test_setup_remote_storage_stops_previous_sync_before_replacing(monkeypatch):
+    from openbench.gui import main_window
+    from openbench.remote.storage import RemoteStorage
+
+    events = []
+
+    class OldSync:
+        def sync_all(self):
+            events.append("old-sync-all")
+            return True
+
+        def stop_background_sync(self):
+            events.append("old-stop")
+
+    class NewSync:
+        def __init__(self, ssh, root):
+            events.append(("new", ssh, root))
+            self._on_status_changed = None
+
+        def start_background_sync(self):
+            events.append("new-start")
+
+        def get_overall_status(self):
+            from openbench.remote.sync import SyncStatus
+
+            return SyncStatus.SYNCED
+
+        def get_pending_count(self):
+            return 0
+
+        def retry_errors(self):
+            pass
+
+    class Controller:
+        storage = RemoteStorage("/old", OldSync())
+        ssh_manager = object()
+
+    ssh = object()
+    window = MainWindow.__new__(MainWindow)
+    window.controller = Controller()
+    window._sync_status = None
+    window._nav_bar_layout = None
+    sync_widget = type(
+        "W",
+        (),
+        {"retry_clicked": type("S", (), {"connect": lambda *a: None})(), "set_status": lambda *a: None},
+    )
+    monkeypatch.setattr(main_window, "SyncStatusWidget", lambda parent: sync_widget())
+    monkeypatch.setattr("openbench.remote.sync.SyncEngine", NewSync)
+
+    window.setup_remote_storage(ssh, "/new")
+
+    assert events[:2] == ["old-sync-all", "old-stop"]
+    assert events[2:] == [("new", ssh, "/new"), "new-start"]
+
+
+def test_setup_remote_storage_disconnects_replaced_ssh_manager(monkeypatch):
+    from openbench.remote.storage import RemoteStorage
+
+    events = []
+
+    class OldSSH:
+        def disconnect(self):
+            events.append("old-disconnect")
+
+    class OldSync:
+        _ssh = OldSSH()
+        _on_status_changed = None
+
+        def sync_all(self):
+            return True
+
+        def stop_background_sync(self):
+            pass
+
+    class NewSync:
+        def __init__(self, ssh, root):
+            self._on_status_changed = None
+
+        def start_background_sync(self):
+            pass
+
+    class Controller:
+        storage = RemoteStorage("/old", OldSync())
+        ssh_manager = object()
+
+    window = MainWindow.__new__(MainWindow)
+    window.controller = Controller()
+    window._sync_status = None
+    window._nav_bar_layout = None
+    window._setup_sync_status = lambda sync_engine: None
+    monkeypatch.setattr("openbench.remote.sync.SyncEngine", NewSync)
+
+    window.setup_remote_storage(object(), "/new")
+
+    assert events == ["old-disconnect"]
+
+
+def test_find_remote_project_root_accepts_v3_source_marker(monkeypatch):
+    from openbench.gui import main_window
+
+    commands = []
+
+    class SSH:
+        is_connected = True
+
+    def fake_execute(_ssh, command, timeout=None):
+        commands.append(command)
+        return "", "", 0
+
+    window = MainWindow.__new__(MainWindow)
+    window._get_remote_ssh_manager = lambda: SSH()
+    monkeypatch.setattr(main_window, "execute_responsive", fake_execute)
+
+    assert window._find_remote_project_root("/remote/OpenBench/output/case") == "/remote/OpenBench/output/case"
+    assert "src/openbench/cli/main.py" in commands[0]
+    assert "openbench/openbench.py" not in commands[0]
+
+
+def test_close_waits_for_remote_download_worker_to_stop(monkeypatch):
+    class DownloadWorker:
+        stopped = False
+
+        def isRunning(self):
+            return True
+
+        def stop(self):
+            self.stopped = True
+
+        def wait(self, timeout):
+            return False
+
+    class Event:
+        ignored = False
+
+        def ignore(self):
+            self.ignored = True
+
+    worker = DownloadWorker()
+    window = MainWindow.__new__(MainWindow)
+    window.pages = {"run_monitor": type("RunPage", (), {"_runner": None, "_download_worker": worker})()}
+    event = Event()
+    monkeypatch.setattr("openbench.gui.main_window.QMessageBox.warning", lambda *args: None)
+
+    window.closeEvent(event)
+
+    assert worker.stopped is True
+    assert event.ignored is True

--- a/tests/test_gui_config_manager.py
+++ b/tests/test_gui_config_manager.py
@@ -226,6 +226,14 @@ def test_validate_requires_selected_items_when_comparison_or_statistics_enabled(
     assert "At least one statistics item must be selected when statistics is enabled" in errors
 
 
+def test_validate_accepts_scores_without_metrics(tmp_path):
+    config = _runnable_config(tmp_path)
+    config["metrics"] = {}
+    config["scores"] = {"Overall_Score": True}
+
+    assert ConfigManager().validate(config) == []
+
+
 def test_generate_config_yaml_does_not_enable_empty_comparison_or_statistics(tmp_path):
     config = _runnable_config(tmp_path)
     config["general"]["comparison"] = True

--- a/tests/test_gui_evaluation_runner.py
+++ b/tests/test_gui_evaluation_runner.py
@@ -197,6 +197,26 @@ def test_local_runner_uses_exact_evaluation_task_count(tmp_path):
     assert runner._total_tasks == 2
 
 
+def test_local_runner_counts_statistics_independently_from_comparisons(tmp_path):
+    runner = EvaluationRunner(str(tmp_path / "openbench.yaml"), python_path="/fake/python")
+
+    runner.set_task_counts(
+        num_variables=1,
+        num_ref_sources=1,
+        num_sim_sources=1,
+        num_metrics=1,
+        num_scores=1,
+        num_groupby=0,
+        num_comparisons=0,
+        do_evaluation=False,
+        do_comparison=False,
+        do_statistics=True,
+        num_statistics=2,
+    )
+
+    assert runner._total_tasks == 2
+
+
 def test_remote_runner_counts_groupby_without_comparison(tmp_path):
     from openbench.gui.remote_runner import RemoteRunner
 
@@ -205,6 +225,28 @@ def test_remote_runner_counts_groupby_without_comparison(tmp_path):
     runner.set_task_counts(2, 1, 1, 1, 1, 1, 0, do_evaluation=True, do_comparison=False)
 
     assert runner._total_tasks == 3
+
+
+def test_remote_runner_counts_statistics_independently_from_comparisons(tmp_path):
+    from openbench.gui.remote_runner import RemoteRunner
+
+    runner = RemoteRunner(str(tmp_path / "openbench.yaml"), object(), {}, config_already_remote=True)
+
+    runner.set_task_counts(
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        do_evaluation=False,
+        do_comparison=False,
+        do_statistics=True,
+        num_statistics=2,
+    )
+
+    assert runner._total_tasks == 2
 
 
 def test_local_runner_does_not_run_when_check_fails(tmp_path, monkeypatch):

--- a/tests/test_gui_page_preview_remote.py
+++ b/tests/test_gui_page_preview_remote.py
@@ -191,6 +191,30 @@ def test_remote_preview_uses_same_remote_path_transform_as_export():
     assert kwargs["path_transform"]("Reference") == "/remote/openbench/Reference"
 
 
+def test_remote_execution_never_falls_back_to_local_export(monkeypatch):
+    from openbench.remote.storage import LocalStorage
+
+    class Controller(FakeControllerBase):
+        config = {"general": {"execution_mode": "remote"}}
+        storage = LocalStorage("/local/project")
+
+        def get_output_dir(self):
+            return "/local/output"
+
+    preview = _preview()
+    preview.controller = Controller()
+    preview.config_manager = type("Manager", (), {"validate": lambda self, config: []})()
+    preview._export_and_run_local = lambda output_dir: pytest.fail("remote mode fell back to local export")
+    warnings = []
+    monkeypatch.setattr(
+        "openbench.gui.pages.page_preview.QMessageBox.warning",
+        lambda *args: warnings.append(args),
+    )
+
+    assert preview._export_and_run_once() is False
+    assert warnings and warnings[-1][1] == "Remote Connection Required"
+
+
 def test_resolve_remote_model_path_raises_on_ssh_failure():
     preview = _preview()
 

--- a/tests/test_gui_page_run_monitor_remote.py
+++ b/tests/test_gui_page_run_monitor_remote.py
@@ -2,7 +2,7 @@ import pytest
 
 pytest.importorskip("PySide6")
 
-from openbench.gui.pages.page_run_monitor import PageRunMonitor  # noqa: E402
+from openbench.gui.pages.page_run_monitor import PageRunMonitor, RemoteFolderDownloadWorker  # noqa: E402
 
 
 class RaisingController:
@@ -17,7 +17,7 @@ class FakeSSH:
         self.exc = exc
         self.commands = []
 
-    def execute(self, command, timeout=30):
+    def execute(self, command, timeout=30, should_abort=None):
         self.commands.append(command)
         if self.exc:
             raise self.exc
@@ -80,3 +80,62 @@ def test_remote_download_relpath_rejects_paths_outside_remote_dir():
     assert page._remote_download_relpath("/remote/output/a/b.nc", "/remote/output") == "a/b.nc"
     assert page._remote_download_relpath("/remote/output2/evil.nc", "/remote/output") is None
     assert page._remote_download_relpath("/etc/passwd", "/remote/output") is None
+
+
+def test_on_finished_reports_stopped_without_failed_warning(monkeypatch):
+    page = _page()
+    page.dashboard = type("Dashboard", (), {"stop_monitoring": lambda self: None})()
+    page._refresh_parent_navigation = lambda: None
+    infos = []
+    warnings = []
+    monkeypatch.setattr(
+        "openbench.gui.pages.page_run_monitor.QMessageBox.information",
+        lambda parent, title, message: infos.append((title, message)),
+    )
+    monkeypatch.setattr(
+        "openbench.gui.pages.page_run_monitor.QMessageBox.warning",
+        lambda parent, title, message: warnings.append((title, message)),
+    )
+
+    page._on_finished(False, "Stopped by user")
+
+    assert infos == [("Stopped", "Evaluation stopped by user.")]
+    assert warnings == []
+
+
+class FakeSftp:
+    def __init__(self):
+        self.downloads = []
+
+    def get(self, remote, local, callback=None):
+        if callback is not None:
+            callback(1, 1)
+        self.downloads.append((remote, local))
+
+
+class ListingSSH(FakeSSH):
+    def __init__(self):
+        super().__init__()
+        self.sftp = FakeSftp()
+
+    def execute(self, command, timeout=30, should_abort=None):
+        self.commands.append(command)
+        return "/remote/output/a.nc\n/remote/output/sub/b.nc\n", "", 0
+
+    def open_sftp(self):
+        return self.sftp
+
+
+def test_remote_folder_download_worker_downloads_in_background_target(tmp_path, qapp):
+    ssh = ListingSSH()
+    worker = RemoteFolderDownloadWorker(ssh, "/remote/output", str(tmp_path / "output"))
+    finished = []
+    worker.finished_signal.connect(
+        lambda success, canceled, message, target: finished.append((success, canceled, message, target))
+    )
+
+    worker.run()
+
+    assert finished == [(True, False, "Download complete", str(tmp_path / "output"))]
+    assert len(ssh.sftp.downloads) == 2
+    assert (tmp_path / "output" / "a.nc").parent.exists()

--- a/tests/test_gui_runtime_paths.py
+++ b/tests/test_gui_runtime_paths.py
@@ -1,0 +1,231 @@
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+from openbench.gui.controller import WizardController  # noqa: E402
+from openbench.gui.pages.page_general import PageGeneral  # noqa: E402
+from openbench.gui.pages.page_runtime import PageRuntime, _LocalInstallWorker  # noqa: E402
+from openbench.gui.widgets.checkbox_group import CheckboxGroup  # noqa: E402
+
+
+def _runtime_page(qapp, monkeypatch):
+    monkeypatch.setattr(PageRuntime, "_detect_python", lambda self: None)
+    monkeypatch.setattr(PageRuntime, "_auto_load_settings", lambda self: None)
+    page = PageRuntime(WizardController())
+    page._auto_save_settings = lambda: None
+    return page
+
+
+def test_runtime_python_combo_uses_item_data_for_paths_with_spaces(qapp, monkeypatch):
+    page = _runtime_page(qapp, monkeypatch)
+    python_path = r"C:\Users\Jane Doe\miniconda3\python.exe"
+
+    page.python_combo.clear()
+    page.python_combo.addItem(f"{python_path} (miniconda3)", python_path)
+    page.python_combo.setCurrentIndex(0)
+    page.conda_combo.setCurrentIndex(0)
+
+    page.save_to_config()
+
+    assert page.controller.config["general"]["python_path"] == python_path
+    assert page._collect_runtime_settings()["python_path"] == python_path
+
+
+def test_runtime_typed_legacy_python_display_suffix_preserves_spaced_path(qapp, monkeypatch):
+    page = _runtime_page(qapp, monkeypatch)
+    python_path = "/tmp/Open Bench Env/bin/python"
+
+    page.python_combo.clear()
+    page.python_combo.setCurrentText(f"{python_path} (PATH)")
+    page.conda_combo.setCurrentIndex(0)
+
+    page.save_to_config()
+
+    assert page.controller.config["general"]["python_path"] == python_path
+
+
+def test_runtime_conda_selection_controls_saved_python_path(qapp, monkeypatch, tmp_path):
+    page = _runtime_page(qapp, monkeypatch)
+    env_path = tmp_path / "conda envs" / "openbench"
+
+    page.conda_combo.addItem("openbench", str(env_path))
+    page.conda_combo.setCurrentIndex(1)
+
+    expected = str(env_path / "bin" / "python")
+    assert page.controller.config["general"]["python_path"] == expected
+    assert page.python_combo.currentData() == expected
+
+
+def test_runtime_remote_mode_saves_remote_cpu_count(qapp, monkeypatch):
+    page = _runtime_page(qapp, monkeypatch)
+
+    page.radio_remote.blockSignals(True)
+    page.radio_remote.setChecked(True)
+    page.radio_local.setChecked(False)
+    page.radio_remote.blockSignals(False)
+    page.remote_config_widget.num_cores_spin.setValue(12)
+    page.num_cores_spin.setValue(3)
+
+    page.save_to_config()
+
+    assert page.controller.config["general"]["num_cores"] == 12
+    assert page._collect_runtime_settings()["num_cores"] == 12
+
+
+def test_runtime_remote_mode_cannot_continue_without_execution_target(qapp, monkeypatch):
+    page = _runtime_page(qapp, monkeypatch)
+    page.radio_remote.setChecked(True)
+    page.remote_config_widget.is_connected = lambda: False
+    warnings = []
+    monkeypatch.setattr(
+        "openbench.gui.pages.page_runtime.QMessageBox.warning",
+        lambda *args: warnings.append(args),
+    )
+
+    assert page.validate() is False
+    assert warnings and warnings[-1][1] == "Remote Connection Required"
+
+
+def test_switching_local_flushes_storage_before_widget_disconnect():
+    events = []
+    page = PageRuntime.__new__(PageRuntime)
+    page.radio_local = SimpleNamespace(isChecked=lambda: True)
+    page.parallel_group = SimpleNamespace(show=lambda: None)
+    page.local_env_group = SimpleNamespace(show=lambda: None)
+    page.cpu_available_label = SimpleNamespace(setText=lambda text: None)
+    page.remote_config_widget = SimpleNamespace(
+        hide=lambda: None,
+        get_ssh_manager=lambda: object(),
+        disconnect=lambda: events.append("disconnect"),
+        reset_to_defaults=lambda: events.append("reset"),
+    )
+    page._switch_to_local_storage = lambda: events.append("flush-and-switch")
+    page._on_config_changed = lambda: events.append("save")
+
+    page._on_execution_mode_changed(True)
+
+    assert events == ["flush-and-switch", "disconnect", "reset", "save"]
+
+
+def test_local_install_commands_include_editable_install_with_selected_python(qapp, monkeypatch, tmp_path):
+    page = _runtime_page(qapp, monkeypatch)
+    install_path = tmp_path / "Open Bench"
+    python_path = tmp_path / "Python Env" / "bin" / "python"
+
+    page.python_combo.clear()
+    page.python_combo.addItem(f"{python_path} (selected)", str(python_path))
+    page.python_combo.setCurrentIndex(0)
+
+    commands, starting = page._build_local_install_commands(str(install_path), "https://example.test/repo.git", False)
+
+    assert starting == "Cloning from https://example.test/repo.git..."
+    assert commands == [
+        ["git", "clone", "--progress", "https://example.test/repo.git", str(install_path)],
+        [str(python_path), "-m", "pip", "install", "-e", str(install_path)],
+    ]
+
+
+def test_local_install_worker_returns_failure_when_editable_install_fails(qapp, monkeypatch):
+    import subprocess
+
+    calls = []
+
+    class FakeProcess:
+        def __init__(self, cmd, returncode):
+            self.cmd = cmd
+            self.stdout = [f"ran {cmd[0]}\n"]
+            self.returncode = returncode
+            self.terminated = False
+
+        def wait(self):
+            return self.returncode
+
+        def terminate(self):
+            self.terminated = True
+
+    returncodes = iter([0, 23])
+
+    def fake_popen(cmd, **_kwargs):
+        calls.append(cmd)
+        return FakeProcess(cmd, next(returncodes))
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    worker = _LocalInstallWorker([["git", "pull"], ["python", "-m", "pip", "install", "-e", "."]])
+    results = []
+    worker.finished_with_result.connect(results.append)
+
+    worker.run()
+
+    assert calls == [["git", "pull"], ["python", "-m", "pip", "install", "-e", "."]]
+    assert results == [23]
+
+
+def test_general_load_from_config_does_not_write_stale_defaults(qapp, tmp_path):
+    controller = WizardController()
+    page = PageGeneral(controller)
+    controller.config = {
+        "general": {
+            "basename": "loaded",
+            "basedir": str(tmp_path),
+            "syear": 1999,
+            "eyear": 2001,
+            "min_year": 2.5,
+            "min_lat": -10.0,
+            "max_lat": 50.0,
+            "min_lon": 20.0,
+            "max_lon": 130.0,
+            "compare_tim_res": "day",
+            "compare_grid_res": 0.25,
+            "compare_tzone": 8.0,
+            "time_alignment": "strict",
+            "evaluation": True,
+            "comparison": False,
+            "statistics": True,
+            "debug_mode": True,
+            "generate_report": False,
+            "only_drawing": True,
+            "IGBP_groupby": False,
+            "PFT_groupby": False,
+            "Climate_zone_groupby": False,
+            "unified_mask": False,
+            "num_cores": 7,
+            "weight": "area",
+            "io": {"netcdf_compression": True, "mfdataset_batch_size": 0},
+            "dask": {
+                "enabled": True,
+                "n_workers": 2,
+                "threads_per_worker": 3,
+                "processes": False,
+                "memory_limit": "1GB",
+            },
+        },
+        "evaluation_items": {},
+        "ref_data": {"general": {}, "def_nml": {}},
+        "sim_data": {"general": {}, "def_nml": {}},
+        "metrics": {},
+        "scores": {},
+        "comparisons": {},
+        "statistics": {},
+    }
+    before = deepcopy(controller.config["general"])
+    sync_calls = []
+    controller.sync_namelists = lambda *args, **kwargs: sync_calls.append((args, kwargs))
+
+    page.load_from_config()
+
+    assert controller.config["general"] == before
+    assert sync_calls == []
+    assert page.weight_combo.currentText() == "area"
+    assert page.num_cores_spin.value() == 7
+
+
+def test_checkbox_group_set_selection_clears_items_not_in_selection(qapp):
+    group = CheckboxGroup({"Group": ["a", "b", "c"]})
+    group.set_selection({"a": True, "b": True, "c": True})
+
+    group.set_selection({"b": True})
+
+    assert group.get_selection() == {"a": False, "b": True, "c": False}

--- a/tests/test_gui_scan_alignment_fixes.py
+++ b/tests/test_gui_scan_alignment_fixes.py
@@ -833,3 +833,103 @@ def test_gui_grid_reference_validation_checks_spatial_range_for_single_file(tmp_
     spatial_check = next(check for check in result.checks if check.name == "spatial_range")
     assert spatial_check.passed is False
     assert "Spatial range insufficient" in spatial_check.message
+
+
+def test_gui_grid_validation_opens_sample_dataset_once(tmp_path, monkeypatch):
+    xr = pytest.importorskip("xarray")
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    import openbench.gui.data_validator as validator_module
+
+    path = tmp_path / "global.nc"
+    longitudes = np.arange(0.0, 360.0, 60.0)
+    xr.Dataset(
+        {"q": (("time", "lat", "lon"), np.ones((2, 2, len(longitudes))))},
+        coords={
+            "time": pd.date_range("2000-01-01", periods=2, freq="YS"),
+            "lat": [-90.0, 90.0],
+            "lon": longitudes,
+        },
+    ).to_netcdf(path)
+    calls = 0
+    real_safe_open = validator_module.safe_open
+
+    def counting_open(candidate):
+        nonlocal calls
+        calls += 1
+        return real_safe_open(candidate)
+
+    monkeypatch.setattr(validator_module, "safe_open", counting_open)
+    result = validator_module.DataValidator().validate_source(
+        "Runoff",
+        "GlobalRef",
+        {
+            "general": {"root_dir": str(tmp_path), "data_type": "grid", "data_groupby": "Single"},
+            "varname": "q",
+            "prefix": "global",
+        },
+        {"syear": 2000, "eyear": 2001, "min_lat": -90, "max_lat": 90, "min_lon": -180, "max_lon": 180},
+    )
+
+    assert result.is_valid is True
+    assert calls == 1
+
+
+def test_gui_grid_validation_normalizes_equivalent_longitude_domains(tmp_path):
+    xr = pytest.importorskip("xarray")
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    from openbench.gui.data_validator import DataValidator
+
+    path = tmp_path / "global.nc"
+    longitudes = np.arange(0.0, 360.0, 60.0)
+    xr.Dataset(
+        {"q": (("time", "lat", "lon"), np.ones((2, 2, len(longitudes))))},
+        coords={
+            "time": pd.date_range("2000-01-01", periods=2, freq="YS"),
+            "lat": [-90.0, 90.0],
+            "lon": longitudes,
+        },
+    ).to_netcdf(path)
+
+    result = DataValidator().validate_source(
+        "Runoff",
+        "GlobalRef",
+        {
+            "general": {"root_dir": str(tmp_path), "data_type": "grid", "data_groupby": "Single"},
+            "varname": "q",
+            "prefix": "global",
+        },
+        {"syear": 2000, "eyear": 2001, "min_lat": -90, "max_lat": 90, "min_lon": -180, "max_lon": 180},
+    )
+
+    spatial = next(check for check in result.checks if check.name == "spatial_range")
+    assert spatial.passed is True
+
+
+def test_gui_grid_validation_does_not_treat_dateline_region_as_global(tmp_path):
+    xr = pytest.importorskip("xarray")
+    np = pytest.importorskip("numpy")
+    pd = pytest.importorskip("pandas")
+    from openbench.gui.data_validator import DataValidator
+
+    longitudes = np.array([350.0, 355.0, 0.0, 5.0, 10.0])
+    path = tmp_path / "dateline.nc"
+    xr.Dataset(
+        {"q": (("time", "lat", "lon"), np.ones((2, 2, len(longitudes))))},
+        coords={"time": pd.date_range("2000-01-01", periods=2, freq="YS"), "lat": [-10.0, 10.0], "lon": longitudes},
+    ).to_netcdf(path)
+
+    result = DataValidator().validate_source(
+        "Runoff",
+        "DatelineRef",
+        {
+            "general": {"root_dir": str(tmp_path), "data_type": "grid", "data_groupby": "Single"},
+            "varname": "q",
+            "prefix": "dateline",
+        },
+        {"syear": 2000, "eyear": 2001, "min_lat": -10, "max_lat": 10, "min_lon": 100, "max_lon": 200},
+    )
+
+    spatial = next(check for check in result.checks if check.name == "spatial_range")
+    assert spatial.passed is False

--- a/tests/test_progress_dashboard.py
+++ b/tests/test_progress_dashboard.py
@@ -14,7 +14,7 @@ def test_set_progress_clamps_bar_and_label(qapp):
     dashboard = ProgressDashboard()
 
     dashboard.set_progress(125)
-    assert dashboard.progress_bar.value() == 100
+    assert dashboard.progress_bar.value() == 1000
     assert dashboard.progress_label.text() == "100%"
 
     dashboard.set_progress(-7)
@@ -29,7 +29,7 @@ def test_running_task_status_does_not_roll_back_numeric_progress(qapp):
 
     dashboard.update_task_status("tas - Evaluation", TaskStatus.RUNNING)
 
-    assert dashboard.progress_bar.value() == 42
+    assert dashboard.progress_bar.value() == 420
     assert dashboard.progress_label.text() == "42%"
 
 
@@ -40,8 +40,17 @@ def test_completed_task_status_can_advance_progress_when_higher(qapp):
 
     dashboard.update_task_status("tas - Evaluation", TaskStatus.COMPLETED)
 
-    assert dashboard.progress_bar.value() == 50
+    assert dashboard.progress_bar.value() == 500
     assert dashboard.progress_label.text() == "50%"
+
+
+def test_set_progress_preserves_decimal_precision_for_large_runs(qapp):
+    dashboard = ProgressDashboard()
+
+    dashboard.set_progress(5.09)
+
+    assert dashboard.progress_bar.value() == 51
+    assert dashboard.progress_label.text() == "5.1%"
 
 
 def test_resource_usage_updates_from_psutil(qapp, monkeypatch):
@@ -56,6 +65,59 @@ def test_resource_usage_updates_from_psutil(qapp, monkeypatch):
 
     assert dashboard.cpu_label.text() == "37%"
     assert dashboard.mem_label.text() == "62%"
+
+
+def test_resource_usage_updates_from_local_process_tree(qapp, monkeypatch):
+    class FakeProcess:
+        def __init__(self, pid, cpu, rss, children=()):
+            self.pid = pid
+            self._cpu = cpu
+            self._rss = rss
+            self._children = list(children)
+
+        def children(self, recursive=True):
+            return self._children
+
+        def cpu_percent(self, interval=None):
+            return self._cpu
+
+        def memory_info(self):
+            return SimpleNamespace(rss=self._rss)
+
+    child = FakeProcess(2, 7.6, 25)
+    root = FakeProcess(1, 12.4, 75, [child])
+    fake_psutil = SimpleNamespace(
+        Process=lambda pid: root if pid == 1 else child,
+        cpu_count=lambda: 4,
+        virtual_memory=lambda: SimpleNamespace(total=1000),
+        NoSuchProcess=RuntimeError,
+        AccessDenied=PermissionError,
+        ZombieProcess=ChildProcessError,
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    dashboard = ProgressDashboard()
+    dashboard.monitor_process_tree(lambda: 1)
+
+    dashboard._update_resource_usage()
+
+    assert dashboard.cpu_label.text() == "5%"
+    assert dashboard.mem_label.text() == "10%"
+
+
+def test_remote_resource_mode_is_explicitly_unavailable(qapp, monkeypatch):
+    fake_psutil = SimpleNamespace(
+        cpu_percent=lambda: 99,
+        virtual_memory=lambda: SimpleNamespace(percent=99),
+    )
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    dashboard = ProgressDashboard()
+    dashboard.show_resource_unavailable("Resources (remote not monitored)")
+
+    dashboard._update_resource_usage()
+
+    assert dashboard.resource_group.title() == "Resources (remote not monitored)"
+    assert dashboard.cpu_label.text() == "N/A"
+    assert dashboard.mem_label.text() == "N/A"
 
 
 def test_resource_usage_shows_unavailable_when_psutil_is_missing(qapp, monkeypatch):
@@ -89,3 +151,30 @@ def test_validation_progress_clamps_out_of_range_counts(qapp):
     ValidationProgressDialog._on_progress(dialog, -1, 2, "tas", "source")
     assert dialog.progress_bar.value() == 0
     assert dialog.progress_label.text() == "0/2"
+
+
+def test_validation_cancel_requests_cooperative_stop_without_waiting(qapp):
+    class Worker:
+        cancelled = False
+
+        def isRunning(self):
+            return True
+
+        def cancel(self):
+            self.cancelled = True
+
+    worker = Worker()
+    dialog = SimpleNamespace(
+        _worker=worker,
+        _cancel_requested=False,
+        _closing=False,
+        cancel_btn=SimpleNamespace(setEnabled=lambda enabled: setattr(dialog, "cancel_enabled", enabled)),
+        progress_label=QLabel(),
+    )
+
+    ValidationProgressDialog._on_cancel(dialog)
+
+    assert worker.cancelled is True
+    assert dialog._cancel_requested is True
+    assert dialog.cancel_enabled is False
+    assert dialog.progress_label.text() == "Cancelling..."

--- a/tests/test_progress_parser.py
+++ b/tests/test_progress_parser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from openbench.gui.pages.page_run_monitor import count_evaluation_tasks
 from openbench.gui.progress_parser import parse_progress_line
 
@@ -12,8 +14,10 @@ def _state(**overrides):
         "completed_eval_tasks": set(),
         "completed_groupby_tasks": set(),
         "completed_comparison_tasks": set(),
+        "completed_statistics_tasks": set(),
         "total_tasks": 0,
         "num_comparisons": 0,
+        "num_statistics": 0,
         "num_variables": 0,
     }
     state.update(overrides)
@@ -139,7 +143,33 @@ def test_progress_parser_counts_actual_groupby_complete_lines():
 
         assert progress == 95
         assert stage == "Comparison"
-        assert ("Runoff", key) in state["completed_groupby_tasks"]
+        assert key in state["completed_groupby_tasks"]
+
+
+def test_progress_parser_counts_statistics_independently_from_comparisons():
+    state = _state(total_tasks=2, num_comparisons=0, num_statistics=2)
+
+    progress, _var, stage = parse_progress_line("Completed Mean analysis", 5, state, CONSTANTS)
+
+    assert progress == 50
+    assert stage == "Statistics"
+    assert "Mean" in state["completed_statistics_tasks"]
+    assert state["completed_comparison_tasks"] == set()
+
+
+def test_progress_parser_large_task_fraction_survives_for_display():
+    state = _state(total_tasks=1000)
+
+    progress, variable, stage = parse_progress_line(
+        'OPENBENCH_PROGRESS {"event":"evaluation_completed","variable":"Runoff","sim":"SimA","ref":"RefA"}',
+        5,
+        state,
+        CONSTANTS,
+    )
+
+    assert progress == pytest.approx(5.09)
+    assert variable == "Runoff"
+    assert stage == "Evaluation"
 
 
 def test_evaluation_task_count_uses_each_variables_bound_sources():

--- a/tests/test_remote_credentials.py
+++ b/tests/test_remote_credentials.py
@@ -46,3 +46,37 @@ def test_reading_corrupt_credentials_returns_empty_without_destroying_file(tmp_p
     assert mgr.get_credential("bob@example.org") is None
     assert mgr.list_hosts() == []
     assert credentials_path.read_text(encoding="utf-8") == "not-json"
+
+
+def test_save_credential_roundtrips_compute_node_key_and_password(tmp_path):
+    mgr = CredentialManager(config_dir=str(tmp_path))
+
+    mgr.save_credential(
+        "alice@example.org",
+        "key",
+        key_file="/keys/login",
+        jump_node="node001",
+        jump_auth="key",
+        node_key_file="/keys/node",
+    )
+
+    cred = mgr.get_credential("alice@example.org")
+    assert cred["key_file"] == "/keys/login"
+    assert cred["jump_node"] == "node001"
+    assert cred["jump_auth"] == "key"
+    assert cred["node_key_file"] == "/keys/node"
+
+    mgr.save_credential(
+        "alice@example.org",
+        "password",
+        password="login-secret",
+        jump_node="node002",
+        jump_auth="password",
+        node_password="node-secret",
+    )
+
+    cred = mgr.get_credential("alice@example.org")
+    assert cred["password"] == "login-secret"
+    assert cred["jump_node"] == "node002"
+    assert cred["jump_auth"] == "password"
+    assert cred["node_password"] == "node-secret"

--- a/tests/test_remote_install_worker.py
+++ b/tests/test_remote_install_worker.py
@@ -186,7 +186,15 @@ def test_gui_modules_have_no_main_thread_ssh_band_aids():
     process_events_allowlist = {"_ssh_worker.py"}
     # Raw executes allowed only where the call already runs off the GUI
     # thread or is the responsive layer itself.
-    raw_execute_allowlist = {"_ssh_worker.py", "remote_config.py", "remote_runner.py", "remote_python.py"}
+    raw_execute_allowlist = {
+        "_ssh_worker.py",
+        "remote_config.py",
+        "remote_runner.py",
+        "remote_python.py",
+        # RemoteFolderDownloadWorker owns its execute() call on a QThread; the
+        # GUI slot only starts the worker and receives signals.
+        "page_run_monitor.py",
+    }
 
     offenders = []
     for path in sorted(gui_root.rglob("*.py")):
@@ -226,6 +234,32 @@ def test_node_connect_is_blocked_while_main_handshake_runs(qapp):
     widget._confirm_node_connection()
 
     assert calls == []
+
+
+@pytest.mark.parametrize("node_auth", ["password", "key"])
+def test_main_connect_rejects_missing_selected_compute_credentials(qapp, monkeypatch, node_auth):
+    from openbench.gui.widgets import remote_config
+
+    widget = RemoteConfigWidget()
+    widget.host_input.setText("alice@login.example")
+    widget.radio_password.setChecked(True)
+    widget.password_input.setText("main-secret")
+    widget.node_group.setChecked(True)
+    widget.node_input.setText("node001")
+    if node_auth == "password":
+        widget.radio_node_password.setChecked(True)
+        widget.node_password_input.clear()
+    else:
+        widget.radio_node_key.setChecked(True)
+        widget.node_key_input.clear()
+
+    warnings = []
+    monkeypatch.setattr(remote_config.QMessageBox, "warning", lambda *args: warnings.append(args))
+    monkeypatch.setattr(remote_config, "SSHManager", lambda *args, **kwargs: pytest.fail("SSH fallback attempted"))
+
+    widget._test_connection()
+
+    assert warnings and warnings[-1][1] == "Authentication Required"
 
 
 def test_conda_env_change_discards_stale_query_result(qapp, monkeypatch):
@@ -764,3 +798,173 @@ def test_runtime_local_install_cleanup_disconnects_and_detaches(qapp):
     assert worker in page_runtime._DETACHED_INSTALL_WORKERS
     assert page._local_install_worker is None
     page_runtime._DETACHED_INSTALL_WORKERS.remove(worker)
+
+
+def test_remote_config_roundtrips_compute_node_key_without_saved_credentials(qapp):
+    widget = RemoteConfigWidget()
+
+    widget.set_config(
+        {
+            "host": "alice@login.example.org",
+            "auth_type": "key",
+            "key_file": "/keys/login",
+            "use_jump": True,
+            "jump_node": "node001",
+            "jump_auth": "key",
+            "node_key_file": "/keys/node",
+            "num_cores": 12,
+            "python_path": "/opt/python/bin/python",
+            "openbench_path": "/remote/OpenBench",
+        }
+    )
+
+    config = widget.get_config()
+    assert widget.key_input.text() == "/keys/login"
+    assert widget.node_group.isChecked() is True
+    assert widget.node_input.text() == "node001"
+    assert widget.radio_node_key.isChecked() is True
+    assert widget.node_key_input.text() == "/keys/node"
+    assert config["jump_auth"] == "key"
+    assert config["node_key_file"] == "/keys/node"
+
+
+def test_test_connection_passes_compute_node_key_to_jump_connect(qapp, monkeypatch):
+    from openbench.gui.widgets import remote_config
+
+    calls = []
+
+    class FakeManager:
+        def __init__(self, host_key_callback=None):
+            self.is_connected = True
+
+        def connect(self, host, password=None, key_file=None):
+            calls.append(("connect", host, password, key_file))
+
+        def connect_with_jump(self, **kwargs):
+            calls.append(("jump", kwargs))
+
+        def execute(self, command, timeout=None):
+            return "banner\n64\n", "", 0
+
+    monkeypatch.setattr(remote_config, "SSHManager", FakeManager)
+    monkeypatch.setattr(remote_config.QMessageBox, "information", staticmethod(lambda *args, **kwargs: None))
+    monkeypatch.setattr(remote_config.QMessageBox, "critical", staticmethod(lambda *args, **kwargs: None))
+
+    widget = RemoteConfigWidget()
+    widget.host_input.setText("alice@login")
+    widget.password_input.setText("login-pw")
+    widget.node_group.setChecked(True)
+    widget.node_input.setText("node001")
+    widget.radio_node_key.setChecked(True)
+    widget.node_key_input.setText("/keys/node")
+
+    widget._test_connection()
+
+    assert ("jump", {"main_host": "node001", "main_password": None, "main_key_file": "/keys/node"}) in calls
+
+
+def test_save_current_credentials_includes_compute_node_secret(qapp):
+    saved = []
+
+    class Creds:
+        def save_credential(self, **kwargs):
+            saved.append(kwargs)
+
+    widget = RemoteConfigWidget()
+    widget._credential_manager = Creds()
+    widget.host_input.setText("alice@login")
+    widget.radio_key.setChecked(True)
+    widget.key_input.setText("/keys/login")
+    widget.node_group.setChecked(True)
+    widget.node_input.setText("node001")
+    widget.radio_node_key.setChecked(True)
+    widget.node_key_input.setText("/keys/node")
+
+    widget._save_current_credentials()
+
+    assert saved == [
+        {
+            "host": "alice@login",
+            "auth_type": "key",
+            "password": None,
+            "key_file": "/keys/login",
+            "jump_node": "node001",
+            "jump_auth": "key",
+            "node_key_file": "/keys/node",
+        }
+    ]
+
+
+def test_load_saved_credentials_restores_compute_node_key(qapp):
+    class Creds:
+        def get_credential(self, host):
+            return {
+                "auth_type": "password",
+                "password": "login-pw",
+                "jump_node": "node001",
+                "jump_auth": "key",
+                "node_key_file": "/keys/node",
+            }
+
+    widget = RemoteConfigWidget()
+    widget._credential_manager = Creds()
+
+    widget._load_saved_credentials("alice@login")
+
+    assert widget.password_input.text() == "login-pw"
+    assert widget.node_group.isChecked() is True
+    assert widget.node_input.text() == "node001"
+    assert widget.radio_node_key.isChecked() is True
+    assert widget.node_key_input.text() == "/keys/node"
+
+
+def test_reset_to_defaults_keeps_compute_node_auth_none(qapp):
+    widget = RemoteConfigWidget()
+    widget.radio_node_password.setChecked(True)
+
+    widget.reset_to_defaults()
+
+    assert widget.radio_node_none.isChecked() is True
+
+
+def test_update_remote_cpu_count_ignores_banner_lines(qapp, monkeypatch):
+    from openbench.gui.widgets import remote_config
+
+    class SSH:
+        is_connected = True
+
+    def fake_execute(_ssh, command, timeout=None):
+        return "Welcome to cluster\n64\n", "", 0
+
+    monkeypatch.setattr(remote_config, "execute_responsive", fake_execute)
+    widget = RemoteConfigWidget()
+    widget._ssh_manager = SSH()
+
+    widget._update_remote_cpu_count()
+
+    assert widget.cpu_available_label.text() == "(Available on remote: 64)"
+    assert widget.num_cores_spin.maximum() >= 128
+
+
+def test_parse_ssh_config_splits_multiple_host_aliases(tmp_path, monkeypatch):
+    from openbench.gui.widgets import remote_config
+
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "config").write_text(
+        "Host login login-short *.internal\n"
+        "  HostName login.example.org\n"
+        "  User alice\n"
+        "  Port 2222\n"
+        "  IdentityFile ~/.ssh/id_login\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(remote_config.platform, "system", lambda: "Darwin")
+
+    hosts = remote_config.parse_ssh_config()
+
+    assert [host["name"] for host in hosts] == ["login", "login-short"]
+    assert {host["hostname"] for host in hosts} == {"login.example.org"}
+    assert {host["user"] for host in hosts} == {"alice"}
+    assert {host["port"] for host in hosts} == {"2222"}

--- a/tests/test_remote_runner.py
+++ b/tests/test_remote_runner.py
@@ -1,3 +1,4 @@
+import base64
 import os
 
 import pytest
@@ -173,9 +174,11 @@ class StreamSSH(FakeSSH):
         self.exit_code = exit_code
         self.exc = exc
         self.stream_command = None
+        self.stream_kwargs = {}
 
-    def execute_stream(self, command):
+    def execute_stream(self, command, **kwargs):
         self.stream_command = command
+        self.stream_kwargs = kwargs
         if self.exc:
             raise self.exc
         yield from self.lines
@@ -197,6 +200,19 @@ def test_execute_remote_openbench_nonzero_exit_includes_log_tail(tmp_path):
     assert "line 3" in message
     assert "line 7" in message
     assert "line 1" not in message
+
+
+def test_execute_remote_openbench_passes_should_abort_to_stream(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    ssh = StreamSSH(lines=["running\n"], exit_code=0)
+    runner = _runner(config, ssh)
+    runner._remote_config_path = "/remote/main.yaml"
+
+    success, _message = runner._execute_remote_openbench()
+
+    assert success is True
+    assert callable(ssh.stream_kwargs.get("should_abort"))
 
 
 def test_execute_remote_openbench_preserves_partial_marker_outside_tail(tmp_path):
@@ -247,7 +263,7 @@ class CloseFailStream:
 
 
 class CloseFailSSH(FakeSSH):
-    def execute_stream(self, command):
+    def execute_stream(self, command, **kwargs):
         return CloseFailStream()
 
     def execute(self, command, timeout=30):
@@ -269,6 +285,71 @@ def test_execute_remote_openbench_logs_stream_close_failure_on_stop(tmp_path):
     assert message == "Stopped by user"
     assert "Warning: could not close remote output stream: close failed" in logs
     assert "Sent kill signal to remote process" in logs
+
+
+def test_remote_runner_stop_is_not_reported_as_failed(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    runner = RemoteRunner(
+        str(config),
+        FakeSSH(),
+        {"python_path": "python3", "openbench_path": "/remote/openbench"},
+        config_already_remote=True,
+    )
+    runner._last_progress = 17
+    runner._execute_remote_openbench = lambda: (False, "Stopped by user")
+    progress = []
+    finished = []
+    runner.progress_updated.connect(progress.append)
+    runner.finished_signal.connect(lambda success, message: finished.append((success, message)))
+
+    runner.run()
+
+    assert finished[-1] == (False, "Stopped by user")
+    assert progress[-1].status.value == "stopped"
+    assert progress[-1].progress != runner.PROGRESS_MAX
+
+
+def test_remote_runner_hard_failure_keeps_current_progress(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    runner = RemoteRunner(
+        str(config),
+        FakeSSH(),
+        {"python_path": "python3", "openbench_path": "/remote/openbench"},
+        config_already_remote=True,
+    )
+    runner._last_progress = 17
+    runner._execute_remote_openbench = lambda: (False, "boom")
+    progress = []
+    runner.progress_updated.connect(progress.append)
+
+    runner.run()
+
+    assert progress[-1].status.value == "failed"
+    assert progress[-1].progress != runner.PROGRESS_MAX
+
+
+def test_remote_runner_applies_remote_num_cores_before_execution(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    ssh = ExecuteSSH(("", "", 0))
+    runner = RemoteRunner(
+        str(config),
+        ssh,
+        {"python_path": "python3", "openbench_path": "/remote/openbench", "num_cores": 12},
+        config_already_remote=True,
+    )
+    runner._remote_config_path = "/remote/main.yaml"
+    logs = []
+    runner.log_message.connect(logs.append)
+
+    assert runner._apply_remote_num_cores_override() is True
+
+    assert ssh.commands
+    payload = ssh.commands[0].split()[2]
+    assert 'project["num_cores"] = 12' in base64.b64decode(payload).decode()
+    assert "Using 12 CPU cores on remote server." in logs
 
 
 def test_remote_runner_progress_parser_ignores_exception_source_names(tmp_path):

--- a/tests/test_remote_ssh.py
+++ b/tests/test_remote_ssh.py
@@ -219,3 +219,60 @@ def test_execute_stream_closes_channel_when_generator_is_closed(monkeypatch):
     stream.close()
 
     assert transport.channel.closed is True
+
+
+def test_jump_connection_failure_disconnects_main_to_avoid_login_node_fallback(monkeypatch):
+    main_client = FakeSSHClient()
+    manager = SSHManager(auto_add_host_keys=True)
+    manager._client = main_client
+    manager._user = "alice"
+
+    class RaisingSSHClient(FakeSSHClient):
+        def __init__(self):
+            super().__init__(raise_on_connect=True)
+
+    monkeypatch.setattr(ssh_module.paramiko, "SSHClient", RaisingSSHClient)
+
+    with pytest.raises(SSHConnectionError, match="Jump connection failed"):
+        manager.connect_with_jump("node001", main_password="secret")
+
+    assert main_client.closed is True
+    assert manager.get_active_client() is None
+
+
+def test_disconnected_requested_compute_node_never_falls_back_to_login_node():
+    manager = SSHManager(auto_add_host_keys=True)
+    manager._client = FakeSSHClient()
+    manager._jump_required = True
+
+    assert manager.get_active_client() is None
+
+
+def test_detect_conda_envs_uses_last_absolute_path_from_noisy_login_shell():
+    manager = SSHManager(auto_add_host_keys=True)
+    calls = []
+
+    def fake_execute(command, timeout=None):
+        calls.append(command)
+        if command == "echo $HOME":
+            return "/home/alice\n", "", 0
+        if "ls -d" in command:
+            return "", "", 1
+        if "which conda" in command:
+            return "Welcome\n/home/alice/miniconda3/bin/conda\n", "", 0
+        if command == "/home/alice/miniconda3/bin/conda env list":
+            return (
+                "# conda environments:\n"
+                "base * /home/alice/miniconda3\n"
+                "openbench /home/alice/miniconda3/envs/openbench\n",
+                "",
+                0,
+            )
+        return "", "", 1
+
+    manager.execute = fake_execute
+
+    assert manager.detect_conda_envs() == [
+        ("base", "/home/alice/miniconda3"),
+        ("openbench", "/home/alice/miniconda3/envs/openbench"),
+    ]

--- a/tests/test_remote_sync.py
+++ b/tests/test_remote_sync.py
@@ -293,3 +293,15 @@ def test_sync_engine_sftp_paths_expand_tilde_project_dir():
         ("/home/openbench/OpenBench/nml/ref.yaml", "wb"),
     ]
     assert all(not path.startswith("~") for path, _mode in ssh.sftp.opens)
+
+
+def test_glob_raises_remote_diagnostics_on_nonzero_exit():
+    class FailingGlobSSH(FakeSSH):
+        def execute(self, command, timeout=30):
+            self.commands.append(command)
+            return "", "permission denied", 13
+
+    sync = SyncEngine(FailingGlobSSH(), "/remote/project")
+
+    with pytest.raises(IOError, match="permission denied"):
+        sync.glob("nml/**/*.yaml")


### PR DESCRIPTION
## Summary
- make execution target selection authoritative and prevent remote-to-local/login-node fallback
- fix Windows interpreter paths, Conda selection, progress/resource reporting, stop/cancel state, and remote CPU settings
- harden SSH key credentials, sync lifecycle, remote download threading, and NetCDF validation
- declare GUI/Distributed runtime dependencies and add regression coverage

## Validation
- `pytest -q`: 1811 passed, 5 skipped
- GUI/remote targeted tests: 407 passed
- `ruff check`, `ruff format --check`, `compileall`, `git diff --check`

## Remaining environment gap
- native Windows desktop and live HPC interactive smoke tests were not available locally