### PR TITLE
Restore time-mask separation and reject ambiguous singleton regrids

### DIFF
--- a/src/openbench/data/regrid/methods/conservative.py
+++ b/src/openbench/data/regrid/methods/conservative.py
@@ -272,6 +272,8 @@ def get_weights(source_coords: np.ndarray, target_coords: np.ndarray, *, spheric
         raise ValueError(
             "Conservative regridding cannot infer finite cell bounds for a non-identical single-point coordinate"
         )
+    if source_coords.size == 1 or target_coords.size == 1:
+        raise ValueError("Conservative regridding requires explicit cell bounds for one-sided singleton coordinates")
     mode = "spherical" if spherical else "linear"
     key = (REGRID_WEIGHT_SCHEMA_VERSION, mode, _coord_cache_token(source_coords), _coord_cache_token(target_coords))
     if _WEIGHTS_CACHE_MAXSIZE:

--- a/src/openbench/data/regrid/utils.py
+++ b/src/openbench/data/regrid/utils.py
@@ -128,8 +128,7 @@ def to_intervalindex(coords: np.ndarray) -> pd.IntervalIndex:
         intervals = pd.IntervalIndex.from_breaks(breaks)
 
     else:
-        # If the target grid has a single point, set search interval to span all space
-        intervals = pd.IntervalIndex.from_breaks([-np.inf, np.inf])
+        raise ValueError("Conservative regridding cannot infer cell bounds from a singleton coordinate")
 
     return intervals
 

--- a/src/openbench/runner/masking.py
+++ b/src/openbench/runner/masking.py
@@ -103,7 +103,7 @@ def apply_unified_mask(
                 raise ValueError(f"Unified mask: no overlapping timestamps for {var_name}")
 
         finite_pairs = np.isfinite(s_aligned) & np.isfinite(o_aligned)
-        if time_alignment == "intersection" and "time" in finite_pairs.dims:
+        if apply_spatial_mask and time_alignment == "intersection" and "time" in finite_pairs.dims:
             non_time_dims = [dim for dim in finite_pairs.dims if dim != "time"]
             valid_times = finite_pairs.any(dim=non_time_dims) if non_time_dims else finite_pairs
             if hasattr(valid_times, "compute"):

--- a/tests/test_regrid_weight_cache.py
+++ b/tests/test_regrid_weight_cache.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 
 def test_conservative_regrid_reuses_weight_matrices(monkeypatch):
@@ -210,13 +211,13 @@ def test_conservative_regrid_skipna_is_intensive_not_extensive_total():
     import openbench.data.regrid  # noqa: F401  register accessor
 
     source = xr.Dataset({"flux": ("x", [1.0, np.nan])}, coords={"x": [0.5, 1.5]})
-    target = xr.Dataset(coords={"x": [1.0]})
+    target = xr.Dataset(coords={"x": [1.0, 3.0]})
 
     default_result = source.regrid.conservative(target, latitude_coord=None, time_dim=None, nan_threshold=1.0)
     strict_result = source.regrid.conservative(target, latitude_coord=None, time_dim=None, nan_threshold=0.0)
 
-    assert float(default_result["flux"].item()) == 1.0
-    assert np.isnan(float(strict_result["flux"].item()))
+    assert float(default_result["flux"].isel(x=0).item()) == 1.0
+    assert np.isnan(float(strict_result["flux"].isel(x=0).item()))
 
 
 def test_normalize_overlap_keeps_zero_overlap_columns_zero():
@@ -346,12 +347,21 @@ def test_conservative_regrid_preserves_single_identical_cell():
 
 
 def test_conservative_regrid_rejects_nonidentical_single_points():
-    import pytest
-
     from openbench.data.regrid.methods import conservative
 
     with pytest.raises(ValueError, match="cannot infer finite cell bounds"):
         conservative.get_weights(np.array([0.0]), np.array([1.0]))
+
+
+@pytest.mark.parametrize(
+    ("source", "target"),
+    [([0.0], [-1.0, 1.0]), ([-1.0, 1.0], [0.0])],
+)
+def test_conservative_regrid_rejects_one_sided_single_points(source, target):
+    from openbench.data.regrid.methods import conservative
+
+    with pytest.raises(ValueError, match="explicit cell bounds"):
+        conservative.get_weights(np.asarray(source), np.asarray(target))
 
 
 def test_weight_disk_cache_rejects_missing_schema_version(tmp_path, monkeypatch):

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -5901,7 +5901,7 @@ def test_intersection_accumulates_across_sibling_simulations(tmp_path):
         assert ds["time"].values[0] == ref_time[1]
 
 
-def test_intersection_drops_reindexed_all_nan_sibling_timesteps(tmp_path):
+def test_intersection_preserves_nan_sibling_timesteps_without_unified_mask(tmp_path):
     import numpy as np
     import pandas as pd
     import xarray as xr
@@ -5934,7 +5934,7 @@ def test_intersection_drops_reindexed_all_nan_sibling_timesteps(tmp_path):
         )
 
     with xr.open_dataset(data_dir / "Runoff_ref_TestRef_runoff_ref.nc") as ds:
-        assert ds.sizes["time"] == 1
+        assert ds.sizes["time"] == 2
         assert ds["time"].values[0] == times[0]
 
 


### PR DESCRIPTION
## Summary
- keep  limited to timestamp coordinates when 
- preserve finite-value time pruning only when the cumulative unified mask is enabled
- reject one-sided singleton conservative grids without explicit cell bounds

## Tested
- 25 focused runner/regrid regression tests
- Ruff and diff checks