### PR TITLE
Reuse expensive preprocessing across model comparisons

### DIFF
--- a/REVIEW_REPORT.md
+++ b/REVIEW_REPORT.md
@@ -1,0 +1,454 @@
+# OpenBench 深度代码审查与修复验收报告
+
+> 审查日期：2026-08-26
+> 阶段：**阶段二修复与性能优化（已完成）**
+> 原始审查冻结快照：分支 `fix/doc2-real-gui-report-audit-main`，提交 `3671375203e59457bda5bef8d263e7c72b5fb285`
+> 最终闭环验收快照：分支 `fix/time-mask-singleton-contracts`，提交 `1a3bd64f2e15ef66fcdc0151e4ebab2742a7e976`
+> 性能优化最终快照：提交 `011a26e`（xESMF 权重复用、MFM 共享计算、unified mask 单次写入）
+> 审查环境：macOS 26.5.2 / arm64，Python 3.12.12，16 逻辑核，64 GiB 内存
+
+## 0. 审查口径与快照说明
+
+- 原始发现和行号以 `3671375` 为准；最终 `[DONE]` 验收结论以已提交快照 `1a3bd64` 为准。
+- 审查开始时仓库位于另一分支/提交（`e16e0ec`），且已有大量未提交改动；审查期间另一个本地 Codex 进程继续修改代码、切换分支并生成提交 `3671375`。这些源码修改和提交**不是本次阶段一审查所作**。
+- 修复验收重新运行全量测试、Ruff、全部变更测试和独立最小反例；随后按确认顺序逐项实施性能优化，每项独立测试和提交。
+- 本报告中的“证据”分为：直接代码证据、可运行最小复现、解析/高精度对照和合成微基准。未在真实 HPC、Windows、NFS 或生产 SSH 环境验证的结论均明确标注。
+
+---
+
+## 1. 执行摘要
+
+### 1.1 总体健康度
+
+**总体状态：PASS（原报告 22 条发现均已通过代码、反例和自动化验收）。**
+
+当前测试规模和静态检查表现良好，基础 RMSE、ubRMSE、NSE、KGE、相关系数的抽样数值对照也通过。最后两条残余已闭合：S-004 在关闭 unified mask 时保留精确 timestamp intersection；S-011 对无法推导有限 bounds 的单侧 singleton conservative 输入明确 fail fast。未计入 22 条发现的三个性能候选——xESMF 权重持久化复用、MFM 共享计算和 unified mask 单次写入——也已全部完成并通过回归、全量测试和 Ruff。
+
+### 1.2 发现统计
+
+| 严重级别 | 数量 | 含义 |
+|---|---:|---|
+| P0 阻塞 | 0 | 未发现普遍阻止运行或确定性破坏所有结果的问题 |
+| P1 高 | 9 | 可静默改变科学结果、时间/空间支持或复用陈旧结果 |
+| P2 中 | 13 | 边界正确性、缓存契约、跨平台或可量化性能问题 |
+| P3 低 | 0 | 风格问题未计入缺陷；最终 Ruff 基线已通过 |
+| **合计** | **22** | 科学正确性 11、缓存/配置正确性 7、性能/并发 4 |
+
+### 1.3 原始最高风险结论
+
+1. **CF 非公历时间会丢样本**：`360_day` 的 2 月 28/29/30 日被压成同一 Gregorian 日期，后续去重静默删除数据。
+2. **默认 OpenBench conservative backend 的网格与球面权重均存在可复现偏差**：常用 `0.1°` 全球目标网格少一行/列；部分纬向重叠使用整源格面积修正而非实际重叠面积。
+3. **时间对齐模式与配置语义不一致**：`intersection` 没有形成跨所有模型的共同时间支持；`strict` 在缺测时间被填成 NaN 后不再报错。
+4. **缓存可能复用陈旧科学结果**：算法源指纹漏掉重网格、单位、时间工具等关键模块；station fulllist 指向的外部数据文件没有进入输入签名。
+
+### 1.4 环境与测试基线
+
+| 时点 | 结果 |
+|---|---|
+| 开始审查时（原工作树） | `1920 passed, 5 skipped, 114 warnings in 135.13s`；114 条均为全 NaN slice 警告 |
+| 开始审查时 Ruff | `ruff check src tests` 有 2 个 `I001`；`ruff format --check` 有 15 个文件待格式化 |
+| 冻结快照 `3671375` | `1925 passed, 5 skipped in 131.40s` |
+| 最终 Ruff | `ruff check src tests`：通过；`ruff format --check src tests`：`376 files already formatted` |
+| 子域验证 | 科学核心相关 19 个测试通过；运行时/缓存相关 378 个测试通过 |
+| 中间修复验收 `2e0c4df` | 定向测试 `332 passed in 17.08s`；全量 `1946 passed, 5 skipped in 136.96s` |
+| 中间 uncertainty 验收 `c72046f` | 定向测试 `12 passed in 1.66s`；全量 `1986 passed, 5 skipped in 132.99s` |
+| 最终主线验收 `3de10ef` | 全量 `1952 passed, 5 skipped in 226.52s`；测试前后 tree `b78aa2c` 未变化 |
+| 最终闭环验收 `1a3bd64` | S-004/S-011 定向测试 `8 passed in 10.94s`；全量 `1954 passed, 5 skipped in 240.91s`；测试前后内容 fingerprint 一致 |
+| xESMF 权重复用 `c25d5d9` | xESMF/cache 相关定向测试通过；全量 `1962 passed, 5 skipped in 233.10s`；缓存 key 覆盖 source/target 坐标、CF bounds、mask、method、periodic 与 xESMF/ESMF 版本 |
+| MFM 共享计算 `413e180` | MFM/evaluation 定向测试 `57 passed`；全量 `1969 passed, 5 skipped in 139.74s`；四项联合 synthetic median `0.1546 s → 0.0794 s`（`-48.6%`） |
+| unified mask 单次写入 `011a26e` | 定向 `240 passed in 13.66s`；全量 `1975 passed, 5 skipped in 200.98s`；7 次中位写入 `4 → 1`，spatial mask 路径 `0.0801 s → 0.0380 s`（`-52.5%`） |
+| 验收 Ruff | `ruff check src tests`：通过；`ruff format --check src tests`：`378 files already formatted` |
+
+### 1.5 数据流认知
+
+从 README 和 runner 调用链确认的主流程为：
+
+1. `config/loader.py` 读取 YAML、include/default/env 等配置；`resolver.py`/`adapter.py` 解析参考数据、模拟数据和 legacy namelist。
+2. `runner/task_planning.py` 建立 `variable × simulation × reference` 任务并计算缓存哈希。
+3. `runner/orchestration.py` 依变量串行调度预处理；grid/station 内部再使用 joblib、xarray/Dask。
+4. `data/_processing_*` 完成坐标规范化、时间完整性、单位转换、重网格、站点抽取与输出物化。
+5. `runner/masking.py` 累积统一掩码；`core/evaluation.py` 对齐 sim/ref 后计算 metrics/scores。
+6. `core/comparison*`、`core/statistics/*`、`visualization/` 生成比较、统计、图表及 HTML/PDF 报告。
+7. `.openbench_cache.json`、任务哈希和重网格权重缓存共同支持增量执行与断点恢复。
+
+### 1.6 已通过的数值抽检
+
+使用同一 pairwise finite mask，以 NumPy `float64` 参考实现对 5 点序列（含 sim/ref 错位 NaN）核验。OpenBench 与参考值的最大绝对误差为 `2.22e-16`：
+
+| 指标 | OpenBench | NumPy 参考 | 绝对误差 |
+|---|---:|---:|---:|
+| RMSE | 0.707106781187 | 0.707106781187 | 0 |
+| ubRMSE | 0.707106781187 | 0.707106781187 | 0 |
+| NSE | 0.865671641791 | 0.865671641791 | 0 |
+| correlation | 0.998373737819 | 0.998373737819 | 1.11e-16 |
+| KGE | 0.639574974051 | 0.639574974051 | 2.22e-16 |
+
+单样本相关、常量观测 NSE/KGE 均返回 NaN，退化行为合理。公式对照依据包括 [Nash–Sutcliffe 原始论文](https://doi.org/10.1016/0022-1694(70)90255-6)、[Gupta 等 2009 KGE 论文](https://doi.org/10.1016/j.jhydrol.2009.08.003) 和 [OpenBench 方法论文](https://doi.org/10.5194/gmd-18-6517-2025)。这只是对核心公式的抽检，不代表 `metrics.py` 中所有水文指标都已用真实数据验证。
+
+### 1.7 与旧报告反馈的口径对齐
+
+- 用户反馈中的 `S-004` / `B-004` / `B-003` 指向旧报告；本报告的同编号分别是全局时间交集、内置 conservative 权重缓存版本化、缓存键可逆性，不是 xESMF periodic、ref/sim 坐标取样或 HDF5 文件锁。
+- 冻结快照中已有对 station 哨兵值、累积量重采样、cgroup/BLAS 资源预算、日期变更线、kappa 标签、单时刻维度以及全 NaN 分组警告等的修复和回归测试；本报告不重复将这些已修复症状计为发现。
+- 相关但不同的剩余问题需分开：S-003 是“部分纬向交叠子区间”的球面积分偏差；S-006 是不完整样本被重标为 12 月气候态；S-009 是小类别分位数裁剪；S-011 是单**空间**格点，均不是已修复项的重复报告。
+- xESMF 官方 API 明确说明 conservative regridding 会强制 `periodic=False`，因此不接受旧报告中“conservative 应启用 `periodic=True`”的建议，见 [xESMF User API](https://xesmf.readthedocs.io/en/stable/user_api.html)。
+- 本报告未引用 `4044c69`，也未把 float32 权重单独定性为缺陷。
+
+### 1.8 修复验收摘要（`1a3bd64`）
+
+**验收结论：PASS。22 条发现全部 `[DONE]`。** 全量测试、Ruff、独立最小反例和代码审查均通过。
+
+| 最后闭合项 | 验收证据 | 结论 |
+|---|---|---|
+| S-004 | `runner/masking.py:105-124` 仅在 `apply_spatial_mask=True` 时按 finite support 裁时次。独立反例中 `apply_spatial_mask=False` 的 2 个相同 timestamp 均被保留；开启 spatial mask 时仍正确删除无有限支持时次。 | `[DONE]`，timestamp intersection 与 cumulative NaN mask 语义已分离。 |
+| S-011 | `conservative.py:267-276` 对 identical 1×1 返回单位权重，对非同点或单侧 singleton 明确报错；`regrid/utils.py:130-131` 不再构造 `[-inf, inf]`。双向 1×N 反例均得到预期 `ValueError`。 | `[DONE]`，不再制造无有限 bounds 的权重。 |
+
+P-001 按原报告的“保留最终 dense API、先去掉 broadcast 临时矩阵”口径标记为 `[DONE]`：3600→3600 构造附加峰值从 `395.6 MiB` 降至 `198.92 MiB`，权重本体为 `98.88 MiB`。最终 dense O(N×M) 仍是可继续优化的性能债，但不再视为本条验收阻塞。
+
+---
+
+## 2. 发现清单
+
+### 2.1 P1：高优先级
+
+#### S-001 [DONE] — P1｜科学正确性 / 时间 / CF calendar
+
+- **文件:行号**：`src/openbench/data/time_utils.py:21-40,81-112`；`src/openbench/data/_processing_time_integrity.py:55-58,108-111`
+- **问题与影响**：原生 `cftime_to_nptime` 无法表示非 Gregorian 日期时，fallback 把非法日夹到 Gregorian 月末。`360_day` 日尺度数据中的 2 月 28/29/30 日会全部变成 2 月 28 日；后续完整性处理保留第一个重复时间，静默删除另外两个样本。多年日尺度模型会形成系统性时间错位，进一步污染月平均、相位和模型间对齐。
+- **证据**：
+
+  ```text
+  输入：cftime.Datetime360Day(2001, 2, 1..30)
+  输出步数=30，唯一时间=28，2001-02-28 出现 3 次
+  ```
+
+  CF 明确定义 `360_day` 为 12 个 30 日月，不能把其日期标签当作 Gregorian 日期无损表示，见 [CF Conventions Calendar](https://cfconventions.org/cf-conventions/cf-conventions.html#calendar)。
+- **建议修复**：保留 `CFTimeIndex` 到时间聚合/对齐边界，或使用显式、单调且一一映射的 calendar conversion policy。不能无损转换时应 fail fast，禁止 clamp 后去重。增加 `360_day` 闰月、跨年、日/月重采样和缓存复跑测试。
+- **置信度**：高。
+
+#### S-002 [DONE] — P1｜科学正确性 / Regrid / 空间边界
+
+- **文件:行号**：`src/openbench/data/regrid/utils.py:57-76`；调用入口 `src/openbench/data/_processing_grid_regrid.py:74-97`
+- **问题与影响**：`create_lat_lon_coords()` 用浮点 `np.remainder(...) > 0` 判断端点是否整除。`0.1`、`0.2`、`0.05` 等常见分辨率的二进制误差会把整除误判为有余数，OpenBench conservative backend 的目标网格少北侧一行、东侧一列。相同配置在 xESMF/CDO 与内置 backend 可得到不同空间形状。
+- **证据**：全球 cell-center 网格最小/最大边界复现：
+
+  | 分辨率 | 实际 lat / 预期 | 实际 lon / 预期 | 实际末坐标 |
+  |---:|---:|---:|---|
+  | 0.2° | 899 / 900 | 1799 / 1800 | 89.7 / 179.7 |
+  | 0.1° | 1799 / 1800 | 3599 / 3600 | 89.85 / 179.85 |
+  | 0.05° | 3599 / 3600 | 7199 / 7200 | 89.925 / 179.925 |
+
+- **建议修复**：用整数格点数构造坐标（`n = round(span / resolution) + 1` 后 `start + arange(n)*resolution`），并用 `isclose` 验证最后一点；与 `_processing_grid_regrid.create_target_grid()` 统一为一个既有实现。增加全球/区域及升降序网格测试。
+- **置信度**：高。
+
+#### S-003 [DONE] — P1｜科学正确性 / Conservative regrid / 球面面积
+
+- **文件:行号**：`src/openbench/data/regrid/methods/conservative.py:154-170,515-570`；`src/openbench/data/regrid/utils.py:130-160`
+- **问题与影响**：先按纬度角的线性重叠长度计算权重，再乘“整个源纬带”的平均球面修正。目标格只覆盖源格一部分时，正确权重应使用该**重叠子区间**的球面面积积分，而不是整源格平均 `cos(lat)`。高纬、粗网格或不对齐网格会产生系统性保守重网格偏差。
+- **解析证据**：
+
+  ```text
+  源 lat 中心 [-60, 0, 60]，值 [0, 1, 2]
+  目标 lat 中心 [-30, 30]
+  OpenBench 公开 regrid accessor: [0.61681394, 1.38318606]
+  精确球面面积均值: [0.57735027, 1.42264973]
+  每格绝对误差: 0.03946367
+  ```
+
+  精确面积与 `sin(phi_upper)-sin(phi_lower)` 成正比；保守映射权重应基于 source/destination 的 fractional area overlap，见 [Jones 1999](https://doi.org/10.1175/1520-0493(1999)127%3C2204:FASOCR%3E2.0.CO;2)。
+- **建议修复**：在构造纬向 overlap 时直接对每个实际交叠上下界积分 `sin(phi_hi)-sin(phi_lo)`，不要事后用整源格面积缩放。用常量场、解析分段场、极区和广度不等间距网格验证守恒与均值精度。
+- **缓存影响**：修复会改变权重，必须同时版本化磁盘权重缓存（见 B-004）；旧权重应明确失效。
+- **置信度**：高。
+
+#### S-004 [DONE] — P1｜科学正确性 / 时间对齐 / Unified mask
+
+- **文件:行号**：`src/openbench/config/runtime_info.py:885-927`；`src/openbench/runner/masking.py:80-111`；`src/openbench/core/evaluation.py:220-238`
+- **问题与影响**：配置注释把 `intersection` 定义为 ref、所有 sim 和配置范围的共同交集，但实现按 pair 计算，并明确复用第一对任务的年份。掩码遇到不等时间轴时只在重叠区累积 invalid mask，然后把非重叠 ref 时间填成 `False`；最终每个 sim 又各自 `xr.align(join="inner")`。因此不同模型会在不同时间样本上得到指标，破坏跨模型可比性。
+- **证据**：
+
+  ```text
+  ref: Jan, Feb；Sim A: Jan；Sim B: Jan, Feb；mode=intersection
+  shared_ref_steps=2
+  pair_A_steps=1
+  pair_B_steps=2
+  ```
+
+- **建议修复**：任务规划后先计算该 variable/ref 下所有 sim 的**精确 timestamp 全局交集**，再一次性裁剪 ref 和所有 sim；`per_pair` 才保留逐对交集。统一掩码必须在同一时间支持上累积。增加三模型、同长度不同时间值、空交集和任务顺序置换测试。
+- **置信度**：高。
+
+#### S-005 [DONE] — P1｜科学正确性 / `strict` 时间对齐
+
+- **文件:行号**：`src/openbench/config/runtime_info.py:904-915`；`src/openbench/data/_processing_time_integrity.py:75-90`；`src/openbench/core/evaluation.py:220-232`
+- **问题与影响**：`strict` 对配置年份覆盖不足只记录 warning；时间完整性处理先把缺失月份/日期 reindex 成 NaN。进入 evaluation 时 sim/ref 时间坐标已经相同，`_align_grid_times()` 不再抛错，metrics 的 pairwise mask 又跳过缺测值。结果是 strict 模式对实际缺时次并不严格。
+- **证据**：12 个月参考数据、模拟缺 6 月：
+
+  ```text
+  raw_steps sim/ref = 11/12
+  after_integrity_steps = 12/12
+  timestamps_equal = True
+  sim_missing_count = 1
+  strict_raised = False
+  ```
+
+- **建议修复**：在补齐缺时次之前保存/验证原始时间覆盖；strict 应对缺失或额外 timestamp、重复时间及覆盖不足直接报错。非 strict 模式仍可 reindex+NaN。
+- **置信度**：高。
+
+#### S-006 [DONE] — P1｜科学正确性 / Climatology
+
+- **文件:行号**：`src/openbench/data/climatology.py:210-235`
+- **问题与影响**：reference 只要 `time_size == 12` 就被当作 Jan–Dec 月气候态并直接重标时间，没有验证原始月份集合、频率或顺序。12 个日样本、12 个不连续样本或重复月份会被伪装成完整年循环，污染 annual/monthly climatology、nPhaseScore 和 nSeasonalityScore。
+- **证据**：
+
+  ```text
+  输入：2001-01-01..2001-01-12，原始月份集合 [1]
+  输出月份：[1,2,...,12]
+  输出值仍为 [1,2,...,12]
+  ```
+
+- **建议修复**：只有时间月份恰好覆盖 `{1..12}` 且每月一个代表值，或配置显式声明 monthly climatology 时才走 12 点快路径；否则按实际时间 groupby，并对缺月报错。
+- **置信度**：高。
+
+#### S-007 [DONE] — P1｜科学正确性 / 缺失时间坐标
+
+- **文件:行号**：`src/openbench/data/_processing_time_core.py:159-183`；当前行为由 `tests/test_processing_time_missing.py:7-21` 固化
+- **问题与影响**：普通非 climatology 数据没有 `time` 坐标时，代码把整个静态 2-D 场广播到配置期内的每个时间步。一个损坏或选错变量的文件可被转换为“全年恒定但完整”的时间序列，产生非常可信的偏差、相关和评分结果，而不是暴露输入错误。
+- **证据**：2×2 无时间场、2000 年日尺度：
+
+  ```text
+  input_shape=(2,2)
+  output_shape=(366,2,2)
+  first_slice == last_slice == input
+  ```
+
+- **建议修复**：除显式 static/climatology 数据类型外，缺少 time 坐标应报可读错误。若兼容旧静态数据，必须用明确配置字段选择广播，而非自动猜测。
+- **置信度**：高。
+
+#### B-001 [DONE] — P1｜缓存正确性 / 算法指纹不完整
+
+- **文件:行号**：`src/openbench/runner/hashing.py:28-93,160-173,427-430`
+- **问题与影响**：`algorithm_source_fingerprint()` 只哈希固定模块列表；`openbench.data.regrid` 只会哈希包的 `__init__.py`，不会递归哈希实现。实际影响预处理/评估缓存输出的 `time_utils`、`unit`、`regrid.utils`、`regrid.methods.conservative`、station matcher/scanner 等均未列入。同一包版本下修正这些算法时，task hash 可保持不变并复用旧结果。
+- **证据**：上述关键模块对 `module in ALGORITHM_SOURCE_MODULES` 均为 `False`。`openbench_version` 不能覆盖 editable checkout、同版本补丁或未升版本的部署。landcover/climatezone groupby 位于 post-evaluation 阶段，不纳入本条 task-cache 主证据。
+- **建议修复**：最小方案是补齐所有直接影响预处理/评估输出的模块并加入显式 cache schema version；更稳妥但仍无需新依赖的方案是对受控 package 文件清单计算内容哈希。新增测试应证明修改每类算法 salt 会改变 task hash。
+- **缓存影响**：修复后相关旧 task cache 应一次性失效，这是必要而非兼容性回归。
+- **置信度**：高。
+
+#### B-002 [DONE] — P1｜缓存正确性 / Station 输入
+
+- **文件:行号**：`src/openbench/runner/hashing.py:214-276`；真实路径解析在 `src/openbench/config/runtime_info.py:387-428`
+- **问题与影响**：`input_file_signature()` 哈希 fulllist 文件本身以及 `root_dir` 下匹配的 NetCDF，却不解析 station CSV 中 `sim_dir`/`ref_dir` 指向的数据文件。站点数据位于 fulllist 外部目录时，数据内容改变但 task hash 不变，会静默复用陈旧指标和报告。
+- **证据**：临时 catalog 的 `stations.csv` 指向 sibling `external/station.nc`；把 station 文件从 `first` 改成 `second-content` 后：
+
+  ```text
+  signature_equal=True
+  signed_files=['stations.csv']
+  listed_station_signed=False
+  ```
+
+- **建议修复**：复用 runtime 的相对路径/env 展开规则解析 fulllist，收集实际 `sim_dir`/`ref_dir` 文件并加入签名；对不存在、重复、大小写扩展名和 Windows 路径加测试。
+- **缓存影响**：需要提升 input-signature schema；旧 station task cache 应失效，grid cache 不应无关失效。
+- **置信度**：高。
+
+### 2.2 P2：中优先级
+
+#### S-008 [DONE] — P2｜科学正确性 / 年循环评分
+
+- **文件:行号**：`src/openbench/core/scores.py:111-136,238-257`
+- **问题与影响**：`nPhaseScore` 和 `nSeasonalityScore` 只要求“任意月份有值”，不要求完整 12 个月；Jan–Feb 两个月完全一致即可得到 1.0，容易把不完整窗口误报为完美季节性。OpenBench 方法论文把 `nstep` 定义为完整年循环（monthly 为 12），见 [OpenBench scoring definition](https://gmd.copernicus.org/articles/18/6517/2025/)。
+- **证据**：Jan/Feb 值 `[1,2]` 的相同 sim/ref：`nPhaseScore=1.0`，`nSeasonalityScore=1.0`。
+- **建议修复**：要求每个空间单元具备 12 个共同有效月份；不足时返回 NaN/明确跳过。日尺度相位应相应验证完整年循环或明确可接受覆盖率。
+- **置信度**：高。
+
+#### S-009 [DONE] — P2｜科学正确性 / 分组统计
+
+- **文件:行号**：`src/openbench/core/landcover_groupby.py:79-95`；`src/openbench/core/climatezone_groupby.py:79-95`
+- **问题与影响**：每个类别先按 5%/95% quantile 删除两端，再算统计。类别只有两个有效格点时，0 和 100 的 quantile 为 5 和 95，两个真实值都被删成 NaN；小面积 landcover/climate zone 会错误显示 N/A。
+- **证据**：`[[0,100]]` 的中位数原为 50；clip 后 `[NaN,NaN]`，finite count=0。
+- **建议修复**：中位数汇总无需预裁剪；若保留 outlier 策略，应设置最小样本数并同时输出 `n_valid`。两个模块应复用同一既有 helper，避免规则漂移。
+- **置信度**：高。
+
+#### S-010 [DONE] — P2｜时间解析 / 小数偏移
+
+- **文件:行号**：`src/openbench/data/time_utils.py:272-326`
+- **问题与影响**：自定义 `<month|year|season> since ...` 解码对 offset 直接 `int(off)`，小数部分被静默截断。`0.5 years/months/seasons since 2000-01-01` 全部变为起始日期，引入隐蔽时间错位。
+- **证据**：三个单位的 `0.5` 偏移实际输出均为 `2000-01-01T00:00:00`。
+- **建议修复**：这些非标准单位若只支持整数偏移，应验证 `off == round(off)` 并报错；不要静默截断。若要支持小数，必须定义明确 calendar-aware 语义。
+- **置信度**：高。
+
+#### S-011 [DONE] — P2｜Regrid / 单格点边界
+
+- **文件:行号**：`src/openbench/data/regrid/utils.py:102-126,150-160,300-301`
+- **问题与影响**：公开 regrid accessor 对 1×1 网格会先在 `format_lat()` 对空 `diff()` 求最大值时崩溃。若绕过 accessor 进入底层权重路径，单坐标又会被转换为 `[-inf, inf]` 区间；source 和 target 的 overlap 为 `inf`，归一化执行 `inf/inf` 而得到 NaN。1×1 区域切片或异常最小网格既不能稳定返回常量，也没有一致错误契约。
+- **证据**：单格值 7 从 `(lat=0, lon=0)` 重网格到相同 1×1 目标，公开 accessor 抛出 `ValueError: numpy.nanmax raises on a.size==0 and axis=None`；隔离调用底层 overlap/normalize 路径则产生 `inf/inf -> NaN`。
+- **建议修复**：单点必须要求/推导有限 bounds；source/target 相同单点可直接单位权重。无法推导物理 cell bounds 时应报错而非用无限区间。
+- **置信度**：高。
+
+#### B-003 [DONE] — P2｜缓存键 / 可逆性
+
+- **文件:行号**：`src/openbench/runner/cache.py:201-203`
+- **问题与影响**：三元组用固定 `__` 拼接，不可逆：`('A__B','C','D')` 和 `('A','B__C','D')` 都得到 `A__B__C__D`。task hash 本身仍包含独立字段，通常会防止错误 cache hit，但同一映射槽会互相覆盖，造成持续 false miss、错误 invalidate 和断点状态丢失。
+- **证据**：上述两个合法 path-safe 名称组合的 key 完全相同。
+- **建议修复**：用稳定 JSON tuple 的 digest 或长度前缀编码。若需要读取旧 `.openbench_cache.json`，可在一个兼容窗口同时查询旧 key，新写只用新 key；随后提升 cache schema。
+- **置信度**：高。
+
+#### B-004 [DONE] — P2｜Regrid 权重磁盘缓存 / 版本化
+
+- **文件:行号**：`src/openbench/data/regrid/methods/conservative.py:257-297,440-489`
+- **问题与影响**：内存/磁盘权重 key 只含 source/target 坐标 dtype、shape 和内容 digest；磁盘文件名不含权重算法或 schema 版本。升级 overlap/normalize 算法后，即使 task hash 触发重算，进程仍可能从 `OPENBENCH_REGRID_WEIGHT_CACHE_DIR` 读出旧权重。
+- **证据**：`_weights_disk_cache_path()` 只对 coordinate key 做 SHA256；`.npz` 也只保存 `weights`，没有版本元数据。
+- **建议修复**：把 `REGRID_WEIGHT_SCHEMA_VERSION` 加入 key 和 `.npz` metadata，加载时验证版本、shape、finite/column sum。首次修复 S-003 时必须让旧权重失效。
+- **缓存影响**：旧权重应明确失效；坐标相同且算法版本相同的缓存命中保持兼容。
+- **置信度**：高。
+
+#### B-005 [DONE] — P2｜缓存 / NetCDF 输出契约
+
+- **文件:行号**：`src/openbench/config/schema.py:50-61`；`src/openbench/runner/hashing.py:419-478`
+- **问题与影响**：`project.io.netcdf_compression` 和 compression level 不进入 task hash。用户从未压缩切到压缩后，已有任务可被跳过，磁盘文件仍保持旧物理编码；数值不变，但配置声明的输出契约没有实现。
+- **证据**：只切换 compression 配置的两个 payload 得到相同 16 位 task hash。
+- **建议修复**：把影响物化文件格式的 IO 字段加入对应输出阶段 hash；不要把纯调优、不会改变文件的 batch planner 字段混入科学结果 hash。
+- **缓存影响**：只应使相关物化输出失效，不应无谓重算更早阶段。
+- **置信度**：高。
+
+#### B-006 [DONE] — P2｜缓存 / 数值栈版本
+
+- **文件:行号**：`src/openbench/runner/hashing.py:176-202,427-451`
+- **问题与影响**：backend signature 只在选择 xESMF/CDO/basic interpolation 时记录少量后端信息；内置路径没有 NumPy、pandas、xarray、cftime 等版本摘要。依赖升级改变时间解析、reduction、dtype promotion 或 backend 行为时，同 OpenBench 版本和源码仍可能命中旧结果。
+- **证据**：task payload 的 `openbench` 只有版本/算法/source fingerprint；`openbench_conservative` 环境值只是布尔 `True`。
+- **建议修复**：只加入会影响数值语义的核心依赖和实际选中 backend 的版本，避免把所有依赖都加入造成过度失效。为版本 salt 增加单元测试。
+- **置信度**：中高；需要先定义项目接受的跨依赖版本缓存兼容政策。
+
+#### B-007 [DONE] — P2｜跨平台 / 配置路径展开
+
+- **文件:行号**：`src/openbench/config/loader.py:1003-1030`；`src/openbench/cli/run.py:243-260`
+- **问题与影响**：`reference.overrides.<source>.root_dir/fulllist` 只校验字符串，不展开 `$ENV`/`~`；CLI 的集中展开也遗漏 reference overrides。HPC、macOS、Linux 和 Windows 上使用可移植环境变量配置时，resolver/adapter 可能访问字面路径，并连带使输入签名错误。
+- **证据**：`$OB_REVIEW_ROOT/data` 经 override validator 后仍为原字符串；CLI `_expand_config_paths()` 只处理 `reference.data_root` 和 simulation。
+- **建议修复**：在一个统一 path-normalization 边界展开所有路径字段，包括 reference override 和变量级 fulllist；CLI、GUI、Python API 共用，避免只在 CLI 补丁。
+- **置信度**：高。
+
+#### P-001 [DONE] — P2｜性能 / Regrid 权重内存峰值
+
+- **文件:行号**：`src/openbench/data/regrid/utils.py:130-160`；`src/openbench/data/regrid/methods/conservative.py:282-288`
+- **问题与影响**：`overlap()` 通过 broadcast 同时构造 `source × target` 的 `mins`、`maxs` 和 overlap dense 矩阵。经纬规则网格的非零重叠实际是窄带稀疏结构，首次构造却按 O(N×M) 内存。0.1° 全球 longitude 3600→3600 的单轴临时峰值接近 396 MiB；多进程/Dask 会放大。
+- **基准证据**：见第 3 节；3600→3600 权重本体 98.9 MiB，构造附加峰值 395.6 MiB。
+- **建议修复**：用双指针扫描有序区间，只生成实际相交 band；先保持最终 dense API 以缩小改动，验证后再考虑已有 optional `sparse` 路径。优化前后必须逐元素对照权重和守恒结果。
+- **置信度**：高。
+
+#### P-002 [DONE] — P2｜性能 / Metrics 重复掩码与线程峰值
+
+- **文件:行号**：`src/openbench/core/evaluation.py:116-119,396-414`；`src/openbench/core/metrics.py:43-64`；`src/openbench/core/scores.py:27-42,200-215`
+- **问题与影响**：evaluation 先对 sim/ref 做一次 pairwise finite mask，每个 metric/score 又各自 align 并重建同样的 mask；`Overall_Score` 内部 5 个分量再次各做验证。metric threading 并行这些大中间数组，速度略升但峰值内存大幅增加。
+- **基准证据**：365×90×180 float64 合成数据，4 个 metrics：串行 0.3171 s / 412.1 MiB 附加峰值；4 线程 0.2081 s / 767.1 MiB，速度约 1.52×，内存约 1.86×。KGE 单项附加峰值 411.9 MiB。
+- **建议修复**：保持公开 metric API 自验证，但 evaluation 内部使用一次已验证输入的私有计算路径，或删除外层重复 mask；对大数组按内存预算限制 metric workers。不要通过降 float 精度优化。
+- **置信度**：高。
+
+#### P-003 [DONE] — P2｜性能 / 缓存过度失效
+
+- **文件:行号**：`src/openbench/runner/hashing.py:423-426`
+- **问题与影响**：evaluation task hash 同时包含 `comparisons` 和 `statistics`。只改画图/比较/统计选项也会使预处理、重网格和指标任务 hash 改变，大数据运行发生无谓重算。
+- **证据**：仅改变 comparison 配置，task hash 从 `e2e395296b4764ea` 变为 `09f56e497258b23a`。
+- **建议修复**：按已有流程边界拆分阶段 hash：preprocess、evaluation、comparison/statistics、report 各验证自身输入；不要先引入通用 DAG/cache 抽象。
+- **置信度**：高。
+
+#### P-004 [DONE] — P2｜并发 / Dask × joblib 超额订阅
+
+- **文件:行号**：`src/openbench/runner/local.py:360-383`；`src/openbench/runner/orchestration.py:332-373`；`src/openbench/data/_processing_grid_core.py:88-142,227-237`
+- **问题与影响**：Dask client 在整个 runner 之前启动；evaluation task-level pool 会感知 Dask 并避免再开进程，但 preprocessing 没收到该预算，仍多处执行 joblib `Parallel(n_jobs=self.num_cores)`。Dask worker 与 loky worker 因而可同时存在并竞争内存/句柄；若 xarray/Dask compute 与 joblib preprocessing 重叠，还会竞争 CPU。
+- **证据**：调用链静态可证；尚未在真实 distributed cluster 复现死锁。
+- **建议修复**：最小方案是在 Dask active 时把 preprocessing 的 joblib worker 限制为 1，或延迟 Dask client 到真正需要 Dask distributed 的阶段。增加资源预算单元测试和一个本地 cluster smoke test。
+- **置信度**：中；真实影响依数据规模、Dask 配置和平台而异。
+
+---
+
+## 3. 性能基准表（修复前与优化对照）
+
+### 3.1 方法
+
+- 原始缺陷基准来自冻结快照 `3671375`；三个性能候选的前后对照分别在对应优化提交前后运行。环境均为单机 macOS/arm64、Python 3.12.12。
+- 计时使用 `time.perf_counter()`；原始表使用 `tracemalloc`，unified mask 对照使用 `psutil` 采样进程 RSS 增量。二者都不是生产数据的总内存需求。
+- 数据为合成数组；未包含真实 NetCDF 网络存储、解压、Dask scheduler 或报告绘图时间。
+
+### 3.2 Conservative weight 冷构造
+
+关闭内存/磁盘权重缓存：
+
+| source→target | 耗时 | 附加峰值 | 最终权重大小 |
+|---:|---:|---:|---:|
+| 180→360 | 0.00089 s | 2.00 MiB | 0.49 MiB |
+| 720→1440 | 0.00462 s | 31.68 MiB | 7.91 MiB |
+| 1800→1800 | 0.01371 s | 98.9 MiB | 24.7 MiB |
+| 1800→3600 | 0.02633 s | 197.84 MiB | 49.44 MiB |
+| 3600→3600 | 0.04994 s | 395.6 MiB | 98.9 MiB |
+
+结论：耗时不高，但 O(N×M) 临时矩阵是明显内存热点；在多 worker 下比单线程耗时更危险。
+
+### 3.3 Metrics / Scores
+
+输入：`time=365, lat=90, lon=180`，约 591 万个 float64/数组，sim/ref 各含约 1% 独立 NaN。
+
+| 计算 | 耗时 | 附加峰值 | 输出形状 |
+|---|---:|---:|---:|
+| RMSE | 0.0322 s | 191.8 MiB | 90×180 |
+| ubRMSE | 0.0543 s | 225.6 MiB | 90×180 |
+| KGE | 0.1712 s | 411.9 MiB | 90×180 |
+| nRMSEScore | 0.0741 s | 226.0 MiB | 90×180 |
+| Overall_Score | 1.0978 s | 247.9 MiB | 90×180 |
+
+并行对照（RMSE、ubRMSE、KGE、NSE）：
+
+| 模式 | 耗时 | 附加峰值 |
+|---|---:|---:|
+| 串行 | 0.3171 s | 412.1 MiB |
+| 4 线程 | 0.2081 s | 767.1 MiB |
+
+### 3.4 输入签名扫描
+
+临时目录内 1 KiB `.nc` 文件，包含 stat 和 head/middle/tail sample hash：
+
+| 文件数 | 耗时 | 峰值 |
+|---:|---:|---:|
+| 100 | 0.0240 s | 0.5 MiB |
+| 1000 | 0.2226 s | 1.0 MiB |
+| 5000 | 1.5168 s | 5.7 MiB |
+
+结论：当前 signature 成本近似线性，单次尚可；本轮更高风险是签名**漏文件**而不是签名本身太慢，不建议为了速度进一步弱化内容指纹。
+
+### 3.5 保留的性能候选项（未计入 22 条发现）
+
+| 候选项 | 当前证据 | 本轮处理 |
+|---|---|---|
+| MFM 逐格 histogram/FFT | 原实现同时请求 `MFM/MFM_omega/MFM_varphi/MFM_eta` 时，组合 MFM 会再次执行已经单独请求的三个组件。固定随机种子合成 `time=120, lat=20, lon=30` float64 数据（含 pairwise NaN），7 次中位耗时 `0.1546 s`，`np.histogram=7200`、`np.fft.rfft=2400`。 | `[DONE]` 提交 `413e180` 不改 histogram/FFT 数学实现，只在联合请求时一次计算并复用组件；中位耗时 `0.0794 s`（`-48.6%`），调用数减半为 `3600/1200`，tracemalloc 峰值 `2.392 → 2.380 MiB`。边界、Dask/eager 与公共 API 严格数值等价测试通过。单独请求 MFM 的逐格算法保持不变。 |
+| xESMF 权重持久化复用 | 提交 `c25d5d9` 新增内容寻址权重缓存，所有三条 xESMF 调用路径统一复用；key 覆盖 source/target 坐标、CF bounds、mask、method、periodic、schema 与 xESMF/ESMF/esmpy 版本，并复用现有跨平台文件锁和原子写。 | `[DONE]` 同网格第二次构造从磁盘加载权重；不同 bounds/mask/method/version 均产生 cache miss。全量 `1962 passed, 5 skipped`，Ruff 通过。环境未安装真实 xESMF/ESMF，故未给出真实权重生成耗时，仅以 mock 调用计数和官方“权重生成昂贵、可复用”的接口契约验收。 |
+| unified mask 合并后单次写入 | 优化前每个 sim 都通过 staged NetCDF + `os.replace` 重写共享 ref。固定随机种子 `1 ref + 4 sims`、`24×60×120` float64，7 次交替次序中位：spatial mask 开启 `0.0801 s`、4 次写入、累计 `2.674 MiB`、65 个 writer 图任务；关闭时 `0.0322 s`、4 次写入、9 个任务。 | `[DONE]` 提交 `011a26e` 在 `runner/masking.py:47-211` 懒合并 sibling finite mask，并在 `preprocessing.py:414-441` 恢复 mixed grid/station 文件后只原子替换一次。开启 spatial mask 时 `0.0380 s`（`-52.5%`）、1 次/`0.669 MiB`/32 个任务；关闭时 `0.0161 s`（`-49.9%`）、1 次/3 个任务。RSS 增量分别 `0.547 → 0.891 MiB` 与 `1.828 → 1.828 MiB`，即用很小的 graph/handle 常驻换取 I/O 减少。76 组随机时空错位/NaN 数值等价对照及定向/全量测试通过；关闭 spatial mask 时现在只收缩 time，不再静默收缩 ref 的 lat/lon。 |
+
+---
+
+## 4. 风险与已知限制
+
+1. **真实数据覆盖不足**：未获得多年度 360_day、极区高分辨率、真实 station fulllist、0.1° 全球多变量案例；当前证据以解析构造和合成数据为主。
+2. **Dask/HPC 未实测**：未运行远程 Dask cluster、NFS/Lustre、scheduler crash/restart 或 Dask worker 内嵌 joblib 的压力测试；P-004 为静态调用链加资源模型推断。
+3. **Windows 未实测**：CI 目标包含 Windows，但本次机器为 macOS；路径、文件替换、spawn、文件锁和 NetCDF/HDF5 句柄未做真实 Windows 运行。
+4. **GUI/SSH 未交互实测**：只做代码走查和现有自动化测试；没有启动 GUI、建立真实 SSH、测试断线重连或凭据生命周期。
+5. **统计假设需要领域数据**：Mann–Kendall、ANOVA、PLSR、FDR、three-cornered hat 的实现和现有测试已走查，未发现可直接证明的 P1/P2 公式错误；但 three-cornered hat 的误差独立性、ANOVA 分布/方差假设不能由代码自动保证，真实报告应显式呈现适用前提。
+6. **指标覆盖不是穷尽式**：本轮用解析/NumPy 对照验证了核心 RMSE/ubRMSE/NSE/KGE/correlation 及退化输入；未逐一对照 `metrics.py` 中所有复合水文指标和 bootstrap 指标。
+7. **报告图形未做像素验证**：`visualization/Fig_*.py` 和 HTML/PDF 仅代码审查；轴、单位、标签的视觉一致性未在所有组合下实测，按任务约束不列为高优先级。
+8. **并发工作区事件**：审查中仓库被另一个本地进程切换分支并多次提交。原始发现已基于 `3671375` 冻结，最终缺陷闭环基于 `1a3bd64` 验收；性能优化从该提交继续，首项为 `c25d5d9`。
+9. **xESMF 真实后端未实测**：当前环境没有 xESMF/ESMF，权重文件生成与命中通过接口一致的 mock 测试验证；真实 ESMF 运行时耗时、NFS 行为和跨版本文件兼容仍需在可选后端环境补测。
+10. **unified mask 大模型数压力未实测**：单次写入路径为保持 Dask lazy graph 会在一次写盘前保持每个 sibling sim 的数据集句柄；当前 4-sim 基准稳定，但数百模型、低文件句柄上限、Windows/NFS 和 distributed Dask 仍需真实压力测试。
+
+---
+
+## 5. 剩余修复顺序
+
+原报告 22 条发现和 §3.5 的三个性能候选均已闭合，无剩余修复顺序。
+
+### 阶段二验证要求补充
+
+- **时间类**：Gregorian/noleap/all_leap/360_day、闰年、日/月/年、同长度错 timestamp、空交集、缺月。
+- **重网格类**：常量守恒、解析纬带积分、极区、regional edge、升/降序坐标、1×1、backend 形状一致性。
+- **缓存类**：记录旧/新 hash 与 schema；明确哪些旧缓存应失效，验证同版本新缓存仍命中；不得用降低输入指纹强度换性能。
+- **指标类**：使用 float64 高精度参考；NaN 必须 pairwise 一致；退化输入明确返回 NaN 或抛错。
+- **并发类**：Linux/macOS/Windows 至少覆盖 spawn、异常传播、取消和 worker 预算；真实 Dask cluster 无法覆盖时明确保留验证缺口。
+
+---
+
+## 6. 阶段状态
+
+**阶段二修复与性能优化验收通过。** 22 条发现与三个性能候选全部 `[DONE]`；xESMF 权重持久化复用（`c25d5d9`）、MFM 共享计算（`413e180`）和 unified mask 单次写入（`011a26e`）均已独立提交，并通过各自定向测试、全量 pytest 与 Ruff。

--- a/src/openbench/core/evaluation.py
+++ b/src/openbench/core/evaluation.py
@@ -99,6 +99,14 @@ except ImportError:
         return ""
 
 
+_MFM_METRIC_NAMES = {"MFM", "MFM_omega", "MFM_varphi", "MFM_eta"}
+
+
+def _mfm_shared_metric_names(metric_names) -> set[str]:
+    names = {name for name in metric_names if name in _MFM_METRIC_NAMES}
+    return names if "MFM" in names and len(names) > 1 else set()
+
+
 def _metric_worker_count(num_cores, metric_count: int, pair_nbytes: int = 0) -> int:
     """Return metric-level workers bounded by configured cores and metric count."""
     if metric_count <= 1:
@@ -189,11 +197,14 @@ def _grid_output_array(value, template: xr.DataArray, name: str) -> xr.DataArray
 
 
 class Evaluation_grid(metrics, scores):
-    def _calculate_metric(self, s, o, metric):
+    def _calculate_metric(self, s, o, metric, shared_metrics=None):
         """Helper method for parallel metric calculation."""
         if not hasattr(self, metric):
             raise ValueError(f"No such metric: {metric}")
-        self.process_metric(metric, s, o)
+        if shared_metrics is not None and metric in shared_metrics:
+            self._save_metric_array(metric, shared_metrics[metric])
+        else:
+            self.process_metric(metric, s, o)
         return metric
 
     def __init__(self, info, fig_nml):
@@ -243,9 +254,7 @@ class Evaluation_grid(metrics, scores):
         logging.warning("%s; using %d overlapping timestamps", message, o_aligned.sizes.get("time", 0))
         return s_aligned, o_aligned
 
-    def process_metric(self, metric, s, o, vkey=""):
-        pb = getattr(self, metric)(s, o)
-        pb_da = _grid_output_array(pb, o, metric)
+    def _save_metric_array(self, metric, pb_da, vkey=""):
         # ponytail: compute before HDF5 write; lazy source reads inside to_netcdf can hang on Windows/netCDF4.
         pb_da = pb_da.load()
 
@@ -270,6 +279,31 @@ class Evaluation_grid(metrics, scores):
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             _write_netcdf_atomic(pb_da, output_path)
             logging.info(f"Saved metric {metric} to {output_path}")
+
+    def process_metric(self, metric, s, o, vkey=""):
+        pb = getattr(self, metric)(s, o)
+        self._save_metric_array(metric, _grid_output_array(pb, o, metric), vkey)
+
+    def _prepare_mfm_shared_metrics(self, s, o):
+        shared_names = _mfm_shared_metric_names(self.metrics)
+        if not shared_names:
+            return None
+        shared = self._MFM_shared_components(s, o)
+        return xr.Dataset({name: _grid_output_array(shared[name], o, name) for name in shared_names}).load()
+
+    def _process_metrics_in_order(self, s, o, shared_ds=None):
+        if shared_ds is None:
+            shared_ds = self._prepare_mfm_shared_metrics(s, o)
+
+        for metric in self.metrics:
+            if hasattr(self, metric):
+                logging.info(f"Calculating metric: {metric}")
+                if shared_ds is not None and metric in shared_ds:
+                    self._save_metric_array(metric, shared_ds[metric])
+                else:
+                    self.process_metric(metric, s, o)
+            else:
+                logging.error(f"No such metric: {metric}; skipping")
 
     def process_score(self, score, s, o, vkey=""):
         pb = getattr(self, score)(s, o)
@@ -408,11 +442,12 @@ class Evaluation_grid(metrics, scores):
                 len(self.metrics),
                 int(s.nbytes + o.nbytes),
             )
+            shared_metrics = self._prepare_mfm_shared_metrics(s, o)
             if _HAS_PARALLEL_ENGINE and metric_workers > 1:
                 logging.info("Processing %d metrics in parallel with %d worker(s)", len(self.metrics), metric_workers)
                 from functools import partial
 
-                metric_func = partial(self._calculate_metric, s, o)
+                metric_func = partial(self._calculate_metric, s, o, shared_metrics=shared_metrics)
                 metric_results = parallel_map(
                     metric_func,
                     self.metrics,
@@ -429,12 +464,7 @@ class Evaluation_grid(metrics, scores):
                 # Sequential processing — log + skip unknown metrics to
                 # match the parallel path (which never sys.exits). A typo
                 # in one metric name should not abort an entire run.
-                for metric in self.metrics:
-                    if hasattr(self, metric):
-                        logging.info(f"Calculating metric: {metric}")
-                        self.process_metric(metric, s, o)
-                    else:
-                        logging.error(f"No such metric: {metric}; skipping")
+                self._process_metrics_in_order(s, o, shared_metrics)
 
             # Process scores (usually fewer, so sequential is fine)
             for score in self.scores:
@@ -706,6 +736,8 @@ class Evaluation_stn(metrics, scores):
             s, o = _apply_pairwise_valid_mask(s, o)
 
             row = {}
+            shared_mfm_names = _mfm_shared_metric_names(self.metrics)
+            shared_mfm = self._MFM_shared_components(s, o) if shared_mfm_names else {}
             # for based plot
             try:
                 row["KGESS"] = self.KGESS(s, o).values
@@ -730,7 +762,7 @@ class Evaluation_stn(metrics, scores):
                     # Take .values when available, otherwise the result
                     # itself; fall back to NaN for None so the row stays
                     # numeric and downstream pd.concat / mean works.
-                    pb = getattr(self, metric)(s, o)
+                    pb = shared_mfm[metric] if metric in shared_mfm_names else getattr(self, metric)(s, o)
                     if pb is None:
                         row[f"{metric}"] = np.nan
                     elif hasattr(pb, "values"):

--- a/src/openbench/core/metrics.py
+++ b/src/openbench/core/metrics.py
@@ -876,6 +876,14 @@ class metrics:
 
         return smpi, smpi_lower, smpi_upper
 
+    def _MFM_shared_components(self, s, o):
+        """Return default MFM components plus combined MFM from one component pass."""
+        omega = self.MFM_omega(s, o)
+        varphi = self.MFM_varphi(s, o)
+        eta = self.MFM_eta(s, o)
+        mfm = 1 - np.sqrt(((1 - omega) ** 2 + (1 - varphi) ** 2 + (1 - eta) ** 2) / 3)
+        return {"MFM_omega": omega, "MFM_varphi": varphi, "MFM_eta": eta, "MFM": mfm}
+
     def MFM_omega(self, s, o, p=1, phase_penalty_scaling=4, phase=True):
         """Return MFM's normalized error with phase penalty component (omega).
 

--- a/src/openbench/core/statistics/Mod_Statistics.py
+++ b/src/openbench/core/statistics/Mod_Statistics.py
@@ -178,7 +178,7 @@ class BasicProcessing(statistics_calculate, BaseDatasetProcessing):
             try:
                 from openbench.data.regrid.regrid_wgs84 import convert_to_wgs84_xesmf
 
-                data = convert_to_wgs84_xesmf(data, self.compare_grid_res)
+                data = convert_to_wgs84_xesmf(data, self.compare_grid_res, cache_dir=self._xesmf_weight_cache_dir())
             except Exception as exc:
                 # Catch Exception (not bare `except:`) so KeyboardInterrupt and
                 # SystemExit can still propagate; log why xesmf failed so the
@@ -236,9 +236,24 @@ class BasicProcessing(statistics_calculate, BaseDatasetProcessing):
     def remap_xesmf(self, data: xr.Dataset, new_grid: xr.Dataset) -> xr.DataArray:
         import xesmf as xe
 
-        regridder = xe.Regridder(data, new_grid, "conservative")
+        from openbench.data.regrid.xesmf_cache import cached_regridder
+
+        regridder = cached_regridder(
+            xe,
+            data,
+            new_grid,
+            "conservative",
+            cache_dir=self._xesmf_weight_cache_dir(),
+            periodic=False,
+        )
         ds = regridder(data)
         return list(Convert_Type.convert_nc(ds.data_vars).values())[0]
+
+    def _xesmf_weight_cache_dir(self) -> str | None:
+        output_dir = getattr(self, "output_dir", None)
+        if output_dir:
+            return os.path.join(str(output_dir), "xesmf_weights")
+        return None
 
     def remap_cdo(self, data: xr.Dataset, new_grid: xr.Dataset) -> xr.DataArray:
         import tempfile

--- a/src/openbench/data/_processing_grid_core.py
+++ b/src/openbench/data/_processing_grid_core.py
@@ -291,8 +291,9 @@ class GridProcessingCoreMixin:
         if data["lon"].ndim == 2 and data["lat"].ndim == 2:
             try:
                 from openbench.data.regrid.regrid_wgs84 import convert_to_wgs84_xesmf
+                from openbench.data.regrid.xesmf_cache import default_weight_cache_dir
 
-                data = convert_to_wgs84_xesmf(data, self.compare_grid_res)
+                data = convert_to_wgs84_xesmf(data, self.compare_grid_res, cache_dir=default_weight_cache_dir(self))
             except (ImportError, ValueError, RuntimeError) as e:
                 logging.debug(f"xesmf regridding failed, falling back to scipy: {e}")
                 from openbench.data.regrid.regrid_wgs84 import convert_to_wgs84_scipy

--- a/src/openbench/data/_processing_grid_regrid.py
+++ b/src/openbench/data/_processing_grid_regrid.py
@@ -113,7 +113,16 @@ class GridRegridMixin:
     def remap_xesmf(self, data: xr.Dataset, new_grid: xr.Dataset) -> xr.Dataset:
         import xesmf as xe
 
-        regridder = xe.Regridder(data, new_grid, "conservative")
+        from openbench.data.regrid.xesmf_cache import cached_regridder, default_weight_cache_dir
+
+        regridder = cached_regridder(
+            xe,
+            data,
+            new_grid,
+            "conservative",
+            cache_dir=default_weight_cache_dir(self),
+            periodic=False,
+        )
         return regridder(data)
 
     def remap_cdo(self, data: xr.Dataset, new_grid: xr.Dataset) -> xr.Dataset:

--- a/src/openbench/data/regrid/regrid_wgs84.py
+++ b/src/openbench/data/regrid/regrid_wgs84.py
@@ -73,7 +73,13 @@ def convert_to_wgs84_scipy(ds: xr.Dataset, resolution=0.1) -> xr.Dataset:
     return new_ds
 
 
-def convert_to_wgs84_xesmf(ds: xr.Dataset, resolution=0.1, method: str = "conservative") -> xr.Dataset:
+def convert_to_wgs84_xesmf(
+    ds: xr.Dataset,
+    resolution=0.1,
+    method: str = "conservative",
+    *,
+    cache_dir: str | None = None,
+) -> xr.Dataset:
     # Step 2: Create a new regular lon-lat grid (WGS84)
     import xesmf as xe
 
@@ -92,7 +98,16 @@ def convert_to_wgs84_xesmf(ds: xr.Dataset, resolution=0.1, method: str = "conser
     )
 
     # Create the regridder
-    regridder = xe.Regridder(ds, target_grid, method)
+    from openbench.data.regrid.xesmf_cache import cached_regridder, default_weight_cache_dir
+
+    regridder = cached_regridder(
+        xe,
+        ds,
+        target_grid,
+        method,
+        cache_dir=cache_dir or default_weight_cache_dir(),
+        periodic=False,
+    )
 
     # Step 3: Perform the regridding
     new_data_vars = {}

--- a/src/openbench/data/regrid/xesmf_cache.py
+++ b/src/openbench/data/regrid/xesmf_cache.py
@@ -1,0 +1,151 @@
+"""Small persistent weight-cache wrapper for xESMF regridders."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from openbench.util.netcdf import write_file_atomic
+
+XESMF_WEIGHT_SCHEMA_VERSION = 1
+
+
+def cached_regridder(
+    xe: Any,
+    source: xr.Dataset | xr.DataArray,
+    target: xr.Dataset,
+    method: str,
+    *,
+    cache_dir: str | os.PathLike[str] | None = None,
+    periodic: bool = False,
+):
+    """Return an xESMF Regridder, loading/storing weights when a cache dir is configured."""
+    if cache_dir is None:
+        return _new_regridder(xe, source, target, method, periodic=periodic)
+
+    cache_path = _cache_path(source, target, method, cache_dir=cache_dir, periodic=periodic)
+    if cache_path.exists():
+        return _new_regridder(xe, source, target, method, periodic=periodic, weights=str(cache_path))
+
+    from openbench.runner.cache import _file_lock
+
+    with _file_lock(cache_path.with_suffix(cache_path.suffix + ".lock")):
+        if cache_path.exists():
+            return _new_regridder(xe, source, target, method, periodic=periodic, weights=str(cache_path))
+        regridder = _new_regridder(xe, source, target, method, periodic=periodic)
+        write_file_atomic(cache_path, lambda tmp: regridder.to_netcdf(str(tmp)), suffix=".nc")
+        return regridder
+
+
+def _new_regridder(
+    xe: Any,
+    source: xr.Dataset | xr.DataArray,
+    target: xr.Dataset,
+    method: str,
+    *,
+    periodic: bool,
+    weights: str | None = None,
+):
+    kwargs: dict[str, object] = {"periodic": periodic}
+    if weights is not None:
+        kwargs["weights"] = weights
+    return xe.Regridder(source, target, method, **kwargs)
+
+
+def default_weight_cache_dir(owner: object | None = None) -> str | None:
+    """Return configured xESMF weight-cache dir; mixin callers fall back to case scratch."""
+    env_dir = os.environ.get("OPENBENCH_XESMF_WEIGHT_CACHE_DIR")
+    if env_dir:
+        return str(Path(env_dir).expanduser())
+    casedir = getattr(owner, "casedir", None)
+    if casedir:
+        return os.path.join(str(casedir), "scratch", "xesmf_weights")
+    return None
+
+
+def _cache_path(
+    source: xr.Dataset | xr.DataArray,
+    target: xr.Dataset,
+    method: str,
+    *,
+    cache_dir: str | os.PathLike[str],
+    periodic: bool,
+) -> Path:
+    digest = hashlib.sha256()
+    payload = {
+        "schema": XESMF_WEIGHT_SCHEMA_VERSION,
+        "method": method,
+        "periodic": bool(periodic),
+        "versions": _versions(),
+        "source": _grid_token(source),
+        "target": _grid_token(target),
+    }
+    digest.update(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    return Path(cache_dir).expanduser() / f"xesmf-weights-{digest.hexdigest()}.nc"
+
+
+def _versions() -> dict[str, str | None]:
+    return {name: _package_version(name) for name in ("xesmf", "ESMF", "esmpy")}
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _grid_token(grid: xr.Dataset | xr.DataArray) -> list[dict[str, object]]:
+    dataset = grid.to_dataset(name="__dataarray__") if isinstance(grid, xr.DataArray) else grid
+    names = {
+        str(name)
+        for name, array in dataset.variables.items()
+        if str(name).lower() in {"lon", "lat", "lon_b", "lat_b", "longitude", "latitude", "x", "y", "mask"}
+        or str(array.attrs.get("standard_name", "")).lower() in {"longitude", "latitude"}
+        or str(array.attrs.get("long_name", "")).lower() in {"longitude", "latitude"}
+        or str(array.attrs.get("axis", "")).upper() in {"X", "Y"}
+        or _is_latlon_unit(array.attrs.get("units"))
+    }
+    for name in tuple(names):
+        bounds = dataset[name].attrs.get("bounds")
+        if isinstance(bounds, str) and bounds in dataset.variables:
+            names.add(bounds)
+    return [_array_token(name, dataset[name]) for name in sorted(names)]
+
+
+def _is_latlon_unit(value: object) -> bool:
+    unit = str(value or "").lower().replace("_", "").replace(" ", "")
+    return unit in {
+        "degreee",
+        "degreeeast",
+        "degreen",
+        "degreenorth",
+        "degreese",
+        "degreeseast",
+        "degreesn",
+        "degreesnorth",
+    }
+
+
+def _array_token(name: str, array: xr.DataArray) -> dict[str, object]:
+    values = np.ascontiguousarray(array.to_numpy())
+    digest = hashlib.sha256(values.view(np.uint8)).hexdigest()
+    return {
+        "name": name,
+        "dims": tuple(str(dim) for dim in array.dims),
+        "dtype": values.dtype.str,
+        "shape": tuple(values.shape),
+        "sha256": digest,
+        "attrs": {
+            key: str(array.attrs[key])
+            for key in ("axis", "bounds", "long_name", "standard_name", "units")
+            if key in array.attrs
+        },
+    }

--- a/src/openbench/runner/masking.py
+++ b/src/openbench/runner/masking.py
@@ -5,163 +5,205 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from collections.abc import Sequence
+from contextlib import ExitStack
 from typing import Callable
 
 logger = logging.getLogger(__name__)
 
 NetcdfWriter = Callable[..., None]
+SimMaskSource = str | tuple[str, str]
+
+
+def _mask_sources(sim_source: SimMaskSource | Sequence[SimMaskSource], default_varname: str) -> list[tuple[str, str]]:
+    if isinstance(sim_source, str):
+        return [(sim_source, default_varname)]
+    if isinstance(sim_source, tuple) and len(sim_source) == 2 and all(isinstance(value, str) for value in sim_source):
+        return [sim_source]
+    return [(source, default_varname) if isinstance(source, str) else source for source in sim_source]
+
+
+def _check_time_alignment(var_name: str, reference, simulation, time_alignment: str) -> bool:
+    import numpy as np
+
+    same_length = len(simulation["time"]) == len(reference["time"])
+    same_values = same_length and np.array_equal(simulation["time"].values, reference["time"].values)
+    if not same_length:
+        message = (
+            f"Unified mask: time length mismatch for {var_name} "
+            f"(ref={len(reference['time'])}, sim={len(simulation['time'])})"
+        )
+        if time_alignment == "strict":
+            raise ValueError(message)
+        logger.warning("%s, using overlapping timestamps", message)
+    elif not same_values:
+        message = f"Unified mask: time values mismatch for {var_name} (lengths equal but timestamps differ)"
+        if time_alignment == "strict":
+            raise ValueError(message)
+        logger.warning("%s, using overlapping timestamps", message)
+    return same_values
 
 
 def apply_unified_mask(
     info: dict,
     var_name: str,
     ref_source: str,
-    sim_source: str,
+    sim_source: SimMaskSource | Sequence[SimMaskSource],
     ref_override: str | None = None,
     *,
     write_netcdf_atomic_fn: NetcdfWriter,
     apply_spatial_mask: bool = True,
 ) -> None:
-    """Apply unified mask: set ref to NaN wherever sim is NaN.
-
-    This ensures evaluation metrics only cover grid cells where BOTH reference
-    and simulation have valid data. Called for each sim source, so the mask
-    accumulates — if any sim has NaN at a point, the ref gets NaN there too,
-    ensuring consistent spatial coverage across all model comparisons.
-
-    Only applies to grid data (station data is skipped).
-    """
+    """Apply unified mask: set ref to NaN wherever sims are NaN."""
     import numpy as np
+    import xarray as xr
+
+    from openbench.util.names import select_data_array
 
     casedir = info["casedir"]
     ref_varname = info.get("ref_varname", "")
     sim_varname = info.get("sim_varname", "")
     time_alignment = info.get("time_alignment", "intersection")
+    sim_sources = _mask_sources(sim_source, sim_varname)
 
     if ref_override:
         ref_path = ref_override
     else:
         ref_path = os.path.join(casedir, "data", f"{var_name}_ref_{ref_source}_{ref_varname}.nc")
-    sim_path = os.path.join(casedir, "data", f"{var_name}_sim_{sim_source}_{sim_varname}.nc")
-
     ref_path = os.path.abspath(ref_path)
-    sim_path = os.path.abspath(sim_path)
+    sim_paths = [
+        os.path.abspath(os.path.join(casedir, "data", f"{var_name}_sim_{source}_{varname}.nc"))
+        for source, varname in sim_sources
+    ]
 
-    missing_paths = [path for path in (ref_path, sim_path) if not os.path.exists(path)]
+    missing_paths = [path for path in (ref_path, *sim_paths) if not os.path.exists(path)]
     if missing_paths:
         raise FileNotFoundError(f"Unified mask input file not found: {', '.join(missing_paths)}")
 
-    ref_ds = None
-    sim_ds = None
     staged_path = None
     try:
-        import xarray as xr
+        with ExitStack() as stack:
+            ref_ds = stack.enter_context(xr.open_dataset(ref_path, chunks="auto"))
+            ref_data = select_data_array(ref_ds, ref_varname, var_name)
 
-        ref_ds = xr.open_dataset(ref_path, chunks="auto")
-        sim_ds = xr.open_dataset(sim_path, chunks="auto")
+            try:
+                from openbench.util.converttype import Convert_Type
 
-        # The flat file stores the variable under the configured name OR the
-        # relabelled evaluation item (when a fallback/convert derived it, e.g.
-        # NEE from f_respc). Resolve robustly instead of hard-indexing the
-        # possibly-stale config varname. (var_name is the evaluation item.)
-        from openbench.util.names import select_data_array
+                ref_data = Convert_Type.convert_nc(ref_data)
+            except ImportError:
+                pass
 
-        o = select_data_array(ref_ds, ref_varname, var_name)
-        s = select_data_array(sim_ds, sim_varname, var_name)
+            if len(sim_sources) == 1:
+                o = ref_data
+                for (source, source_varname), sim_path in zip(sim_sources, sim_paths, strict=True):
+                    sim_ds = stack.enter_context(xr.open_dataset(sim_path, chunks="auto"))
+                    s = select_data_array(sim_ds, source_varname, var_name)
+                    try:
+                        from openbench.util.converttype import Convert_Type
 
-        # Convert types if needed
-        try:
-            from openbench.util.converttype import Convert_Type
+                        s = Convert_Type.convert_nc(s)
+                    except ImportError:
+                        pass
 
-            o = Convert_Type.convert_nc(o)
-            s = Convert_Type.convert_nc(s)
-        except ImportError:
-            pass
+                    same_values = _check_time_alignment(var_name, o, s, time_alignment)
+                    if same_values:
+                        o_aligned, s_aligned = o, s
+                    else:
+                        excluded_dims = set() if apply_spatial_mask else (set(o.dims) | set(s.dims)) - {"time"}
+                        o_aligned, s_aligned = xr.align(o, s, join="inner", exclude=excluded_dims)
+                        if o_aligned.sizes.get("time", 0) == 0:
+                            raise ValueError(f"Unified mask: no overlapping timestamps for {var_name}")
 
-        # Align time dimension. In strict mode mismatches are errors. In the
-        # default intersection mode, contribute the overlapping timestamps to
-        # the shared mask instead of silently skipping this simulation; skipping
-        # makes final masks depend on which sibling sims happened to align.
-        same_length = len(s["time"]) == len(o["time"])
-        same_values = same_length and np.array_equal(s["time"].values, o["time"].values)
-        if not same_length:
-            message = f"Unified mask: time length mismatch for {var_name} (ref={len(o['time'])}, sim={len(s['time'])})"
-            if time_alignment == "strict":
-                raise ValueError(message)
-            logger.warning("%s, using overlapping timestamps", message)
-        elif not same_values:
-            message = f"Unified mask: time values mismatch for {var_name} (lengths equal but timestamps differ)"
-            if time_alignment == "strict":
-                raise ValueError(message)
-            logger.warning("%s, using overlapping timestamps", message)
+                    finite_pairs = np.isfinite(s_aligned) & np.isfinite(o_aligned) if apply_spatial_mask else None
+                    if finite_pairs is not None and time_alignment == "intersection" and "time" in finite_pairs.dims:
+                        non_time_dims = [dim for dim in finite_pairs.dims if dim != "time"]
+                        valid_times = finite_pairs.any(dim=non_time_dims) if non_time_dims else finite_pairs
+                        if hasattr(valid_times, "compute"):
+                            valid_times = valid_times.compute()
+                        if not bool(valid_times.any().item()):
+                            raise ValueError(f"Unified mask: no overlapping finite timestamps for {var_name}")
+                        o_aligned = o_aligned.where(valid_times, drop=True)
+                        s_aligned = s_aligned.where(valid_times, drop=True)
+                        finite_pairs = np.isfinite(s_aligned) & np.isfinite(o_aligned)
 
-        if same_values:
-            o_aligned, s_aligned = o, s
-        else:
-            o_aligned, s_aligned = xr.align(o, s, join="inner")
-            if o_aligned.sizes.get("time", 0) == 0:
-                raise ValueError(f"Unified mask: no overlapping timestamps for {var_name}")
+                    invalid_overlap = ~finite_pairs if finite_pairs is not None else None
+                    if time_alignment == "intersection":
+                        o = o_aligned.where(~invalid_overlap) if invalid_overlap is not None else o_aligned
+                    elif same_values:
+                        o = o.where(~invalid_overlap) if invalid_overlap is not None else o
+                    else:
+                        invalid_full = (
+                            invalid_overlap.reindex_like(o, fill_value=False) if invalid_overlap is not None else None
+                        )
+                        o = o.where(~invalid_full) if invalid_full is not None else o
+            else:
+                aligned_ref = ref_data
+                global_finite = None
+                # ponytail: one open handle per sibling avoids repeat reads/writes;
+                # batch/reopen only if real model counts approach OS handle limits.
+                for (source, source_varname), sim_path in zip(sim_sources, sim_paths, strict=True):
+                    sim_ds = stack.enter_context(xr.open_dataset(sim_path, chunks="auto"))
+                    sim_data = select_data_array(sim_ds, source_varname, var_name)
+                    try:
+                        from openbench.util.converttype import Convert_Type
 
-        finite_pairs = np.isfinite(s_aligned) & np.isfinite(o_aligned)
-        if apply_spatial_mask and time_alignment == "intersection" and "time" in finite_pairs.dims:
-            non_time_dims = [dim for dim in finite_pairs.dims if dim != "time"]
-            valid_times = finite_pairs.any(dim=non_time_dims) if non_time_dims else finite_pairs
-            if hasattr(valid_times, "compute"):
-                valid_times = valid_times.compute()
-            if not bool(valid_times.any().item()):
-                raise ValueError(f"Unified mask: no overlapping finite timestamps for {var_name}")
-            o_aligned = o_aligned.where(valid_times, drop=True)
-            s_aligned = s_aligned.where(valid_times, drop=True)
-            finite_pairs = np.isfinite(s_aligned) & np.isfinite(o_aligned)
+                        sim_data = Convert_Type.convert_nc(sim_data)
+                    except ImportError:
+                        pass
 
-        # Keep the spatial mask lazy so chunked/dask-backed inputs are not
-        # materialized twice before the NetCDF writer streams them.
-        invalid_overlap = ~finite_pairs if apply_spatial_mask else None
-        if time_alignment == "intersection":
-            # Persist the exact shared time support. Repeating this for each
-            # sibling simulation makes the reference time axis the global,
-            # order-independent intersection used by every model.
-            o_data = o_aligned.where(~invalid_overlap) if invalid_overlap is not None else o_aligned
-        elif same_values:
-            o_data = o.where(~invalid_overlap) if invalid_overlap is not None else o
-        else:
-            invalid_full = invalid_overlap.reindex_like(o, fill_value=False) if invalid_overlap is not None else None
-            o_data = o.where(~invalid_full) if invalid_full is not None else o
+                    same_values = _check_time_alignment(var_name, aligned_ref, sim_data, time_alignment)
+                    if apply_spatial_mask or not same_values:
+                        excluded_dims = (
+                            set() if apply_spatial_mask else (set(aligned_ref.dims) | set(sim_data.dims)) - {"time"}
+                        )
+                        aligned_ref, sim_aligned = xr.align(
+                            aligned_ref,
+                            sim_data,
+                            join="inner",
+                            exclude=excluded_dims,
+                        )
+                        if aligned_ref.sizes.get("time", 0) == 0:
+                            raise ValueError(f"Unified mask: no overlapping timestamps for {var_name}")
+                        if global_finite is not None:
+                            global_finite = global_finite.reindex_like(aligned_ref, fill_value=False)
+                    else:
+                        sim_aligned = sim_data
+                    if apply_spatial_mask:
+                        sim_finite = np.isfinite(sim_aligned)
+                        global_finite = sim_finite if global_finite is None else (global_finite & sim_finite)
 
-        # Write to a sibling staging target while the lazy source datasets are
-        # open, then close them before replacing the original. Windows refuses
-        # to replace an open NetCDF file even when the replacement itself is atomic.
-        fd, staged_path = tempfile.mkstemp(
-            prefix=f".{os.path.basename(ref_path)}.mask-",
-            suffix=".nc",
-            dir=os.path.dirname(ref_path),
-        )
-        os.close(fd)
-        write_netcdf_atomic_fn(o_data, staged_path, compression=False)
-        ref_ds.close()
-        ref_ds = None
-        sim_ds.close()
-        sim_ds = None
+                if apply_spatial_mask:
+                    assert global_finite is not None
+                    global_finite = global_finite & np.isfinite(aligned_ref)
+                    if time_alignment == "intersection" and "time" in global_finite.dims:
+                        non_time_dims = [dim for dim in global_finite.dims if dim != "time"]
+                        valid_times = global_finite.any(dim=non_time_dims) if non_time_dims else global_finite
+                        if hasattr(valid_times, "compute"):
+                            valid_times = valid_times.compute()
+                        if not bool(valid_times.any().item()):
+                            raise ValueError(f"Unified mask: no overlapping finite timestamps for {var_name}")
+                        global_finite = global_finite.where(valid_times, drop=True)
+                        aligned_ref = aligned_ref.where(valid_times, drop=True)
+                    o = aligned_ref.where(global_finite)
+                else:
+                    o = aligned_ref
+
+            fd, staged_path = tempfile.mkstemp(
+                prefix=f".{os.path.basename(ref_path)}.mask-",
+                suffix=".nc",
+                dir=os.path.dirname(ref_path),
+            )
+            os.close(fd)
+            write_netcdf_atomic_fn(o, staged_path, compression=False)
+
         os.replace(staged_path, ref_path)
         staged_path = None
-        logger.debug("Unified mask applied: %s (sim=%s)", var_name, sim_source)
-
-        del o, s, o_aligned, s_aligned, invalid_overlap, o_data
+        logger.debug("Unified mask applied: %s (sims=%s)", var_name, [source for source, _ in sim_sources])
 
     except Exception:
         logger.exception("Unified mask failed for %s (sim=%s)", var_name, sim_source)
         raise
     finally:
-        if ref_ds is not None:
-            try:
-                ref_ds.close()
-            except Exception:
-                pass
-        if sim_ds is not None:
-            try:
-                sim_ds.close()
-            except Exception:
-                pass
         if staged_path is not None:
             try:
                 os.unlink(staged_path)

--- a/src/openbench/runner/preprocessing.py
+++ b/src/openbench/runner/preprocessing.py
@@ -54,9 +54,8 @@ def preprocess_variable(
     # ref_source -> flat ref NC path (only valid while a grid-only path lives there)
     ref_flat_paths: dict[str, str] = {}
     sim_flat_paths: dict[str, str] = {}
-    # ref_source -> temporary backup of the current flat ref NC. This is
-    # refreshed whenever shared unified_mask mutates the flat file, so a
-    # later station extraction can delete the flat without losing masks.
+    # Temporary copies let mixed station/grid preprocessing restore flat files
+    # consumed by station extraction before the final shared mask is written.
     ref_flat_backups: dict[str, str] = {}
     sim_flat_backups: dict[str, str] = {}
     temp_backup_paths: set[str] = set()
@@ -77,6 +76,19 @@ def preprocess_variable(
         ref: {task["sim_source"] for task in vtasks if task["ref_source"] == ref}
         for ref in {task["ref_source"] for task in vtasks}
     }
+    pending_shared_masks: dict[str, dict[str, Any]] = {}
+    failed_shared_mask_refs: set[str] = set()
+
+    def _shared_mask_group(ref_source: str) -> dict[str, Any]:
+        return pending_shared_masks.setdefault(ref_source, {"info": None, "sims": [], "tasks": []})
+
+    def _mark_shared_mask_group_failed(ref_source: str, message: str) -> None:
+        failed_shared_mask_refs.add(ref_source)
+        group = pending_shared_masks.get(ref_source)
+        group_tasks = group["tasks"] if group else [task for task in vtasks if task["ref_source"] == ref_source]
+        for group_task in group_tasks:
+            group_task["preprocess_failed"] = True
+        phase_errors.append(make_phase_error_fn("preprocess", message, variable=var_name, ref=ref_source))
 
     def _backup_flat_ref(ref_source: str) -> None:
         flat_path = ref_flat_paths.get(ref_source)
@@ -138,6 +150,9 @@ def preprocess_variable(
                 continue
             ref_source = task["ref_source"]
             sim_source = task["sim_source"]
+            ref_dtype = None
+            sim_dtype = None
+            defer_completion = False
             emit_gui_preprocessing_started(task)
             try:
                 info = build_bridge_runtime_info_fn(task)
@@ -276,20 +291,23 @@ def preprocess_variable(
                             # Record per-pair ref path so evaluation uses this copy
                             task["ref_file_override"] = pair_ref
                         elif time_alignment != "per_pair":
-                            # intersection/strict: mask accumulates across sims onto shared ref
-                            _restore_flat_ref_if_missing(ref_source)
-                            apply_unified_mask_fn(
-                                info,
-                                var_name,
-                                ref_source,
-                                sim_source,
-                                apply_spatial_mask=bool(unified_mask),
-                            )
-                            _backup_flat_ref(ref_source)
+                            # intersection/strict: apply once per shared ref after all sibling sims are ready.
+                            group = _shared_mask_group(ref_source)
+                            group["info"] = group["info"] or dict(info)
+                            group["sims"].append((sim_source, info.get("sim_varname", "")))
+                            group["tasks"].append(task)
+                            defer_completion = True
 
                 task["ref_preprocessed"] = True
 
             except Exception as exc:
+                if (
+                    ref_dtype != "stn"
+                    and sim_dtype != "stn"
+                    and time_alignment != "per_pair"
+                    and (unified_mask or (time_alignment == "intersection" and len(sibling_sims[ref_source]) > 1))
+                ):
+                    failed_shared_mask_refs.add(ref_source)
                 task["preprocess_failed"] = True
                 phase_errors.append(
                     make_phase_error_fn(
@@ -312,7 +330,8 @@ def preprocess_variable(
                 else:
                     logger.exception("Preprocessing failed: %s (sim=%s, ref=%s)", var_name, sim_source, ref_source)
             else:
-                emit_gui_preprocessing_completion(task)
+                if not defer_completion:
+                    emit_gui_preprocessing_completion(task)
 
         # End-of-loop flat-NC restoration:
         # If a ref had any stn-involved prep AND any grid×grid task in this
@@ -320,8 +339,7 @@ def preprocess_variable(
         # the shared flat NC at data/<var>_ref_<ref>_<varname>.nc. The
         # downstream grid evaluation reads that exact path and would crash
         # with FileNotFoundError. Prefer restoring the last backed-up flat
-        # ref, which preserves accumulated unified_mask edits; fall back to
-        # re-running grid prep only if no backup is available.
+        # ref; fall back to re-running grid prep only if no backup is available.
         refs_needing_restore = refs_with_stn_prep & refs_with_grid_tasks
         for ref_to_restore in sorted(refs_needing_restore):
             if _restore_flat_ref_if_missing(ref_to_restore):
@@ -392,6 +410,35 @@ def preprocess_variable(
                     var_name,
                     sim_to_restore,
                 )
+
+        # Apply shared grid masks only after every sibling sim for the ref is preprocessed.
+        # A later failure leaves the original flat ref untouched and blocks the whole group.
+        for ref_source, group in pending_shared_masks.items():
+            if ref_source in failed_shared_mask_refs:
+                _mark_shared_mask_group_failed(
+                    ref_source,
+                    "shared unified-mask preprocessing skipped because a sibling task failed",
+                )
+                continue
+            try:
+                _restore_flat_ref_if_missing(ref_source)
+                apply_unified_mask_fn(
+                    group["info"],
+                    var_name,
+                    ref_source,
+                    group["sims"],
+                    apply_spatial_mask=bool(unified_mask),
+                )
+            except Exception as exc:
+                logger.exception("Shared unified mask failed: %s (ref=%s)", var_name, ref_source)
+                _mark_shared_mask_group_failed(
+                    ref_source,
+                    f"shared unified-mask preprocessing failed: {exc}",
+                )
+            else:
+                for group_task in group["tasks"]:
+                    if not group_task.get("preprocess_failed"):
+                        emit_gui_preprocessing_completion(group_task)
 
     finally:
         _cleanup_flat_backups()

--- a/tests/test_audit_bugfixes.py
+++ b/tests/test_audit_bugfixes.py
@@ -354,9 +354,9 @@ def test_curvilinear_xesmf_defaults_to_conservative(monkeypatch):
     methods = []
 
     class FakeRegridder:
-        def __init__(self, _source, target_grid, method):
+        def __init__(self, _source, target_grid, method, *, periodic=False):
             self.target_grid = target_grid
-            methods.append(method)
+            methods.append((method, periodic))
 
         def __call__(self, _data):
             return xr.DataArray(
@@ -375,7 +375,7 @@ def test_curvilinear_xesmf_defaults_to_conservative(monkeypatch):
 
     convert_to_wgs84_xesmf(ds, resolution=1.0)
 
-    assert methods == ["conservative"]
+    assert methods == [("conservative", False)]
 
 
 def test_unified_mask_non_strict_uses_overlapping_times(tmp_path):

--- a/tests/test_core/test_metrics.py
+++ b/tests/test_core/test_metrics.py
@@ -360,3 +360,65 @@ def test_mfm_component_domains_only_require_observed_mean_for_omega():
     assert np.isfinite(float(m.MFM_varphi(sim, obs)))
     assert np.isfinite(float(m.MFM_eta(sim, obs)))
     assert np.isnan(float(m.MFM(sim, obs)))
+
+
+def test_mfm_shared_components_match_public_metrics_edge_cases():
+    from openbench.core.metrics import metrics
+
+    m = metrics()
+    cases = [
+        (make_da([1.0, np.nan, 3.0, 4.0, 5.0]), make_da([1.1, 2.0, 2.8, np.nan, 5.2])),
+        (make_da([2.0, 2.0, 2.0, 2.0]), make_da([2.0, 2.0, 2.0, 2.0])),
+        (make_da([1.0, 2.0]), make_da([1.0, 2.0])),
+        (make_da([0.5, 0.0, -0.5]), make_da([-1.0, 0.0, 1.0])),
+    ]
+
+    for sim, obs in cases:
+        shared = m._MFM_shared_components(sim, obs)
+        xr.testing.assert_allclose(shared["MFM_omega"], m.MFM_omega(sim, obs), rtol=0, atol=0)
+        xr.testing.assert_allclose(shared["MFM_varphi"], m.MFM_varphi(sim, obs), rtol=0, atol=0)
+        xr.testing.assert_allclose(shared["MFM_eta"], m.MFM_eta(sim, obs), rtol=0, atol=0)
+        xr.testing.assert_allclose(shared["MFM"], m.MFM(sim, obs), rtol=0, atol=0)
+
+
+def test_mfm_shared_components_lock_degenerate_values():
+    from openbench.core.metrics import metrics
+
+    m = metrics()
+
+    perfect = m._MFM_shared_components(make_da([2.0, 2.0, 2.0, 2.0]), make_da([2.0, 2.0, 2.0, 2.0]))
+    for name in ["MFM_omega", "MFM_varphi", "MFM_eta", "MFM"]:
+        assert float(perfect[name]) == 1.0
+
+    too_short = m._MFM_shared_components(make_da([1.0, 2.0]), make_da([1.0, 2.0]))
+    for name in ["MFM_omega", "MFM_varphi", "MFM_eta", "MFM"]:
+        assert np.isnan(float(too_short[name]))
+
+    zero_mean_obs = m._MFM_shared_components(make_da([0.5, 0.0, -0.5]), make_da([-1.0, 0.0, 1.0]))
+    assert np.isnan(float(zero_mean_obs["MFM_omega"]))
+    assert np.isnan(float(zero_mean_obs["MFM"]))
+    assert np.isfinite(float(zero_mean_obs["MFM_varphi"]))
+    assert np.isfinite(float(zero_mean_obs["MFM_eta"]))
+
+
+def test_mfm_shared_components_match_public_mfm_for_dask():
+    pytest = __import__("pytest")
+    pytest.importorskip("dask.array")
+    from openbench.core.metrics import metrics
+
+    m = metrics()
+    times = pd.date_range("2001-01-01", periods=8)
+    obs = xr.DataArray(
+        np.arange(32.0).reshape(8, 2, 2) + 1,
+        coords={"time": times, "lat": [0.0, 1.0], "lon": [10.0, 20.0]},
+        dims=("time", "lat", "lon"),
+    )
+    sim = obs * 1.05
+    obs_dask = obs.chunk({"time": 4})
+    sim_dask = sim.chunk({"time": 4})
+
+    shared = xr.Dataset(m._MFM_shared_components(sim_dask, obs_dask)).compute()
+    eager = m._MFM_shared_components(sim, obs)
+
+    for name, expected in eager.items():
+        xr.testing.assert_allclose(shared[name], expected, rtol=0, atol=0)

--- a/tests/test_metric_score_core_regressions.py
+++ b/tests/test_metric_score_core_regressions.py
@@ -12,6 +12,7 @@ from openbench.core.evaluation import (
     Evaluation_stn,
     _apply_pairwise_valid_mask,
     _has_any_valid_pair,
+    _mfm_shared_metric_names,
 )
 from openbench.core.metrics import metrics
 from openbench.core.registry import IMPLEMENTED_METRICS, IMPLEMENTED_SCORES
@@ -288,3 +289,144 @@ def test_preflight_station_columns_require_finite_requested_values(tmp_path):
     missing = missing_expected_outputs(out, task)
 
     assert path in missing
+
+
+def test_mfm_shared_detection_uses_unique_metric_names():
+    assert _mfm_shared_metric_names(["MFM", "MFM"]) == set()
+    assert _mfm_shared_metric_names(["MFM", "MFM_eta", "MFM_eta"]) == {"MFM", "MFM_eta"}
+
+
+def test_grid_evaluation_reuses_shared_mfm_components(monkeypatch):
+    ev = Evaluation_grid.__new__(Evaluation_grid)
+    ev.metrics = ["MFM", "MFM_eta", "MFM_omega"]
+    ev.item = "Runoff"
+    ev.ref_source = "Ref"
+    ev.sim_source = "Sim"
+    ev.output_manager = None
+    counts = {"omega": 0, "varphi": 0, "eta": 0, "mfm": 0}
+    saved = []
+    arr = xr.DataArray([[1.0]], coords={"lat": [0.0], "lon": [0.0]}, dims=("lat", "lon"))
+
+    def component(name, value):
+        def _inner(_s, _o):
+            counts[name] += 1
+            return arr * value
+
+        return _inner
+
+    ev.MFM_omega = component("omega", 0.8)
+    ev.MFM_varphi = component("varphi", 0.7)
+    ev.MFM_eta = component("eta", 0.6)
+    ev.MFM = component("mfm", 0.1)
+
+    def save_metric(name, da, vkey=""):
+        saved.append((name, float(da.values.squeeze())))
+
+    monkeypatch.setattr(ev, "_save_metric_array", save_metric)
+    template = xr.DataArray(
+        np.ones((4, 1, 1)),
+        coords={"time": pd.date_range("2001-01-01", periods=4), "lat": [0.0], "lon": [0.0]},
+        dims=("time", "lat", "lon"),
+    )
+
+    ev._process_metrics_in_order(template, template)
+
+    assert counts == {"omega": 1, "varphi": 1, "eta": 1, "mfm": 0}
+    assert [name for name, _ in saved] == ev.metrics
+    expected_mfm = 1 - np.sqrt(((1 - 0.8) ** 2 + (1 - 0.7) ** 2 + (1 - 0.6) ** 2) / 3)
+    assert saved[0][1] == pytest.approx(expected_mfm)
+
+
+def test_station_evaluation_reuses_shared_mfm_components(tmp_path, monkeypatch):
+    monkeypatch.setattr("openbench.core.evaluation.plot_stn", lambda *args, **kwargs: None)
+    ev = Evaluation_stn.__new__(Evaluation_stn)
+    ev.casedir = str(tmp_path)
+    ev.item = "Runoff"
+    ev.ref_source = "Ref"
+    ev.sim_source = "Sim"
+    ev.ref_varname = ["v"]
+    ev.sim_varname = ["v"]
+    ev.metrics = ["MFM", "MFM_eta"]
+    ev.scores = []
+    ev.compare_tim_res = ""
+    counts = {"omega": 0, "varphi": 0, "eta": 0, "mfm": 0}
+
+    def component(name, value):
+        def _inner(_s, _o):
+            counts[name] += 1
+            return xr.DataArray(value)
+
+        return _inner
+
+    ev.MFM_omega = component("omega", 0.8)
+    ev.MFM_varphi = component("varphi", 0.7)
+    ev.MFM_eta = component("eta", 0.6)
+    ev.MFM = component("mfm", 0.1)
+    data_dir = tmp_path / "data" / "stn_Ref_Sim"
+    data_dir.mkdir(parents=True)
+    time = pd.date_range("2001-01-01", periods=4)
+    ds = xr.Dataset({"v": ("time", np.arange(4.0) + 1)}, coords={"time": time})
+    ds.to_netcdf(data_dir / "Runoff_sim_S1_2001_2001.nc")
+    ds.to_netcdf(data_dir / "Runoff_ref_S1_2001_2001.nc")
+    station_list = {"ID": ["S1"], "use_syear": [2001], "use_eyear": [2001], "ref_lat": [0.0], "ref_lon": [0.0]}
+
+    row = ev.make_evaluation_parallel(station_list, 0)
+
+    assert counts == {"omega": 1, "varphi": 1, "eta": 1, "mfm": 0}
+    assert float(row["MFM_eta"]) == pytest.approx(0.6)
+    expected_mfm = 1 - np.sqrt(((1 - 0.8) ** 2 + (1 - 0.7) ** 2 + (1 - 0.6) ** 2) / 3)
+    assert float(row["MFM"]) == pytest.approx(expected_mfm)
+
+
+def test_parallel_metric_keeps_parallel_map_with_shared_mfm(monkeypatch):
+    calls = []
+    counts = {"omega": 0, "varphi": 0, "eta": 0, "mfm": 0, "other": 0}
+
+    def fake_parallel_map(func, items, **kwargs):
+        calls.append((list(items), kwargs))
+        return [func(item) for item in items]
+
+    monkeypatch.setattr("openbench.core.evaluation._HAS_PARALLEL_ENGINE", True)
+    monkeypatch.setattr("openbench.core.evaluation.parallel_map", fake_parallel_map)
+    monkeypatch.setattr("openbench.core.evaluation.make_plot_index_grid", lambda _self: None)
+    monkeypatch.setattr(
+        "openbench.core.evaluation.open_dataset_chunked",
+        lambda path: xr.Dataset(
+            {"v": (("time", "lat", "lon"), np.ones((4, 1, 1)))},
+            coords={"time": pd.date_range("2001-01-01", periods=4), "lat": [0.0], "lon": [0.0]},
+        ),
+    )
+    monkeypatch.setattr("openbench.util.names.select_data_array", lambda ds, *_args: ds["v"])
+
+    def component(name, value):
+        def _inner(self, _s, _o):
+            counts[name] += 1
+            return xr.DataArray([[value]], coords={"lat": [0.0], "lon": [0.0]}, dims=("lat", "lon"))
+
+        return _inner
+
+    monkeypatch.setattr(Evaluation_grid, "MFM_omega", component("omega", 0.8))
+    monkeypatch.setattr(Evaluation_grid, "MFM_varphi", component("varphi", 0.7))
+    monkeypatch.setattr(Evaluation_grid, "MFM_eta", component("eta", 0.6))
+    monkeypatch.setattr(Evaluation_grid, "MFM", component("mfm", 0.1))
+    monkeypatch.setattr(Evaluation_grid, "other_metric", component("other", 0.2), raising=False)
+    monkeypatch.setattr(Evaluation_grid, "_save_metric_array", lambda *args, **kwargs: None)
+
+    ev = Evaluation_grid.__new__(Evaluation_grid)
+    ev.casedir = "/tmp"
+    ev.item = "Runoff"
+    ev.ref_source = "Ref"
+    ev.sim_source = "Sim"
+    ev.ref_varname = "v"
+    ev.sim_varname = "v"
+    ev.metrics = ["MFM", "MFM_eta", "other_metric"]
+    ev.scores = []
+    ev.num_cores = 2
+    ev.output_manager = None
+    ev.compare_tim_res = "Month"
+
+    ev.make_Evaluation()
+
+    assert calls and calls[0][0] == ev.metrics
+    assert calls[0][1]["backend"] == "threading"
+    assert counts == {"omega": 1, "varphi": 1, "eta": 1, "mfm": 0, "other": 1}

--- a/tests/test_regrid_weight_cache.py
+++ b/tests/test_regrid_weight_cache.py
@@ -382,3 +382,264 @@ def test_weight_disk_cache_rejects_missing_schema_version(tmp_path, monkeypatch)
     np.savez_compressed(path, weights=np.ones((2, 2)))
 
     assert conservative._load_weights_from_disk(key) is None
+
+
+def test_xesmf_weight_cache_reuses_existing_file(tmp_path, monkeypatch):
+    import xarray as xr
+
+    from openbench.data.regrid import xesmf_cache
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "test", "ESMF": "test", "esmpy": None})
+    calls = []
+
+    class FakeRegridder:
+        def __init__(self, _source, _target, method, *, periodic=False, weights=None):
+            calls.append({"method": method, "periodic": periodic, "weights": weights})
+            self.weights = weights
+
+        def to_netcdf(self, filename):
+            assert self.weights is None
+            with open(filename, "wb") as handle:
+                handle.write(b"weights")
+
+    xe = type("FakeXe", (), {"Regridder": FakeRegridder})
+    source = xr.Dataset(coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]})
+    target = xr.Dataset(coords={"lat": [0.0, 0.5, 1.0], "lon": [10.0, 10.5, 11.0]})
+
+    xesmf_cache.cached_regridder(xe, source, target, "conservative", cache_dir=tmp_path, periodic=False)
+    files = list(tmp_path.glob("xesmf-weights-*.nc"))
+    assert len(files) == 1
+
+    xesmf_cache.cached_regridder(xe, source.copy(), target.copy(), "conservative", cache_dir=tmp_path, periodic=False)
+
+    assert calls == [
+        {"method": "conservative", "periodic": False, "weights": None},
+        {"method": "conservative", "periodic": False, "weights": str(files[0])},
+    ]
+
+
+def test_xesmf_weight_cache_key_includes_mask_bounds_method_and_versions(tmp_path, monkeypatch):
+    import xarray as xr
+
+    from openbench.data.regrid import xesmf_cache
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "1", "ESMF": "1", "esmpy": None})
+    source = xr.Dataset(
+        {
+            "lat_vertices": ("lat_vertices", [-0.5, 0.5, 1.5]),
+            "lon_vertices": ("lon_vertices", [9.5, 10.5, 11.5]),
+            "mask": (("lat", "lon"), [[1, 1], [1, 0]]),
+        },
+        coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+    )
+    source["lat"].attrs["bounds"] = "lat_vertices"
+    source["lon"].attrs["bounds"] = "lon_vertices"
+    target = xr.Dataset(coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]})
+
+    base = xesmf_cache._cache_path(source, target, "conservative", cache_dir=tmp_path, periodic=False)
+    changed_mask = source.copy(deep=True)
+    changed_mask["mask"].values[0, 0] = 0
+    changed_bounds = source.copy(deep=True)
+    changed_bounds["lat_vertices"].values[0] = -1.0
+
+    assert xesmf_cache._cache_path(changed_mask, target, "conservative", cache_dir=tmp_path, periodic=False) != base
+    assert xesmf_cache._cache_path(changed_bounds, target, "conservative", cache_dir=tmp_path, periodic=False) != base
+    assert xesmf_cache._cache_path(source, target, "bilinear", cache_dir=tmp_path, periodic=False) != base
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "2", "ESMF": "1", "esmpy": None})
+    assert xesmf_cache._cache_path(source, target, "conservative", cache_dir=tmp_path, periodic=False) != base
+
+
+def test_xesmf_weight_cache_key_recognizes_cf_units(tmp_path, monkeypatch):
+    import xarray as xr
+
+    from openbench.data.regrid import xesmf_cache
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "1", "ESMF": "1", "esmpy": None})
+    source = xr.Dataset(
+        coords={
+            "xc": (("y", "x"), [[10.0, 11.0], [10.0, 11.0]], {"units": "degrees_east"}),
+            "yc": (("y", "x"), [[0.0, 0.0], [1.0, 1.0]], {"units": "degrees_north"}),
+        }
+    )
+    changed = source.copy(deep=True)
+    changed["xc"].values[0, 0] = 9.0
+
+    assert xesmf_cache._cache_path(
+        source, source, "conservative", cache_dir=tmp_path, periodic=False
+    ) != xesmf_cache._cache_path(changed, source, "conservative", cache_dir=tmp_path, periodic=False)
+
+
+def test_processing_xesmf_uses_case_weight_cache(tmp_path, monkeypatch):
+    import sys
+    import types
+
+    import xarray as xr
+
+    from openbench.data._processing_grid_regrid import GridRegridMixin
+    from openbench.data.regrid import xesmf_cache
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "test", "ESMF": "test", "esmpy": None})
+    calls = []
+
+    class FakeRegridder:
+        def __init__(self, _source, _target, _method, *, periodic=False, weights=None):
+            calls.append((periodic, weights))
+            self.weights = weights
+
+        def to_netcdf(self, filename):
+            with open(filename, "wb") as handle:
+                handle.write(b"weights")
+
+        def __call__(self, data):
+            return data
+
+    class Processor(GridRegridMixin):
+        casedir = str(tmp_path)
+
+    monkeypatch.setitem(sys.modules, "xesmf", types.SimpleNamespace(Regridder=FakeRegridder))
+    data = xr.Dataset(
+        {"value": (("lat", "lon"), [[1.0, 2.0], [3.0, 4.0]])},
+        coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+    )
+    target = xr.Dataset(coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]})
+
+    Processor().remap_xesmf(data, target)
+    Processor().remap_xesmf(data, target)
+
+    files = list((tmp_path / "scratch" / "xesmf_weights").glob("xesmf-weights-*.nc"))
+    assert len(files) == 1
+    assert calls == [(False, None), (False, str(files[0]))]
+
+
+def test_xesmf_weight_cache_ignores_legacy_conservative_env(tmp_path, monkeypatch):
+    from openbench.data.regrid.xesmf_cache import default_weight_cache_dir
+
+    monkeypatch.delenv("OPENBENCH_XESMF_WEIGHT_CACHE_DIR", raising=False)
+    monkeypatch.setenv("OPENBENCH_REGRID_WEIGHT_CACHE_DIR", str(tmp_path / "legacy"))
+
+    assert default_weight_cache_dir() is None
+
+
+def test_convert_to_wgs84_xesmf_accepts_explicit_cache_dir(tmp_path, monkeypatch):
+    import sys
+    import types
+
+    import xarray as xr
+
+    from openbench.data.regrid import xesmf_cache
+    from openbench.data.regrid.regrid_wgs84 import convert_to_wgs84_xesmf
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "test", "ESMF": "test", "esmpy": None})
+    calls = []
+
+    class FakeRegridder:
+        def __init__(self, _source, target_grid, _method, *, periodic=False, weights=None):
+            calls.append((periodic, weights))
+            self.target_grid = target_grid
+            self.weights = weights
+
+        def to_netcdf(self, filename):
+            with open(filename, "wb") as handle:
+                handle.write(b"weights")
+
+        def __call__(self, _data):
+            return xr.DataArray(
+                np.zeros((self.target_grid.sizes["lat"], self.target_grid.sizes["lon"])),
+                dims=("lat", "lon"),
+            )
+
+    monkeypatch.setitem(sys.modules, "xesmf", types.SimpleNamespace(Regridder=FakeRegridder))
+    ds = xr.Dataset(
+        {"flux": (("y", "x"), np.ones((2, 2)))},
+        coords={
+            "lat": (("y", "x"), np.array([[0.0, 0.0], [1.0, 1.0]])),
+            "lon": (("y", "x"), np.array([[10.0, 11.0], [10.0, 11.0]])),
+        },
+    )
+
+    convert_to_wgs84_xesmf(ds, resolution=1.0, cache_dir=str(tmp_path))
+    convert_to_wgs84_xesmf(ds, resolution=1.0, cache_dir=str(tmp_path))
+
+    files = list(tmp_path.glob("xesmf-weights-*.nc"))
+    assert len(files) == 1
+    assert calls == [(False, None), (False, str(files[0]))]
+
+
+def test_core_curvilinear_preprocess_passes_case_local_xesmf_cache(tmp_path, monkeypatch):
+    import xarray as xr
+
+    from openbench.data._processing_grid_core import GridProcessingCoreMixin
+
+    seen = []
+
+    def fake_convert(data, resolution, *, cache_dir=None):
+        seen.append((resolution, cache_dir))
+        return xr.Dataset(
+            {"flux": (("lat", "lon"), np.ones((2, 2)))},
+            coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+        )
+
+    class Processor(GridProcessingCoreMixin):
+        casedir = str(tmp_path)
+        compare_grid_res = 1.0
+
+        def check_coordinate(self, data):
+            return data
+
+        def _normalize_longitude_axis(self, data):
+            return data
+
+    monkeypatch.setattr("openbench.data.regrid.regrid_wgs84.convert_to_wgs84_xesmf", fake_convert)
+    data = xr.Dataset(
+        {"flux": (("y", "x"), np.ones((2, 2)))},
+        coords={
+            "lat": (("y", "x"), np.array([[0.0, 0.0], [1.0, 1.0]])),
+            "lon": (("y", "x"), np.array([[10.0, 11.0], [10.0, 11.0]])),
+        },
+    )
+
+    Processor().preprocess_grid_data(data)
+
+    assert seen == [(1.0, str(tmp_path / "scratch" / "xesmf_weights"))]
+
+
+def test_statistics_xesmf_uses_output_dir_weight_cache(tmp_path, monkeypatch):
+    import sys
+    import types
+
+    import xarray as xr
+
+    from openbench.core.statistics.Mod_Statistics import BasicProcessing, Convert_Type
+    from openbench.data.regrid import xesmf_cache
+
+    monkeypatch.setattr(xesmf_cache, "_versions", lambda: {"xesmf": "test", "ESMF": "test", "esmpy": None})
+    calls = []
+
+    class FakeRegridder:
+        def __init__(self, _source, _target, _method, *, periodic=False, weights=None):
+            calls.append((periodic, weights))
+            self.weights = weights
+
+        def to_netcdf(self, filename):
+            with open(filename, "wb") as handle:
+                handle.write(b"weights")
+
+        def __call__(self, data):
+            return data
+
+    monkeypatch.setitem(sys.modules, "xesmf", types.SimpleNamespace(Regridder=FakeRegridder))
+    monkeypatch.setattr(Convert_Type, "convert_nc", staticmethod(lambda value: value))
+    processor = object.__new__(BasicProcessing)
+    processor.output_dir = str(tmp_path / "out")
+    data = xr.Dataset(
+        {"value": (("lat", "lon"), [[1.0, 2.0], [3.0, 4.0]])},
+        coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+    )
+    target = xr.Dataset(coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]})
+
+    BasicProcessing.remap_xesmf(processor, data, target)
+    BasicProcessing.remap_xesmf(processor, data, target)
+
+    files = list((tmp_path / "out" / "xesmf_weights").glob("xesmf-weights-*.nc"))
+    assert len(files) == 1
+    assert calls == [(False, None), (False, str(files[0]))]

--- a/tests/test_runner/test_cache.py
+++ b/tests/test_runner/test_cache.py
@@ -276,3 +276,145 @@ def test_unified_mask_keeps_chunked_data_lazy_until_writer(tmp_path, monkeypatch
     assert ref_path.read_bytes() == b"masked"
     assert observed["values"].shape == (1, 1, 1)
     assert observed["values"][0, 0, 0] == 1.0
+
+
+def test_unified_mask_batches_sibling_sims_into_one_ref_write(tmp_path, monkeypatch):
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    import openbench.runner.masking as masking_module
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    times = pd.date_range("2001-01-01", periods=2, freq="D")
+    xr.Dataset(
+        {"ref": (("time", "lat", "lon"), np.ones((2, 2, 2)))},
+        coords={"time": times, "lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+    ).to_netcdf(data_dir / "GPP_ref_Ref_ref.nc")
+    nan_cells = [(0, 0, 0), (0, 0, 1), (1, 1, 0), (1, 1, 1)]
+    for idx, cell in enumerate(nan_cells):
+        values = np.ones((2, 2, 2))
+        values[cell] = np.nan
+        xr.Dataset(
+            {f"sim{idx}": (("time", "lat", "lon"), values)},
+            coords={"time": times, "lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+        ).to_netcdf(data_dir / f"GPP_sim_Sim{idx}_sim{idx}.nc")
+
+    writes = []
+
+    def writer(data, path, **_kwargs):
+        writes.append(data.compute().values)
+        Path(path).write_bytes(b"masked")
+
+    masking_module.apply_unified_mask(
+        {"casedir": str(tmp_path), "ref_varname": "ref", "time_alignment": "intersection"},
+        "GPP",
+        "Ref",
+        [(f"Sim{idx}", f"sim{idx}") for idx in range(4)],
+        write_netcdf_atomic_fn=writer,
+    )
+
+    assert len(writes) == 1
+    assert np.isnan(writes[0]).sum() == 4
+
+
+def test_unified_mask_batch_without_spatial_mask_writes_global_time_intersection_once(tmp_path):
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    import openbench.runner.masking as masking_module
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    times = pd.date_range("2001-01-01", periods=4, freq="D")
+    xr.Dataset(
+        {"ref": (("time", "lat", "lon"), np.ones((4, 2, 3)))},
+        coords={"time": times, "lat": [0.0, 1.0], "lon": [10.0, 11.0, 12.0]},
+    ).to_netcdf(data_dir / "GPP_ref_Ref_ref.nc")
+    sim_inputs = {
+        "A": (times[:3], [0.0], [10.0, 11.0]),
+        "B": (times[1:], [1.0], [11.0, 12.0]),
+    }
+    for sim, (sim_times, lat, lon) in sim_inputs.items():
+        xr.Dataset(
+            {"sim": (("time", "lat", "lon"), np.ones((3, len(lat), len(lon))))},
+            coords={"time": sim_times, "lat": lat, "lon": lon},
+        ).to_netcdf(data_dir / f"GPP_sim_Sim{sim}_sim.nc")
+
+    writes = []
+
+    def writer(data, path, **_kwargs):
+        writes.append(data.compute())
+        Path(path).write_bytes(b"masked")
+
+    masking_module.apply_unified_mask(
+        {"casedir": str(tmp_path), "ref_varname": "ref", "sim_varname": "sim", "time_alignment": "intersection"},
+        "GPP",
+        "Ref",
+        ["SimA", "SimB"],
+        write_netcdf_atomic_fn=writer,
+        apply_spatial_mask=False,
+    )
+
+    assert len(writes) == 1
+    assert list(writes[0]["time"].values) == list(times[1:3].values)
+    assert writes[0].sizes == {"time": 2, "lat": 2, "lon": 3}
+
+
+def test_unified_mask_batch_matches_sequential_for_spatial_coordinate_mismatch(tmp_path):
+    import numpy as np
+    import xarray as xr
+
+    import openbench.runner.masking as masking_module
+    from openbench.util.netcdf import write_netcdf_atomic
+
+    coords_ref = {"time": [0], "lat": [0.0, 1.0], "lon": [10.0, 11.0, 12.0]}
+    coords_sim1 = {"time": [0], "lat": [0.0, 1.0], "lon": [10.0, 11.0]}
+    coords_sim2 = {"time": [0], "lat": [1.0], "lon": [11.0, 12.0]}
+
+    def write_inputs(case):
+        data_dir = case / "data"
+        data_dir.mkdir(parents=True)
+        xr.Dataset(
+            {"ref": (("time", "lat", "lon"), np.arange(6.0).reshape(1, 2, 3))},
+            coords=coords_ref,
+        ).to_netcdf(data_dir / "GPP_ref_Ref_ref.nc")
+        xr.Dataset(
+            {"sim": (("time", "lat", "lon"), np.ones((1, 2, 2)))},
+            coords=coords_sim1,
+        ).to_netcdf(data_dir / "GPP_sim_Sim1_sim.nc")
+        xr.Dataset(
+            {"sim": (("time", "lat", "lon"), np.ones((1, 1, 2)))},
+            coords=coords_sim2,
+        ).to_netcdf(data_dir / "GPP_sim_Sim2_sim.nc")
+
+    sequential_case = tmp_path / "sequential"
+    batch_case = tmp_path / "batch"
+    write_inputs(sequential_case)
+    write_inputs(batch_case)
+
+    info = {"ref_varname": "ref", "sim_varname": "sim", "time_alignment": "intersection"}
+    for sim in ("Sim1", "Sim2"):
+        masking_module.apply_unified_mask(
+            {**info, "casedir": str(sequential_case)},
+            "GPP",
+            "Ref",
+            sim,
+            write_netcdf_atomic_fn=write_netcdf_atomic,
+        )
+    masking_module.apply_unified_mask(
+        {**info, "casedir": str(batch_case)},
+        "GPP",
+        "Ref",
+        ["Sim1", "Sim2"],
+        write_netcdf_atomic_fn=write_netcdf_atomic,
+    )
+
+    with xr.open_dataset(sequential_case / "data" / "GPP_ref_Ref_ref.nc") as old_ds:
+        old = old_ds.load()
+    with xr.open_dataset(batch_case / "data" / "GPP_ref_Ref_ref.nc") as new_ds:
+        new = new_ds.load()
+    xr.testing.assert_identical(new, old)
+    assert old.sizes == {"time": 1, "lat": 1, "lon": 1}

--- a/tests/test_runner/test_local.py
+++ b/tests/test_runner/test_local.py
@@ -9127,3 +9127,220 @@ def test_task_config_hash_includes_selected_regrid_backend(tmp_path):
     runner_cfg.general["regrid_backend"] = "xesmf_conservative"
 
     assert cache_hash() != first
+
+
+def test_preprocess_shared_mask_failure_keeps_ref_and_fails_group(tmp_path, monkeypatch):
+    import numpy as np
+    import pandas as pd
+    import xarray as xr
+
+    import openbench.data.processing as processing_module
+    import openbench.runner.preprocessing as preprocessing_module
+    from openbench.runner.masking import apply_unified_mask
+    from openbench.util.netcdf import write_netcdf_atomic
+
+    case_dir = tmp_path / "case"
+    data_dir = case_dir / "data"
+    data_dir.mkdir(parents=True)
+    times = pd.date_range("2001-01-01", periods=2, freq="D")
+    ref_path = data_dir / "Runoff_ref_Ref_ref.nc"
+    xr.Dataset(
+        {"ref": (("time", "lat", "lon"), np.ones((2, 1, 1)))},
+        coords={"time": times, "lat": [0.0], "lon": [10.0]},
+    ).to_netcdf(ref_path)
+    sim_a_values = np.ones((2, 1, 1))
+    sim_a_values[1, 0, 0] = np.nan
+    xr.Dataset(
+        {"sim": (("time", "lat", "lon"), sim_a_values)},
+        coords={"time": times, "lat": [0.0], "lon": [10.0]},
+    ).to_netcdf(data_dir / "Runoff_sim_SimA_sim.nc")
+    xr.Dataset(
+        {"sim": (("time", "lat", "lon"), np.ones((2, 1, 1)))},
+        coords={"time": pd.date_range("2001-01-02", periods=2, freq="D"), "lat": [0.0], "lon": [10.0]},
+    ).to_netcdf(data_dir / "Runoff_sim_SimB_sim.nc")
+
+    class NoopProcessing:
+        def __init__(self, _info):
+            pass
+
+        def prepare_source(self, _kind):
+            pass
+
+    monkeypatch.setattr(processing_module, "DatasetProcessing", NoopProcessing)
+    completed = []
+    monkeypatch.setattr(preprocessing_module, "emit_gui_preprocessing_started", lambda _task: None)
+    monkeypatch.setattr(
+        preprocessing_module,
+        "emit_gui_preprocessing_completion",
+        lambda task: completed.append(task["sim_source"]),
+    )
+
+    tasks = [{"ref_source": "Ref", "sim_source": "SimA"}, {"ref_source": "Ref", "sim_source": "SimB"}]
+
+    def build_info(task):
+        return {
+            "casedir": str(case_dir),
+            "ref_varname": "ref",
+            "sim_varname": "sim",
+            "ref_data_type": "grid",
+            "sim_data_type": "grid",
+            "time_alignment": "strict",
+        }
+
+    errors = preprocessing_module.preprocess_variable(
+        "Runoff",
+        tasks,
+        unified_mask=True,
+        time_alignment="strict",
+        build_bridge_runtime_info_fn=build_info,
+        make_phase_error_fn=lambda phase, message, **kw: {"phase": phase, "message": message, **kw},
+        clone_or_link_ref_for_pair_fn=lambda source, target: "copy2",
+        apply_unified_mask_fn=lambda *args, **kwargs: apply_unified_mask(
+            *args, **kwargs, write_netcdf_atomic_fn=write_netcdf_atomic
+        ),
+    )
+
+    assert {task["sim_source"] for task in tasks if task.get("preprocess_failed")} == {"SimA", "SimB"}
+    assert completed == []
+    assert any("shared unified-mask preprocessing failed" in error["message"] for error in errors)
+    with xr.open_dataset(ref_path) as ds:
+        np.testing.assert_allclose(ds["ref"].values, np.ones((2, 1, 1)))
+
+
+def test_preprocess_intersection_batches_shared_ref_mask_after_sim_restore(tmp_path, monkeypatch):
+    import os
+    from pathlib import Path
+
+    import openbench.data.processing as processing_module
+    import openbench.runner.preprocessing as preprocessing_module
+
+    class NoopProcessing:
+        def __init__(self, info):
+            self.info = info
+
+        def prepare_source(self, kind):
+            data_dir = Path(self.info["casedir"]) / "data"
+            if kind == "sim":
+                sim_path = data_dir / f"Runoff_sim_{self.info['sim_source']}_{self.info['sim_varname']}.nc"
+                sim_path.write_bytes(b"sim")
+                if self.info["ref_source"] == "RefStn":
+                    os.remove(data_dir / "Runoff_sim_SimA_simA.nc")
+
+    monkeypatch.setattr(processing_module, "DatasetProcessing", NoopProcessing)
+    monkeypatch.setattr(preprocessing_module, "emit_gui_preprocessing_started", lambda _task: None)
+    completed = []
+    monkeypatch.setattr(
+        preprocessing_module,
+        "emit_gui_preprocessing_completion",
+        lambda task: completed.append((task["ref_source"], task["sim_source"])),
+    )
+    data_dir = tmp_path / "case" / "data"
+    data_dir.mkdir(parents=True)
+    for ref in ("RefGrid", "RefStn"):
+        (data_dir / f"Runoff_ref_{ref}_ref.nc").write_bytes(b"ref")
+    for sim in ("A", "B", "C", "D"):
+        (data_dir / f"Runoff_sim_Sim{sim}_sim{sim}.nc").write_bytes(b"sim")
+
+    tasks = [
+        {"ref_source": "RefGrid", "sim_source": "SimA"},
+        {"ref_source": "RefStn", "sim_source": "SimA"},
+        {"ref_source": "RefGrid", "sim_source": "SimB"},
+        {"ref_source": "RefGrid", "sim_source": "SimC"},
+        {"ref_source": "RefGrid", "sim_source": "SimD"},
+    ]
+    calls = []
+
+    def build_info(task):
+        return {
+            "casedir": str(tmp_path / "case"),
+            "ref_varname": "ref",
+            "sim_varname": task["sim_source"].replace("Sim", "sim"),
+            "ref_data_type": "stn" if task["ref_source"] == "RefStn" else "grid",
+            "sim_data_type": "grid",
+            "time_alignment": "intersection",
+            "ref_source": task["ref_source"],
+            "sim_source": task["sim_source"],
+        }
+
+    def apply_mask(info, var_name, ref_source, sim_sources, **kwargs):
+        calls.append((info["ref_varname"], var_name, ref_source, sim_sources, kwargs))
+
+    errors = preprocessing_module.preprocess_variable(
+        "Runoff",
+        tasks,
+        unified_mask=True,
+        time_alignment="intersection",
+        build_bridge_runtime_info_fn=build_info,
+        make_phase_error_fn=lambda phase, message, **kw: {"phase": phase, "message": message, **kw},
+        clone_or_link_ref_for_pair_fn=lambda source, target: "copy2",
+        apply_unified_mask_fn=apply_mask,
+    )
+
+    assert errors == []
+    assert len(calls) == 1
+    assert calls[0][2:] == (
+        "RefGrid",
+        [("SimA", "simA"), ("SimB", "simB"), ("SimC", "simC"), ("SimD", "simD")],
+        {"apply_spatial_mask": True},
+    )
+    assert (data_dir / "Runoff_sim_SimA_simA.nc").exists()
+    assert completed[-4:] == [
+        ("RefGrid", "SimA"),
+        ("RefGrid", "SimB"),
+        ("RefGrid", "SimC"),
+        ("RefGrid", "SimD"),
+    ]
+
+
+def test_preprocess_per_pair_still_masks_each_pair(tmp_path, monkeypatch):
+    import shutil
+
+    import openbench.data.processing as processing_module
+    import openbench.runner.preprocessing as preprocessing_module
+
+    class NoopProcessing:
+        def __init__(self, _info):
+            pass
+
+        def prepare_source(self, _kind):
+            pass
+
+    monkeypatch.setattr(processing_module, "DatasetProcessing", NoopProcessing)
+    monkeypatch.setattr(preprocessing_module, "emit_gui_preprocessing_started", lambda _task: None)
+    monkeypatch.setattr(preprocessing_module, "emit_gui_preprocessing_completion", lambda _task: None)
+    data_dir = tmp_path / "case" / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "Runoff_ref_Ref_ref.nc").write_bytes(b"ref")
+    for sim in ("A", "B"):
+        (data_dir / f"Runoff_sim_Sim{sim}_sim.nc").write_bytes(b"sim")
+
+    tasks = [{"ref_source": "Ref", "sim_source": "SimA"}, {"ref_source": "Ref", "sim_source": "SimB"}]
+    calls = []
+
+    def build_info(_task):
+        return {
+            "casedir": str(tmp_path / "case"),
+            "ref_varname": "ref",
+            "sim_varname": "sim",
+            "ref_data_type": "grid",
+            "sim_data_type": "grid",
+            "time_alignment": "per_pair",
+        }
+
+    def clone(source, target):
+        shutil.copy2(source, target)
+        return "copy2"
+
+    preprocessing_module.preprocess_variable(
+        "Runoff",
+        tasks,
+        unified_mask=True,
+        time_alignment="per_pair",
+        build_bridge_runtime_info_fn=build_info,
+        make_phase_error_fn=lambda phase, message, **kw: {"phase": phase, "message": message, **kw},
+        clone_or_link_ref_for_pair_fn=clone,
+        apply_unified_mask_fn=lambda _info, _var, _ref, sim, **kwargs: calls.append((sim, kwargs["ref_override"])),
+    )
+
+    assert [call[0] for call in calls] == ["SimA", "SimB"]
+    assert all(task.get("ref_file_override") for task in tasks)


### PR DESCRIPTION
## Summary

- persist xESMF weights under content-addressed, version-aware keys using the existing atomic-write and cross-platform lock paths
- reuse already-computed MFM omega/varphi/eta components when the combined outputs are requested
- accumulate sibling unified masks lazily and atomically rewrite each shared grid reference once
- preserve `per_pair` isolation, mixed station/grid restoration, strict/intersection behavior, and time-only alignment when spatial masking is disabled
- add `REVIEW_REPORT.md` with the completed audit, benchmarks, and remaining platform limitations

## Performance evidence

- MFM combined outputs: median `0.1546 s -> 0.0794 s` (`-48.6%`); histogram and FFT calls halved
- unified mask, 1 ref + 4 sims (`24x60x120`, 7-run median):
  - spatial mask on: `0.0801 s -> 0.0380 s` (`-52.5%`)
  - spatial mask off: `0.0322 s -> 0.0161 s` (`-49.9%`)
  - shared reference writes: `4 -> 1`; cumulative written bytes: `2.674 MiB -> 0.669 MiB`

## Validation

- `python -m pytest -q`: `1975 passed, 5 skipped`
- targeted runner/masking regression suite: `240 passed`
- `ruff check src tests`: passed
- `ruff format --check src tests`: `378 files already formatted`
- 76 randomized batch-vs-sequential unified-mask equivalence cases passed
- independent final code review: approved with no blocking issues

## Known limitations

- real xESMF/ESMF is unavailable in the validation environment; cache behavior is covered with interface-faithful mocks
- Windows, NFS/Lustre, distributed Dask, and very high sibling-model file-handle pressure were not exercised locally
