### PR TITLE
Keep GUI environment discovery portable across platforms

### DIFF
--- a/src/openbench/gui/widgets/remote_config.py
+++ b/src/openbench/gui/widgets/remote_config.py
@@ -105,7 +105,7 @@ def parse_ssh_config() -> List[Dict[str, str]]:
         ]
     else:
         # Unix/macOS: ~/.ssh/config
-        home = os.path.expanduser("~")
+        home = os.environ.get("HOME") or os.path.expanduser("~")
         config_paths = [
             os.path.join(home, ".ssh", "config"),
         ]

--- a/tests/test_gui_runtime_paths.py
+++ b/tests/test_gui_runtime_paths.py
@@ -1,3 +1,4 @@
+import sys
 from copy import deepcopy
 from types import SimpleNamespace
 
@@ -54,7 +55,7 @@ def test_runtime_conda_selection_controls_saved_python_path(qapp, monkeypatch, t
     page.conda_combo.addItem("openbench", str(env_path))
     page.conda_combo.setCurrentIndex(1)
 
-    expected = str(env_path / "bin" / "python")
+    expected = str(env_path / ("python.exe" if sys.platform == "win32" else "bin/python"))
     assert page.controller.config["general"]["python_path"] == expected
     assert page.python_combo.currentData() == expected
 


### PR DESCRIPTION
## Summary
- make the conda runtime-path regression test platform-aware
- honor HOME explicitly when parsing Unix-style SSH configuration

## Verification
- same narrow follow-up as PR #156
- targeted GUI runtime and remote install tests: 43 passed
- main lineage full suite: 1811 passed, 5 skipped