### PR TITLE
Make verified reliability fixes installable as beta 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [3.0.0b15] - 2026-08-26
+
+Beta release over 3.0.0b14 for GUI/runtime reliability, truthful reporting,
+station evaluation fixes, and preprocessing performance.
+
+### Added
+- Content-addressed xESMF weight caching to reuse identical regridding weights.
+- GUI progress events and bounded report summaries for safer long-running local
+  and remote evaluations.
+
+### Changed
+- Local Dask evaluation avoids distributed NetCDF/HDF5 worker writes and keeps
+  scanned simulation case cards readable.
+- Shared preprocessing, reference masking, MFM component work, and multi-model
+  comparisons reuse expensive intermediate work where results are equivalent.
+
+### Fixed
+- GUI local and remote workflows now fail truthfully instead of silently falling
+  back, stalling, or running on the wrong target.
+- Reference and simulation scanning preserve requested datasets, station lists,
+  paths, and inline metadata more reliably.
+- Time alignment, finite-observation masks, singleton conservative regrids, and
+  station missing-value handling no longer silently alter scientific results.
+- Large NetCDF/CSV reports remain bounded and avoid fabricated or incomplete
+  summaries.
+- Windows path normalization, environment discovery, CPU quota handling, and CI
+  formatting stability.
+- Station evaluation process updates from PRs #167 and #170.
+
 ## [3.0.0b14] - 2026-08-22
 
 Beta release over 3.0.0b13 for actionable GUI preflight diagnostics.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ conda install -c conda-forge colm-openbench
 mamba install -c conda-forge colm-openbench   # or the faster mamba
 ```
 
-> **Note:** the current release is a Beta pre-release (`3.0.0b14`) and is **not on
+> **Note:** the current release is a Beta pre-release (`3.0.0b15`) and is **not on
 > conda-forge yet**. Until it is, use one of the two paths below.
 
 If your platform does not have wheels for geospatial dependencies such as

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b14" %}
+{% set version = "3.0.0b15" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: 9c12511f54ef6e48d2c8120860d056cb7998f833fa42228d68c2875deae42be9
+  sha256: 3b40f83f4dddab4f0b678be7b877a7e2c2434c00acd69a8d12c1080d241538ef
 
 build:
   noarch: python

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b14"
+__version__ = "3.0.0b15"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"


### PR DESCRIPTION
## Summary
- bump the package, README, and Conda recipe to `3.0.0b15`
- add beta-15 release notes for GUI/runtime reliability, scientific correctness, reporting, and preprocessing reuse
- pin the Conda recipe to the verified source-distribution checksum

## Verified artifacts
- wheel SHA-256: `b818a8e454e96d06205b5de238017092137893f2fafdb681f6b2fdbd0d217db7`
- sdist SHA-256: `3b40f83f4dddab4f0b678be7b877a7e2c2434c00acd69a8d12c1080d241538ef`

## Validation
- `pytest -q` -> `1982 passed, 5 skipped`
- Ruff check/format -> pass
- Twine check -> pass
- archive member and metadata checks -> pass
- isolated wheel import and CLI smoke -> pass
- independent release verification -> GO
