### PR TITLE
Normalize station scalar outputs on uncertainty branch

### DIFF
--- a/src/openbench/core/evaluation.py
+++ b/src/openbench/core/evaluation.py
@@ -834,6 +834,9 @@ class Evaluation_stn(metrics, scores):
             missing_columns = [col for col in requested_columns if col not in station_list.columns]
             if missing_columns:
                 raise RuntimeError(f"Station evaluation missing requested column(s): {missing_columns}")
+            station_list[requested_columns] = station_list[requested_columns].map(
+                lambda value: value.item() if isinstance(value, np.ndarray) and value.ndim == 0 else value
+            )
             numeric_results = station_list[requested_columns].apply(pd.to_numeric, errors="coerce")
             empty_columns = [
                 col for col in requested_columns if not np.isfinite(numeric_results[col].to_numpy(dtype=float)).any()


### PR DESCRIPTION
## Summary
- port PR #170's zero-dimensional NumPy station-output normalization to the uncertainty branch
- keep requested metric/score columns scalar before pandas numeric and finite-value validation
- retain Ruff-compliant formatting

## Validation
- `ruff format --check src/ tests/` -> pass
- `ruff check src/ tests/` -> pass
- targeted station regressions -> `53 passed`
- `pytest -q` -> `2016 passed, 5 skipped`
- `python -m compileall -q src tests`
