### PR TITLE
Port safe Dask NetCDF writes and readable case cards

### DIFF
--- a/src/openbench/gui/localization.py
+++ b/src/openbench/gui/localization.py
@@ -293,6 +293,18 @@ ZH_CN = {
     "Case": "案例",
     "Path": "路径",
     "Model": "模型",
+    "Model required": "需要选择模型",
+    "No Models": "没有可用模型",
+    "Register a model in Data Registry first.": "请先在数据注册表中注册模型。",
+    "Select Model": "选择模型",
+    "Model:": "模型：",
+    "Select Model...": "选择模型...",
+    "Change Model...": "更换模型...",
+    "Model Settings": "模型设置",
+    "Data Type:": "数据类型：",
+    "File Matching (Advanced)": "文件匹配规则（高级）",
+    "Prefix:": "前缀：",
+    "Suffix:": "后缀：",
     "Variable Name in File": "文件中的变量名",
     "Units": "单位",
     "Dimensions": "维度",
@@ -373,6 +385,9 @@ def translate_text(text: str, language: str = ENGLISH) -> str:
     match = re.fullmatch(r"Version (.+)", text)
     if match:
         return f"版本 {match.group(1)}"
+    match = re.fullmatch(r"Model: (.+)", text)
+    if match:
+        return f"模型：{match.group(1)}"
     match = re.fullmatch(r"Selected: (\d+)(?: / (\d+))?", text)
     if match:
         suffix = f" / {match.group(2)}" if match.group(2) else ""

--- a/src/openbench/gui/pages/page_general.py
+++ b/src/openbench/gui/pages/page_general.py
@@ -5,6 +5,7 @@ General settings page.
 
 import logging
 
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QFormLayout,
     QLineEdit,
@@ -15,6 +16,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QMessageBox,
     QPushButton,
+    QSizePolicy,
 )
 from openbench.gui.remote_python import quote_remote_path
 from openbench.gui.widgets._ssh_worker import execute_responsive
@@ -40,9 +42,12 @@ class PageGeneral(BasePage):
         # === Project Info ===
         project_group = QGroupBox("Project Information")
         project_layout = QFormLayout(project_group)
+        project_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        project_layout.setLabelAlignment(Qt.AlignLeft)
 
         # Output directory first
         self.basedir_input = PathSelector(mode="directory", placeholder="Output directory")
+        self.basedir_input.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         self.basedir_input.path_changed.connect(self._on_basedir_changed)
         self.basedir_input.set_custom_browse_handler(self._browse_output_directory)
         project_layout.addRow("Output Directory:", self.basedir_input)

--- a/src/openbench/gui/pages/page_sim_data.py
+++ b/src/openbench/gui/pages/page_sim_data.py
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
     QApplication,
     QCheckBox,
     QComboBox,
+    QFrame,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
@@ -29,11 +30,13 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QPushButton,
     QScrollArea,
+    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )
 from PySide6.QtCore import Qt, Signal
 
+from openbench.gui.localization import get_language_manager, translate_text
 from openbench.gui.remote_python import quote_remote_path
 from openbench.gui.widgets._ssh_worker import call_responsive, execute_responsive
 from openbench.gui.pages.base_page import BasePage
@@ -392,6 +395,8 @@ class PageSimData(BasePage):
         # === Scan section ===
         scan_group = QGroupBox("Scan for Cases")
         scan_form = QFormLayout(scan_group)
+        scan_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        scan_form.setLabelAlignment(Qt.AlignLeft)
 
         root_row = QHBoxLayout()
         self._root_input = QLineEdit()
@@ -415,10 +420,13 @@ class PageSimData(BasePage):
         # === Case list (scrollable) ===
         self._case_scroll = QScrollArea()
         self._case_scroll.setWidgetResizable(True)
+        self._case_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._case_scroll.setMinimumHeight(240)
         self._case_widget = QWidget()
         self._case_layout = QVBoxLayout(self._case_widget)
         self._case_layout.setContentsMargins(4, 4, 4, 4)
         self._case_layout.setSpacing(4)
+        self._case_layout.setAlignment(Qt.AlignTop)
         self._case_scroll.setWidget(self._case_widget)
         self.content_layout.addWidget(self._case_scroll, 1)
 
@@ -673,51 +681,81 @@ class PageSimData(BasePage):
         multi_stream: bool = False,
         scan_metadata: Dict[str, Any] = None,
     ):
-        """Add one case row: [checkbox] label  path  [model combo]"""
-        row = QWidget()
-        row_layout = QHBoxLayout(row)
-        row_layout.setContentsMargins(2, 2, 2, 2)
+        """Add a readable case card without squeezing paths and controls into one row."""
+        row = QFrame()
+        row.setFrameShape(QFrame.StyledPanel)
+        row_layout = QVBoxLayout(row)
+        row_layout.setContentsMargins(10, 8, 10, 8)
+        row_layout.setSpacing(8)
+
+        header_layout = QHBoxLayout()
 
         cb = QCheckBox(label)
         cb.setChecked(checked)
         cb.toggled.connect(self._on_selection_changed)
-        row_layout.addWidget(cb)
+        header_layout.addWidget(cb)
 
-        path_label = QLabel(nc_dir)
-        path_label.setStyleSheet("color: #888; font-size: 11px;")
-        path_label.setToolTip(nc_dir)
-        row_layout.addWidget(path_label, 1)
+        status_label = QLabel()
+        header_layout.addWidget(status_label)
+        header_layout.addStretch()
+
+        model_button = QPushButton()
+        header_layout.addWidget(model_button)
+
+        gear_btn = QPushButton("Model Settings")
+        gear_btn.setToolTip("Manage models in Data Registry")
+        gear_btn.clicked.connect(lambda: self.controller.go_to_page("registry"))
+        header_layout.addWidget(gear_btn)
+        row_layout.addLayout(header_layout)
+
+        path_layout = QHBoxLayout()
+        path_layout.addWidget(QLabel("Path:"))
+        path_input = QLineEdit(nc_dir)
+        path_input.setReadOnly(True)
+        path_input.setCursorPosition(0)
+        path_input.setToolTip(nc_dir)
+        path_input.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+        path_layout.addWidget(path_input, 1)
+        row_layout.addLayout(path_layout)
 
         metadata = dict(scan_metadata or {})
-        detected = [
-            str(value)
-            for value in (metadata.get("data_type"), metadata.get("tim_res"), metadata.get("grid_res"))
-            if value not in (None, "")
-        ]
-        metadata_label = QLabel(" / ".join(detected) if detected else "metadata unresolved")
-        metadata_label.setStyleSheet("color: #777; font-size: 10px;")
-        metadata_label.setToolTip("Detected data_type / tim_res / grid_res")
-        row_layout.addWidget(metadata_label)
+        metadata_layout = QHBoxLayout()
+        metadata_layout.addWidget(QLabel("Data Type:"))
+        metadata_layout.addWidget(QLabel(str(metadata.get("data_type") or "—")))
+        metadata_layout.addSpacing(18)
+        metadata_layout.addWidget(QLabel("Time Resolution:"))
+        metadata_layout.addWidget(QLabel(str(metadata.get("tim_res") or "—")))
+        metadata_layout.addSpacing(18)
+        metadata_layout.addWidget(QLabel("Grid Resolution:"))
+        grid_res = metadata.get("grid_res")
+        metadata_layout.addWidget(QLabel(f"{grid_res:g}°" if isinstance(grid_res, (int, float)) else "—"))
+        metadata_layout.addStretch()
+        row_layout.addLayout(metadata_layout)
+
+        pattern_toggle = QPushButton("File Matching (Advanced)")
+        pattern_toggle.setCheckable(True)
+        row_layout.addWidget(pattern_toggle, alignment=Qt.AlignLeft)
+
+        pattern_widget = QWidget()
+        pattern_layout = QHBoxLayout(pattern_widget)
+        pattern_layout.setContentsMargins(0, 0, 0, 0)
 
         prefix_input = QLineEdit(prefix)
         prefix_input.setPlaceholderText("prefix")
-        prefix_input.setMaximumWidth(240)
         if multi_stream:
             prefix_input.setToolTip(
                 "One file per variable detected — per-variable file patterns "
                 "are exported instead of a single case prefix."
             )
-        row_layout.addWidget(QLabel("prefix:"))
-        row_layout.addWidget(prefix_input)
+        pattern_layout.addWidget(QLabel("Prefix:"))
+        pattern_layout.addWidget(prefix_input, 1)
 
         suffix_input = QLineEdit(suffix)
         suffix_input.setPlaceholderText("suffix")
-        suffix_input.setMaximumWidth(120)
-        row_layout.addWidget(QLabel("suffix:"))
-        row_layout.addWidget(suffix_input)
+        pattern_layout.addWidget(QLabel("Suffix:"))
+        pattern_layout.addWidget(suffix_input, 1)
 
         model_combo = QComboBox()
-        model_combo.setMinimumWidth(150)
         model_combo.addItem("Select model...", "")
         for mn in self._model_names:
             model_combo.addItem(mn, mn)
@@ -725,24 +763,24 @@ class PageSimData(BasePage):
             idx = model_combo.findData(model_name)
             if idx >= 0:
                 model_combo.setCurrentIndex(idx)
-        row_layout.addWidget(model_combo)
+        model_combo.hide()
 
         patterns_btn = QPushButton("Variables...")
         patterns_btn.setToolTip("Edit per-variable varname, unit, prefix, and suffix")
-        row_layout.addWidget(patterns_btn)
-
-        gear_btn = QPushButton("⚙")
-        gear_btn.setFixedWidth(30)
-        gear_btn.setToolTip("Manage models in Data Registry")
-        gear_btn.clicked.connect(lambda: self.controller.go_to_page("registry"))
-        row_layout.addWidget(gear_btn)
+        pattern_layout.addWidget(patterns_btn)
+        pattern_widget.hide()
+        pattern_toggle.toggled.connect(pattern_widget.setVisible)
+        row_layout.addWidget(pattern_widget)
 
         self._case_layout.addWidget(row)
         case = {
             "checkbox": cb,
             "model_combo": model_combo,
+            "model_button": model_button,
+            "status_label": status_label,
             "label": label,
             "nc_dir": nc_dir,
+            "path_input": path_input,
             "auto_prefix": prefix,
             "auto_suffix": suffix,
             "prefix_input": prefix_input,
@@ -753,12 +791,50 @@ class PageSimData(BasePage):
             "multi_stream": multi_stream,
             "scan_metadata": metadata,
             "row_widget": row,
+            "pattern_widget": pattern_widget,
         }
         prefix_input.textEdited.connect(lambda _text, c=case: self._on_case_pattern_changed(c))
         suffix_input.textEdited.connect(lambda _text, c=case: self._on_case_pattern_changed(c))
         model_combo.currentIndexChanged.connect(lambda _index, c=case: self._on_case_model_changed(c))
+        model_button.clicked.connect(lambda _checked=False, c=case: self._choose_case_model(c))
         patterns_btn.clicked.connect(lambda _checked=False, c=case: self._edit_variable_pattern(c))
+        self._update_case_model_summary(case)
         self._cases.append(case)
+
+    def _choose_case_model(self, case: Dict[str, Any]):
+        language = get_language_manager().language
+        if not self._model_names:
+            QMessageBox.information(
+                self,
+                translate_text("No Models", language),
+                translate_text("Register a model in Data Registry first.", language),
+            )
+            return
+        combo = case["model_combo"]
+        current = self._model_names.index(combo.currentData()) if combo.currentData() in self._model_names else 0
+        model_name, accepted = QInputDialog.getItem(
+            self,
+            translate_text("Select Model", language),
+            translate_text("Model:", language),
+            self._model_names,
+            current,
+            False,
+        )
+        if accepted and model_name:
+            combo.setCurrentIndex(combo.findData(model_name))
+
+    def _update_case_model_summary(self, case: Dict[str, Any]):
+        model_name = case["model_combo"].currentData() or ""
+        if not model_name:
+            case["status_label"].setText("Model required")
+            case["status_label"].setStyleSheet("color: #b45309;")
+            case["model_button"].setText("Select Model...")
+        else:
+            case["status_label"].setText(f"Model: {model_name}")
+            case["status_label"].setStyleSheet("color: #15803d;")
+            case["model_button"].setText("Change Model...")
+        if case["row_widget"].isVisible():
+            get_language_manager().apply(case["row_widget"])
 
     def _on_case_pattern_changed(self, case: Dict[str, Any]):
         case["case_pattern_edited"] = True
@@ -800,6 +876,7 @@ class PageSimData(BasePage):
         Only possible when the scan captured the case's file list; rows
         restored from a saved config keep their stored overrides.
         """
+        self._update_case_model_summary(case)
         if case.get("files"):
             from openbench.remote.storage import RemoteStorage
 

--- a/src/openbench/util/netcdf.py
+++ b/src/openbench/util/netcdf.py
@@ -28,6 +28,38 @@ _NETCDF_COMPRESSION_LEVEL_ENV = "OPENBENCH_NETCDF_COMP_LEVEL"
 _DEFAULT_COMPRESSION_LEVEL = 1
 
 
+def _distributed_client_active() -> bool:
+    try:
+        from distributed import get_client
+
+        get_client()
+        return True
+    except (ImportError, ValueError):
+        return False
+
+
+def _needs_local_dask_netcdf_write(data: Any) -> bool:
+    """Keep distributed workers out of the HDF5 store phase."""
+    if not _distributed_client_active() or not isinstance(data, (xr.Dataset, xr.DataArray)):
+        return False
+
+    try:
+        from dask.base import is_dask_collection
+    except ImportError:
+        return False
+
+    arrays = data.variables.values() if isinstance(data, xr.Dataset) else (data.variable,)
+    return any(is_dask_collection(variable.data) for variable in arrays)
+
+
+def _has_distributed_futures(data: Any) -> bool:
+    try:
+        from distributed import futures_of
+    except ImportError:
+        return False
+    return bool(futures_of(data))
+
+
 def _env_truthy(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in _TRUTHY
 
@@ -199,6 +231,19 @@ def write_netcdf_atomic(
     def _locked_write(tmp_path: Path) -> None:
         # Serialize HDF5 writes across threads (netCDF4/HDF5 is not thread-safe).
         with _NETCDF_WRITE_LOCK:
-            data.to_netcdf(tmp_path, **nc_kwargs)
+            if _needs_local_dask_netcdf_write(data):
+                if _has_distributed_futures(data):
+                    raise ValueError(
+                        "Cannot write xarray data backed by distributed Futures; "
+                        "pass the unpersisted lazy Dataset or DataArray instead."
+                    )
+                logger.info("Writing lazy xarray data with local single-threaded NetCDF scheduler")
+                # ponytail: serial HDF5 store; use Zarr when parallel output bandwidth becomes the bottleneck.
+                data.to_netcdf(tmp_path, compute=False, **nc_kwargs).compute(
+                    scheduler="threads",
+                    num_workers=1,
+                )
+            else:
+                data.to_netcdf(tmp_path, **nc_kwargs)
 
     write_file_atomic(output_path, _locked_write, suffix=".tmp.nc")

--- a/tests/test_gui_localization.py
+++ b/tests/test_gui_localization.py
@@ -30,6 +30,8 @@ def test_language_switch_is_reversible_and_persistent(qapp, tmp_path):
     assert (title.text(), next_button.text(), count.text()) == ("General Settings", "Next", "Selected: 3 / 5")
     assert LanguageManager(user_dir=tmp_path).language == ENGLISH
     assert translate_text("Step 3 of 12", CHINESE) == "第 3 步，共 12 步"
+    assert translate_text("Model: CLM5", CHINESE) == "模型：CLM5"
+    assert translate_text("Select Model", CHINESE) == "选择模型"
 
 
 def test_show_event_respects_i18n_skip(qapp):

--- a/tests/test_gui_runtime_paths.py
+++ b/tests/test_gui_runtime_paths.py
@@ -328,6 +328,20 @@ def test_general_load_from_config_does_not_write_stale_defaults(qapp, tmp_path):
     assert page.num_cores_spin.value() == 7
 
 
+def test_general_project_fields_expand_cross_platform(qapp):
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QFormLayout, QGroupBox, QSizePolicy
+
+    controller = WizardController()
+    page = PageGeneral(controller)
+    project_group = next(group for group in page.findChildren(QGroupBox) if group.title() == "Project Information")
+    layout = project_group.layout()
+
+    assert layout.fieldGrowthPolicy() == QFormLayout.AllNonFixedFieldsGrow
+    assert layout.labelAlignment() & Qt.AlignLeft
+    assert page.basedir_input.sizePolicy().horizontalPolicy() == QSizePolicy.Expanding
+
+
 def test_checkbox_group_set_selection_clears_items_not_in_selection(qapp):
     group = CheckboxGroup({"Group": ["a", "b", "c"]})
     group.set_selection({"a": True, "b": True, "c": True})

--- a/tests/test_gui_sim_data.py
+++ b/tests/test_gui_sim_data.py
@@ -275,3 +275,65 @@ def test_save_to_config_only_assigns_variables_to_supporting_cases(monkeypatch):
     general = controller.updated[1]["general"]
     assert general["Runoff_sim_source"] == ["RunoffCase"]
     assert general["Latent_Heat_sim_source"] == ["ManualHeatCase"]
+
+
+def test_simulation_case_uses_readable_card_layout(qapp):
+    from PySide6.QtCore import Qt
+    from PySide6.QtWidgets import QFormLayout, QGroupBox, QSizePolicy
+
+    from openbench.gui.controller import WizardController
+    from openbench.gui.pages.page_sim_data import PageSimData
+
+    page = PageSimData(WizardController())
+    page._model_names = ["CLM5"]
+    path = r"G:\Cases_for_openbench\Simulation\LSMs\CLM5"
+    page._add_case_row(
+        "CLM5",
+        path,
+        "prefix_",
+        model_name="CLM5",
+        suffix=".nc",
+        scan_metadata={"data_type": "grid", "tim_res": "Month", "grid_res": 1.8947},
+    )
+
+    scan_group = next(group for group in page.findChildren(QGroupBox) if group.title() == "Scan for Cases")
+    case = page._cases[0]
+
+    assert PageSimData.CONTENT_EXPAND is True
+    assert scan_group.layout().fieldGrowthPolicy() == QFormLayout.AllNonFixedFieldsGrow
+    assert page._case_scroll.minimumHeight() >= 220
+    assert page._case_layout.alignment() & Qt.AlignTop
+    assert case["path_input"].text() == path
+    assert case["path_input"].isReadOnly()
+    assert case["path_input"].sizePolicy().horizontalPolicy() == QSizePolicy.Expanding
+    assert case["status_label"].text() == "Model: CLM5"
+    assert case["model_combo"].isHidden()
+    assert case["pattern_widget"].isHidden()
+
+
+def test_simulation_case_model_picker_updates_hidden_state(qapp, monkeypatch):
+    from openbench.gui.controller import WizardController
+    from openbench.gui.pages.page_sim_data import PageSimData
+
+    page = PageSimData(WizardController())
+    page._model_names = ["CLM5", "CoLM2024"]
+    page._add_case_row(
+        "CaseA",
+        "/sim/CaseA",
+        "hist_",
+        model_name="CLM5",
+        scan_metadata={"data_type": "grid", "tim_res": "Month", "grid_res": 1.0},
+    )
+    case = page._cases[0]
+
+    monkeypatch.setattr(
+        page_sim_data.QInputDialog,
+        "getItem",
+        lambda *args: ("CoLM2024", True),
+    )
+
+    page._choose_case_model(case)
+
+    assert case["model_combo"].currentData() == "CoLM2024"
+    assert case["status_label"].text() == "Model: CoLM2024"
+    assert page.get_selected_cases()[0]["model"] == "CoLM2024"

--- a/tests/test_netcdf_lifecycle_atomic.py
+++ b/tests/test_netcdf_lifecycle_atomic.py
@@ -247,6 +247,70 @@ def test_netcdf_compression_is_opt_in_by_environment(tmp_path, monkeypatch):
     assert "encoding" not in captured
 
 
+@pytest.mark.parametrize("kind", ["dataset", "dataarray"])
+def test_distributed_netcdf_write_uses_local_serial_scheduler_for_lazy_data(tmp_path, monkeypatch, kind):
+    import openbench.util.netcdf as netcdf
+
+    array = xr.DataArray(
+        da.from_array(np.ones((2, 2)), chunks=(1, 1)),
+        dims=("lat", "lon"),
+        coords={"lat": [0.0, 1.0], "lon": [10.0, 11.0]},
+        name="metric",
+    )
+    lazy = array.to_dataset() if kind == "dataset" else array
+    captured = {}
+
+    class FakeDelayed:
+        def compute(self, **kwargs):
+            captured["compute"] = kwargs
+
+    def fake_to_netcdf(self, path, *args, **kwargs):
+        captured["compute_false"] = kwargs.get("compute") is False
+        captured["lazy"] = hasattr(self["metric"].data if isinstance(self, xr.Dataset) else self.data, "compute")
+        return FakeDelayed()
+
+    monkeypatch.setattr(netcdf, "_distributed_client_active", lambda: True)
+    monkeypatch.setattr(type(lazy), "to_netcdf", fake_to_netcdf)
+
+    netcdf.write_netcdf_atomic(lazy, tmp_path / "out.nc")
+
+    assert hasattr(lazy["metric"].data if kind == "dataset" else lazy.data, "compute")
+    assert captured == {
+        "compute_false": True,
+        "lazy": True,
+        "compute": {"scheduler": "threads", "num_workers": 1},
+    }
+
+
+def test_distributed_netcdf_write_rejects_persisted_futures(tmp_path, monkeypatch):
+    import openbench.util.netcdf as netcdf
+
+    lazy = xr.Dataset({"metric": ("x", da.ones(2, chunks=1))})
+    monkeypatch.setattr(netcdf, "_distributed_client_active", lambda: True)
+    monkeypatch.setattr(netcdf, "_has_distributed_futures", lambda _data: True)
+
+    with pytest.raises(ValueError, match="unpersisted lazy Dataset or DataArray"):
+        netcdf.write_netcdf_atomic(lazy, tmp_path / "out.nc")
+
+    assert not (tmp_path / "out.nc").exists()
+
+
+def test_netcdf_write_without_distributed_client_keeps_normal_path(tmp_path, monkeypatch):
+    import openbench.util.netcdf as netcdf
+
+    captured = {}
+
+    def fake_to_netcdf(self, path, *args, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(netcdf, "_distributed_client_active", lambda: False)
+    monkeypatch.setattr(xr.Dataset, "to_netcdf", fake_to_netcdf)
+
+    netcdf.write_netcdf_atomic(_grid_dataset("metric", 1.0), tmp_path / "out.nc")
+
+    assert "compute" not in captured
+
+
 def test_netcdf_compression_defaults_to_level_one_for_numeric_variables(tmp_path, monkeypatch):
     from openbench.util.netcdf import write_netcdf_atomic
 


### PR DESCRIPTION
## Summary
- port the safe local single-threaded Dask/NetCDF store path to the uncertainty branch
- preserve the non-Dask write path and reject persisted Future-backed xarray inputs explicitly
- port the clearer Simulation Data case cards, path sizing, explicit model identity, and model-selection localization

## Validation
- `pytest -q` -> `2016 passed, 5 skipped`
- targeted Dask/NetCDF/GUI suite -> `42 passed`
- `ruff format --check .`
- `ruff check .`
- `python -m compileall -q src tests`
- real LocalCluster normal/distributed/persisted-guard smoke
