### PR TITLE
Make remote setup and data discovery reliable

### DIFF
--- a/src/openbench/data/registry/scanner.py
+++ b/src/openbench/data/registry/scanner.py
@@ -1256,12 +1256,20 @@ def _scan_ignore_profile(ref_root: Path, profile_name: str, scan: dict) -> tuple
     return None, {ignored_root}
 
 
-def _scan_profile_layouts(ref_root: Path, on_skip=None) -> tuple[dict[str, DatasetGroup], set[Path]]:
+def _scan_profile_layouts(
+    ref_root: Path,
+    on_skip=None,
+    selected_scope: str | None = None,
+) -> tuple[dict[str, DatasetGroup], set[Path]]:
     """Scan profile-declared layouts before generic directory walking."""
     groups: dict[str, DatasetGroup] = {}
     consumed_dirs: set[Path] = set()
 
     for profile_name, profile, scan in _profile_scan_specs():
+        root_sub_dir = str(scan.get("root_sub_dir", ""))
+        profile_scope = Path(root_sub_dir).parts[0].casefold() if root_sub_dir else ""
+        if selected_scope and profile_scope != selected_scope:
+            continue
         layout = scan.get("layout")
         scanned = None
         consumed: set[Path] = set()
@@ -1293,31 +1301,37 @@ def _scan_profile_layouts(ref_root: Path, on_skip=None) -> tuple[dict[str, Datas
     return groups, consumed_dirs
 
 
-def _reference_dataset_dirs(ref_root: Path, consumed_dirs: set[Path]) -> list[Path]:
+def _reference_dataset_dirs(
+    ref_root: Path,
+    consumed_dirs: set[Path],
+    selected_scope: str | None = None,
+) -> list[Path]:
     """Collect generic dataset roots that need recursive NetCDF discovery."""
     directories = []
-    grid_dir = _child_dir_case_insensitive(ref_root, "Grid")
-    for res_name in ("LowRes", "MidRes", "HigRes"):
-        res_dir = _child_dir_case_insensitive(grid_dir, res_name)
-        for category_dir in _iter_dirs(res_dir):
-            for var_dir in _iter_dirs(category_dir):
-                if not _is_profile_consumed(var_dir, consumed_dirs):
-                    directories.extend(
-                        dataset_dir
-                        for dataset_dir in _iter_dirs(var_dir)
-                        if not _is_profile_consumed(dataset_dir, consumed_dirs)
-                    )
+    if selected_scope != "station":
+        grid_dir = _child_dir_case_insensitive(ref_root, "Grid")
+        for res_name in ("LowRes", "MidRes", "HigRes"):
+            res_dir = _child_dir_case_insensitive(grid_dir, res_name)
+            for category_dir in _iter_dirs(res_dir):
+                for var_dir in _iter_dirs(category_dir):
+                    if not _is_profile_consumed(var_dir, consumed_dirs):
+                        directories.extend(
+                            dataset_dir
+                            for dataset_dir in _iter_dirs(var_dir)
+                            if not _is_profile_consumed(dataset_dir, consumed_dirs)
+                        )
 
-    station_dir = _child_dir_case_insensitive(ref_root, "Station")
-    for category_dir in _iter_dirs(station_dir):
-        for var_dir in _iter_dirs(category_dir):
-            if _is_profile_consumed(var_dir, consumed_dirs) or _count_nc(var_dir):
-                continue
-            directories.extend(
-                dataset_dir
-                for dataset_dir in _iter_dirs(var_dir)
-                if not _is_profile_consumed(dataset_dir, consumed_dirs)
-            )
+    if selected_scope != "grid":
+        station_dir = _child_dir_case_insensitive(ref_root, "Station")
+        for category_dir in _iter_dirs(station_dir):
+            for var_dir in _iter_dirs(category_dir):
+                if _is_profile_consumed(var_dir, consumed_dirs) or _count_nc(var_dir):
+                    continue
+                directories.extend(
+                    dataset_dir
+                    for dataset_dir in _iter_dirs(var_dir)
+                    if not _is_profile_consumed(dataset_dir, consumed_dirs)
+                )
     return list(dict.fromkeys(directories))
 
 
@@ -1359,13 +1373,16 @@ def scan_reference_directory(
         List of DatasetGroup, each containing resolution variants.
     """
     ref_root = Path(ref_root)
+    selected_scope = ref_root.name.casefold() if ref_root.name.casefold() in {"grid", "station"} else None
+    if selected_scope:
+        ref_root = ref_root.parent
     if not ref_root.exists():
         logger.warning("Reference directory not found: %s", ref_root)
         return []
 
-    groups, consumed_dirs = _scan_profile_layouts(ref_root, on_skip=on_skip)
+    groups, consumed_dirs = _scan_profile_layouts(ref_root, on_skip=on_skip, selected_scope=selected_scope)
     nc_locations = _find_reference_nc_dirs(
-        _reference_dataset_dirs(ref_root, consumed_dirs),
+        _reference_dataset_dirs(ref_root, consumed_dirs, selected_scope=selected_scope),
         max_workers=max_workers,
     )
 
@@ -1376,7 +1393,7 @@ def scan_reference_directory(
     # If a 3rd-level dir has NC files → standard dataset.
     # If not but its children do → dataset with sub-dirs (depth 4).
     grid_dir = _child_dir_case_insensitive(ref_root, "Grid")
-    if grid_dir.exists():
+    if selected_scope != "station" and grid_dir.exists():
         for res_name in ["LowRes", "MidRes", "HigRes"]:
             res_dir = _child_dir_case_insensitive(grid_dir, res_name)
             if not res_dir.exists():
@@ -1520,7 +1537,7 @@ def scan_reference_directory(
     # Scan station data: Station/<category>/<variable>/<dataset>/
     # Also handles Composite layout: Station/Composite/<dataset>/dataset/*.nc
     stn_dir = _child_dir_case_insensitive(ref_root, "Station")
-    if stn_dir.exists():
+    if selected_scope != "grid" and stn_dir.exists():
         if on_progress:
             on_progress("Scanning Station/...")
         for category_dir in _iter_dirs(stn_dir):
@@ -3123,7 +3140,28 @@ def _numeric_scalar_or_singleton(value) -> float | None:
     return float(arr.reshape(-1)[0])
 
 
-def _station_coordinate_value(ds, coord_var: str | None, station_dim: str, index: int) -> float | None:
+def _station_coordinate_values(ds, coord_var: str | None, station_dim: str):
+    """Load a merged station coordinate once, with the station axis first."""
+    if not coord_var:
+        return None
+
+    import numpy as np
+
+    data_array = ds[coord_var]
+    if station_dim in data_array.dims:
+        return np.moveaxis(data_array.values, data_array.dims.index(station_dim), 0)
+    if data_array.size == 1:
+        return data_array.values
+    logger.warning(
+        "Skipping merged station coordinate %s: dims %s are not indexed by station dimension %s",
+        coord_var,
+        data_array.dims,
+        station_dim,
+    )
+    return None
+
+
+def _station_coordinate_value(values, coord_var: str | None, index: int) -> float | None:
     """Return a station coordinate only when it is scalar for this station.
 
     Merged station files should expose lat/lon either as scalar values or as
@@ -3137,19 +3175,10 @@ def _station_coordinate_value(ds, coord_var: str | None, station_dim: str, index
 
     import numpy as np
 
-    data_array = ds[coord_var]
-    if station_dim in data_array.dims:
-        value = data_array.isel({station_dim: index}).values
-    elif data_array.size == 1:
-        value = data_array.values
-    else:
-        logger.warning(
-            "Skipping merged station coordinate %s: dims %s are not indexed by station dimension %s",
-            coord_var,
-            data_array.dims,
-            station_dim,
-        )
+    if values is None:
         return None
+
+    value = values if np.asarray(values).size == 1 else values[index]
 
     scalar = _numeric_scalar_or_singleton(value)
     if scalar is not None:
@@ -3343,6 +3372,10 @@ def _parse_merged_station_file(nc_file: Path, dataset_dir: Path) -> list:
             n_stations = ds.sizes[stn_dim]
             lat_var = _find_var(ds, LAT_NAMES)
             lon_var = _find_var(ds, LON_NAMES)
+            lat_values = _station_coordinate_values(ds, lat_var, stn_dim)
+            lon_values = _station_coordinate_values(ds, lon_var, stn_dim)
+            id_values = [(name, ds[name].values) for name in ("station_id", "site_id", "station_name", "site") if name in ds]
+            station_values = ds[stn_dim].values if stn_dim in ds.coords else None
 
             # Time range (case-insensitive dim name)
             syear = ""
@@ -3358,19 +3391,17 @@ def _parse_merged_station_file(nc_file: Path, dataset_dir: Path) -> list:
 
             for i in range(n_stations):
                 station_id = None
-                for id_var in ("station_id", "site_id", "station_name", "site"):
-                    if id_var in ds:
-                        values = ds[id_var].values
-                        try:
-                            station_id = _decode_station_id_value(values[i])
-                        except Exception:
-                            station_id = None
-                        if station_id:
-                            break
+                for _id_var, values in id_values:
+                    try:
+                        station_id = _decode_station_id_value(values[i])
+                    except Exception:
+                        station_id = None
+                    if station_id:
+                        break
                 if not station_id:
-                    station_id = str(ds[stn_dim].values[i]) if stn_dim in ds.coords else str(i)
-                lat = _station_coordinate_value(ds, lat_var, stn_dim, i)
-                lon = _station_coordinate_value(ds, lon_var, stn_dim, i)
+                    station_id = str(station_values[i]) if station_values is not None else str(i)
+                lat = _station_coordinate_value(lat_values, lat_var, i)
+                lon = _station_coordinate_value(lon_values, lon_var, i)
 
                 if lat is not None and lon is not None and not (np.isnan(lat) or np.isnan(lon)):
                     rows.append([station_id, syear, eyear, lon, lat, str(nc_file)])

--- a/src/openbench/gui/main_window.py
+++ b/src/openbench/gui/main_window.py
@@ -125,12 +125,14 @@ class MainWindow(QMainWindow):
 
         # Logo/Title area
         title_frame = QFrame()
-        title_frame.setStyleSheet("background-color: #252525; padding: 20px;")
+        title_frame.setStyleSheet("background-color: #252525;")
         title_layout = QVBoxLayout(title_frame)
+        title_layout.setContentsMargins(16, 16, 16, 16)
 
         self.logo_label = QLabel()
         if not self._logo_pixmap.isNull():
-            self.logo_label.setPixmap(self._logo_pixmap.scaled(160, 92, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+            self.logo_label.setPixmap(self._logo_pixmap.scaled(132, 76, Qt.KeepAspectRatio, Qt.SmoothTransformation))
+        self.logo_label.setStyleSheet("background-color: #ffffff; border-radius: 8px; padding: 6px;")
         self.logo_label.setAlignment(Qt.AlignCenter)
         title_layout.addWidget(self.logo_label)
 
@@ -1240,6 +1242,8 @@ class MainWindow(QMainWindow):
         """
         from openbench.remote.sync import SyncEngine
 
+        was_remote = isinstance(self.controller.storage, RemoteStorage)
+
         get_target_identity = getattr(ssh_manager, "get_active_target_identity", None)
         if callable(get_target_identity) and get_target_identity() is None:
             QMessageBox.warning(
@@ -1285,6 +1289,12 @@ class MainWindow(QMainWindow):
         sync_engine = SyncEngine(ssh_manager, remote_project_dir)
         self.controller.storage = RemoteStorage(remote_project_dir, sync_engine)
         self.controller.ssh_manager = ssh_manager
+        config = getattr(self.controller, "config", None)
+        if not was_remote and isinstance(config, dict):
+            config.setdefault("general", {})["basedir"] = f"{remote_project_dir.rstrip('/')}/output"
+        general_page = getattr(self, "pages", {}).get("general")
+        if general_page is not None:
+            general_page.load_from_config()
         from openbench.gui.remote_registry import clear_registry
 
         clear_registry(self.controller)
@@ -1304,11 +1314,18 @@ class MainWindow(QMainWindow):
         Args:
             project_dir: Local project directory path
         """
+        was_remote = isinstance(self.controller.storage, RemoteStorage)
         if not self._cleanup_remote_storage(sync_pending=True, disconnect_ssh=True):
             return False
 
         self.controller.storage = LocalStorage(project_dir)
         self.controller.project_root = project_dir
+        config = getattr(self.controller, "config", None)
+        if was_remote and isinstance(config, dict):
+            config.setdefault("general", {})["basedir"] = os.path.join(project_dir, "output")
+        general_page = getattr(self, "pages", {}).get("general")
+        if general_page is not None:
+            general_page.load_from_config()
 
         # Remove sync status widget if exists
         if self._sync_status:

--- a/src/openbench/gui/pages/_scan_worker.py
+++ b/src/openbench/gui/pages/_scan_worker.py
@@ -113,6 +113,9 @@ def _remote_bootstrap(openbench_source_path: str) -> str:
 def _remote_ref_root_setup(data_root: str) -> str:
     return (
         f"_data_root = os.path.abspath(os.path.expanduser({json.dumps(data_root)}))\n"
+        "_scan_root = _data_root\n"
+        'if os.path.basename(_data_root).casefold() in {"grid", "station"}:\n'
+        "    _data_root = os.path.dirname(_data_root)\n"
         'os.environ["OPENBENCH_REF_ROOT"] = _data_root\n'
     )
 
@@ -253,11 +256,11 @@ if selected_variants is not None:
 elif {rescan!r}:
     scan_fn = scan_reference_directory or find_new_datasets
     scan_kwargs = {{}} if scan_reference_directory is not None else {{"existing_names": set()}}
-    groups = _scan_with_skips(scan_fn, _data_root, **scan_kwargs)
+    groups = _scan_with_skips(scan_fn, _scan_root, **scan_kwargs)
 else:
     scan_fn = find_new_datasets or scan_reference_directory
     scan_kwargs = {{"existing_names": registered_names}} if find_new_datasets is not None else {{}}
-    groups = _scan_with_skips(scan_fn, _data_root, **scan_kwargs)
+    groups = _scan_with_skips(scan_fn, _scan_root, **scan_kwargs)
 payload = []
 for group in groups:
     variants = {{}}

--- a/src/openbench/gui/pages/page_general.py
+++ b/src/openbench/gui/pages/page_general.py
@@ -58,6 +58,7 @@ class PageGeneral(BasePage):
         self.basename_input = QLineEdit()
         self.basename_input.setPlaceholderText("Project name (e.g., Initial_test)")
         self.basename_input.textChanged.connect(self._on_project_name_changed)
+        self._confirmed_project = None
         name_layout.addWidget(self.basename_input)
 
         self.btn_confirm_name = QPushButton("Confirm")
@@ -410,6 +411,7 @@ class PageGeneral(BasePage):
         Note: Only saves to config without triggering sync_namelists.
         Directory creation happens only when Confirm button is clicked.
         """
+        self._confirmed_project = None
         self._save_to_config_no_sync()
 
     def _on_basedir_changed(self, path):
@@ -418,6 +420,7 @@ class PageGeneral(BasePage):
         Note: Only saves to config without triggering sync_namelists.
         Directory creation happens only when Confirm button is clicked.
         """
+        self._confirmed_project = None
         self._save_to_config_no_sync()
 
     def _on_confirm_project(self):
@@ -493,7 +496,8 @@ class PageGeneral(BasePage):
 
         if is_remote:
             # Create directories on remote server
-            self._create_remote_project_folder(output_dir)
+            if self._create_remote_project_folder(output_dir):
+                self._confirmed_project = (basedir, basename)
         else:
             # Create the output directory and nml subdirectories locally
             try:
@@ -503,6 +507,7 @@ class PageGeneral(BasePage):
 
                 # Trigger namelist sync
                 self.controller.sync_namelists()
+                self._confirmed_project = (basedir, basename)
 
                 QMessageBox.information(self, "Project Created", f"Project folder created:\n{output_dir}")
             except Exception as e:
@@ -515,7 +520,7 @@ class PageGeneral(BasePage):
             QMessageBox.warning(
                 self, "Not Connected", "Please connect to the remote server first in the Runtime Environment page."
             )
-            return
+            return False
 
         try:
             # Create directories on remote server
@@ -530,12 +535,14 @@ class PageGeneral(BasePage):
                 QMessageBox.information(
                     self, "Project Created", f"Project folder created on remote server:\n{output_dir}"
                 )
+                return True
             else:
                 QMessageBox.critical(
                     self, "Error", f"Failed to create project folder on remote server:\n{stderr or stdout}"
                 )
         except Exception as e:
             QMessageBox.critical(self, "Error", f"Failed to create project folder:\n{str(e)}")
+        return False
 
     def load_from_config(self):
         """Load settings from controller config."""
@@ -873,7 +880,7 @@ class PageGeneral(BasePage):
 
     def validate(self) -> bool:
         """Validate page input."""
-        from openbench.gui.validation import FieldValidator, ValidationManager
+        from openbench.gui.validation import FieldValidator, ValidationError, ValidationManager
 
         errors = []
         manager = ValidationManager(self)
@@ -887,7 +894,8 @@ class PageGeneral(BasePage):
             widget=self.basename_input,
         )
         if error:
-            errors.append(error)
+            manager.show_error_and_focus(error, allow_skip=False)
+            return False
 
         # Output directory required
         error = FieldValidator.required(
@@ -898,7 +906,21 @@ class PageGeneral(BasePage):
             widget=self.basedir_input,
         )
         if error:
-            errors.append(error)
+            manager.show_error_and_focus(error, allow_skip=False)
+            return False
+
+        project = (self.basedir_input.path().strip(), self.basename_input.text().strip())
+        if self._confirmed_project != project:
+            manager.show_error_and_focus(
+                ValidationError(
+                    "project",
+                    "Enter a project name and click Confirm before continuing.",
+                    self.PAGE_ID,
+                    self.btn_confirm_name,
+                ),
+                allow_skip=False,
+            )
+            return False
 
         # Year range validation
         error = FieldValidator.min_max(

--- a/src/openbench/gui/pages/page_sim_data.py
+++ b/src/openbench/gui/pages/page_sim_data.py
@@ -14,6 +14,7 @@ variables are available for evaluation downstream.
 import logging
 import os
 import threading
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
@@ -769,6 +770,7 @@ class PageSimData(BasePage):
         # live event loop), so the window stays painted while the progress
         # dialog can cancel the SSH command.
         QApplication.setOverrideCursor(Qt.WaitCursor)
+        scan_was_canceled = False
         try:
             discovered = []
             # label → {files, suffix, multi_stream}; carried past the confirm
@@ -800,12 +802,13 @@ class PageSimData(BasePage):
                     QMessageBox.critical(self, "Error", f"Cannot scan directory:\n{exc}")
                     return
         finally:
+            scan_was_canceled = cancel_event is not None and cancel_event.is_set()
             QApplication.restoreOverrideCursor()
             if progress is not None:
                 progress.close()
                 progress.deleteLater()
 
-        if cancel_event is not None and cancel_event.is_set():
+        if scan_was_canceled:
             return
 
         if not discovered:
@@ -1568,6 +1571,11 @@ class PageSimData(BasePage):
                 if not nc_dir:
                     issues.append(f"{c['label']}: no NetCDF files found ({c['nc_dir']})")
                     continue
+                try:
+                    available_files = _remote_list_nc_files(ssh_manager, nc_dir)
+                except Exception as exc:
+                    issues.append(f"{c['label']}: {exc}")
+                    continue
             else:
                 if not os.path.isdir(c["nc_dir"]):
                     issues.append(f"{c['label']}: directory not found ({c['nc_dir']})")
@@ -1576,6 +1584,7 @@ class PageSimData(BasePage):
                 if not nc_dir:
                     issues.append(f"{c['label']}: no NetCDF files found ({c['nc_dir']})")
                     continue
+                available_files = [str(path) for path in _glob_nc_local(nc_dir)]
 
             variable_patterns = [
                 (name, override)
@@ -1596,7 +1605,16 @@ class PageSimData(BasePage):
                     ssh_manager=ssh_manager,
                     remote_openbench_root=remote_openbench_root,
                 )
-                sample_paths = path_gen.get_sample_paths()
+                candidate_patterns = (
+                    path_gen._candidate_filenames()
+                    if str(path_gen.data_groupby).lower() == "single"
+                    else path_gen._candidate_patterns()
+                )
+                sample_paths = [
+                    path
+                    for path in available_files
+                    if any(fnmatch(os.path.basename(path), pattern) for pattern in candidate_patterns)
+                ]
                 issue_label = f"{c['label']} ({variable_name})" if variable_name else c["label"]
                 if not sample_paths:
                     pattern = path_gen.describe_pattern()
@@ -1604,17 +1622,6 @@ class PageSimData(BasePage):
                         f"No files found matching pattern '{pattern}' in {path_gen._get_base_dir()}"
                     )
                     issues.append(f"{issue_label}: {message}")
-                    continue
-
-                file_checks = [file_checker.check_file_exists(path) for path in sample_paths]
-                if not any(check.passed for check in file_checks):
-                    pattern = path_gen.describe_pattern()
-                    issues.append(
-                        f"{issue_label}: No files found matching pattern '{pattern}' in {path_gen._get_base_dir()}"
-                    )
-                elif any(not check.passed for check in file_checks):
-                    failed = next(check for check in file_checks if not check.passed)
-                    issues.append(f"{issue_label}: {failed.message}")
         if issues:
             QMessageBox.warning(self, "Validation Issues", "\n".join(issues))
         else:

--- a/src/openbench/gui/remote_registry.py
+++ b/src/openbench/gui/remote_registry.py
@@ -62,6 +62,14 @@ def _remote_settings(controller) -> dict[str, Any]:
     return {}
 
 
+def _configured_source_path(settings: dict[str, Any]) -> str:
+    source_path = str(settings.get("openbench_source_path") or "").strip()
+    package_path = str(settings.get("openbench_package_path") or "").strip().replace("\\", "/").rstrip("/")
+    if not source_path and package_path.endswith("/src/openbench"):
+        source_path = package_path[: -len("/src/openbench")]
+    return source_path
+
+
 def _ssh_manager(controller):
     if hasattr(controller, "storage"):
         from openbench.gui.path_utils import get_remote_ssh_manager
@@ -86,7 +94,7 @@ def _execution_context(settings: dict[str, Any]) -> tuple[str, str, str]:
     return (
         str(settings.get("python_path") or ""),
         str(settings.get("conda_env") or ""),
-        str(settings.get("openbench_source_path") or ""),
+        _configured_source_path(settings),
     )
 
 
@@ -112,7 +120,7 @@ def _remote_json(controller, script: str):
     from openbench.gui import remote_python
 
     settings = _remote_settings(controller)
-    script = _remote_bootstrap(settings.get("openbench_source_path", "")) + script
+    script = _remote_bootstrap(_configured_source_path(settings)) + script
     return remote_python.run_remote_python_json(
         _ssh_manager(controller),
         script,

--- a/src/openbench/gui/widgets/remote_config.py
+++ b/src/openbench/gui/widgets/remote_config.py
@@ -184,8 +184,7 @@ class ClickableLineEdit(QLineEdit):
     def mousePressEvent(self, event):
         """Handle mouse press event."""
         super().mousePressEvent(event)
-        if not self.text():  # Only show menu if empty
-            self.clicked.emit()
+        self.clicked.emit()
 
 
 # Delimits the resolve/ls/find sections of the combined listing command.
@@ -215,7 +214,7 @@ def _build_conda_create_task(ssh_manager, quoted_conda_exe, quoted_env_name, env
         if interrupted():
             output_chunks.append("\nInterrupted before environment creation.\n")
             return {"exit_code": 130, "output": "".join(output_chunks), "envs": []}
-        cmd = f"{quoted_conda_exe} create -n {quoted_env_name} python=3.12 -y 2>&1"
+        cmd = f"{quoted_conda_exe} create -n {quoted_env_name} -c conda-forge python=3.12 -y 2>&1"
         stdout, stderr, exit_code = ssh_manager.execute(cmd, timeout=300, should_abort=interrupted)
         output_chunks.append(f"$ {cmd}\n{stdout}{stderr}\n")
         envs = ssh_manager.detect_conda_envs() if exit_code == 0 and not interrupted() else []
@@ -2206,14 +2205,23 @@ if spec is not None:
                 else:
                     return
             else:
-                # Never delete an arbitrary remote directory on the user's behalf.
-                QMessageBox.warning(
-                    self,
-                    "Directory Exists",
-                    f"Directory {install_path} already exists but is not an OpenBench git repository.\n\n"
-                    "Choose an empty path or move/remove that directory manually.",
+                stdout3, stderr3, exit_code3 = execute_responsive(
+                    ssh_manager,
+                    (
+                        f"first_entry=$(find {quoted_install_path} -mindepth 1 -maxdepth 1 -print -quit "
+                        f"2>/dev/null) && test -z \"$first_entry\" && test -w {quoted_install_path} && echo is_empty"
+                    ),
+                    timeout=10,
                 )
-                return
+                if exit_code3 != 0 or not _has_exact_stdout_line(stdout3, "is_empty"):
+                    # Never delete an arbitrary remote directory on the user's behalf.
+                    QMessageBox.warning(
+                        self,
+                        "Directory Exists",
+                        f"Directory {install_path} already exists but is not an OpenBench git repository.\n\n"
+                        "Choose an empty path or move/remove that directory manually.",
+                    )
+                    return
 
         # Protocol selection dialog
         if not is_update:
@@ -2448,6 +2456,12 @@ if spec is not None:
             # Extract env name from "envname (type)" format
             conda_env = conda_env_text.split()[0]
 
+        package_path = self.openbench_package_input.text().strip()
+        source_path = self._openbench_source_path
+        normalized_package_path = package_path.replace("\\", "/").rstrip("/")
+        if not source_path and normalized_package_path.endswith("/src/openbench"):
+            source_path = normalized_package_path[: -len("/src/openbench")]
+
         return {
             "host": self.host_input.text().strip(),
             "auth_type": "password" if self.radio_password.isChecked() else "key",
@@ -2460,8 +2474,8 @@ if spec is not None:
             "python_path": self.python_combo.currentText().strip(),
             "conda_env": conda_env,
             "openbench_path": self.openbench_input.text().strip(),
-            "openbench_source_path": self._openbench_source_path,
-            "openbench_package_path": self.openbench_package_input.text().strip(),
+            "openbench_source_path": source_path,
+            "openbench_package_path": package_path,
         }
 
     def set_config(self, config: Dict[str, Any]):

--- a/tests/test_gui_controller_paths.py
+++ b/tests/test_gui_controller_paths.py
@@ -400,10 +400,32 @@ def test_remote_storage_setup_expands_tilde_project_dir(monkeypatch):
     window._current_sync_engine = lambda: None
     window._cleanup_remote_storage = lambda sync_pending=True, disconnect_ssh=False: True
     window._setup_sync_status = lambda sync: None
+    reloads = []
+    window.pages = {"general": SimpleNamespace(load_from_config=lambda: reloads.append(True))}
     monkeypatch.setattr("openbench.remote.sync.SyncEngine", Sync)
 
     assert window.setup_remote_storage(SSH(), "~/OpenBench") is True
     assert window.controller.storage.project_dir == "/home/alice/OpenBench"
+    assert window.controller.config["general"]["basedir"] == "/home/alice/OpenBench/output"
+    assert reloads == [True]
+
+
+def test_local_storage_restores_local_output_directory():
+    from openbench.gui.main_window import MainWindow
+
+    window = MainWindow.__new__(MainWindow)
+    window.controller = _controller(
+        {"general": {"basedir": "/remote/OpenBench/output"}},
+        storage=RemoteStorage("/remote/OpenBench", sync_engine=object()),
+    )
+    window._cleanup_remote_storage = lambda **_kwargs: True
+    window._sync_status = None
+    reloads = []
+    window.pages = {"general": SimpleNamespace(load_from_config=lambda: reloads.append(True))}
+
+    assert window.setup_local_storage("/local/OpenBench") is True
+    assert window.controller.config["general"]["basedir"] == os.path.join("/local/OpenBench", "output")
+    assert reloads == [True]
 
 
 def test_remote_output_dir_expands_tilde_basedir_with_connected_ssh():

--- a/tests/test_gui_general_confirmation.py
+++ b/tests/test_gui_general_confirmation.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("PySide6")
+
+from openbench.gui.controller import WizardController  # noqa: E402
+from openbench.gui.pages.page_general import PageGeneral  # noqa: E402
+
+
+def test_general_requires_confirm_after_project_name_changes(qapp, monkeypatch, tmp_path):
+    controller = WizardController()
+    page = PageGeneral(controller)
+    page.basedir_input.set_path(str(tmp_path))
+    page.basename_input.setText("demo")
+    warnings = []
+    monkeypatch.setattr(
+        "openbench.gui.validation.QMessageBox.warning",
+        lambda _parent, title, message: warnings.append((title, message)),
+    )
+
+    assert page.validate() is False
+    assert "click Confirm" in warnings[0][1]
+
+    controller.sync_namelists = lambda: None
+    monkeypatch.setattr("openbench.gui.pages.page_general.QMessageBox.information", lambda *_args: None)
+    page._on_confirm_project()
+    assert page.validate() is True
+
+    page.basename_input.setText("renamed")
+    assert page.validate() is False

--- a/tests/test_gui_remote_registry.py
+++ b/tests/test_gui_remote_registry.py
@@ -160,6 +160,31 @@ def test_remote_registry_does_not_import_from_workspace(monkeypatch):
     assert "/stale/OpenBench" not in captured["script"]
 
 
+def test_remote_registry_recovers_source_root_from_detected_src_package(monkeypatch):
+    from openbench.gui import remote_python, remote_registry
+
+    remote_registry._REMOTE_CACHE.clear()
+    controller = FakeController(
+        FakeSSH(("direct", "alice", "login", 22)),
+        {
+            "python_path": "/env/bin/python",
+            "openbench_path": "/workspace",
+            "openbench_package_path": "/tera/OpenBench/src/openbench",
+        },
+    )
+    captured = {}
+
+    def fake_run(_ssh, script, **_kwargs):
+        captured["script"] = script
+        return _snapshot()
+
+    monkeypatch.setattr(remote_python, "run_remote_python_json", fake_run)
+
+    remote_registry.get_registry(controller, refresh=True)
+
+    assert "/tera/OpenBench/src" in captured["script"]
+
+
 def test_remote_cache_is_bound_to_active_target_identity(monkeypatch):
     from openbench.gui import remote_python, remote_registry
 

--- a/tests/test_gui_remote_scanner_workflow.py
+++ b/tests/test_gui_remote_scanner_workflow.py
@@ -106,8 +106,9 @@ def test_remote_reference_scan_script_sets_absolute_ref_root(monkeypatch):
 
     script = captured["script"]
     assert '_data_root = os.path.abspath(os.path.expanduser("~/Reference"))' in script
+    assert "_scan_root = _data_root" in script
     assert 'os.environ["OPENBENCH_REF_ROOT"] = _data_root' in script
-    assert "groups = _scan_with_skips(scan_fn, _data_root" in script
+    assert "groups = _scan_with_skips(scan_fn, _scan_root" in script
     assert '"data_root": _data_root' in script
     compile(script, "<remote-scan-script>", "exec")
 

--- a/tests/test_gui_sim_data.py
+++ b/tests/test_gui_sim_data.py
@@ -87,6 +87,82 @@ def test_remote_sim_scan_cancel_uses_threading_event(qapp, monkeypatch):
     assert page._scan_btn.enabled is True
 
 
+def test_remote_sim_scan_keeps_results_when_progress_close_emits_cancel(qapp, monkeypatch):
+    from openbench.gui.dialogs import scan_confirm
+    from openbench.remote.storage import RemoteStorage
+
+    class Signal:
+        def connect(self, slot):
+            self.slot = slot
+
+        def emit(self):
+            self.slot()
+
+    class Progress:
+        def __init__(self, *_args):
+            self.canceled = Signal()
+
+        def setWindowTitle(self, *_args):
+            pass
+
+        def setWindowModality(self, *_args):
+            pass
+
+        def setMinimumDuration(self, *_args):
+            pass
+
+        def show(self):
+            pass
+
+        def close(self):
+            self.canceled.emit()
+
+        def deleteLater(self):
+            pass
+
+    class Dialog:
+        register_button = SimpleNamespace(clicked=SimpleNamespace(connect=lambda *_args: None))
+
+        def __init__(self, **_kwargs):
+            pass
+
+        def exec(self):
+            return True
+
+        def get_results(self):
+            return [{"label": "CLM5", "nc_dir": "/remote/sim/CLM5", "prefix": "hist_", "model": "CLM5"}]
+
+    added = []
+    page = SimpleNamespace(
+        controller=SimpleNamespace(storage=RemoteStorage("/remote", object()), remote_settings=lambda: {}),
+        _root_input=_Text("/remote/sim"),
+        _clear_cases=lambda: None,
+        _registry_model_names=lambda: ["CLM5"],
+        _compute_variable_overrides=lambda *_args: {},
+        _add_case_row=lambda *args, **kwargs: added.append((args, kwargs)),
+        _settings_group=SimpleNamespace(setVisible=lambda *_args: None),
+        _on_selection_changed=lambda: None,
+    )
+    monkeypatch.setattr(page_sim_data, "get_remote_ssh_manager", lambda _controller: SimpleNamespace(is_connected=True))
+    monkeypatch.setattr(page_sim_data, "_remote_is_dir", lambda *_args: True)
+    monkeypatch.setattr(page_sim_data, "QProgressDialog", Progress)
+    monkeypatch.setattr(
+        page_sim_data,
+        "scan_simulation_cases_remote",
+        lambda *_args, **_kwargs: (
+            [("CLM5", "/remote/sim/CLM5", "hist_")],
+            {"CLM5": {"model": "CLM5", "variables": ["Runoff"]}},
+        ),
+    )
+    monkeypatch.setattr(scan_confirm, "ScanConfirmDialog", Dialog)
+    monkeypatch.setattr(page_sim_data.QApplication, "setOverrideCursor", lambda *_args: None)
+    monkeypatch.setattr(page_sim_data.QApplication, "restoreOverrideCursor", lambda: None)
+
+    page_sim_data.PageSimData._do_scan_flow(page)
+
+    assert added and added[0][0][:3] == ("CLM5", "/remote/sim/CLM5", "hist_")
+
+
 def test_remote_sim_scan_helpers_quote_paths_and_find_nc4():
     commands = []
 
@@ -491,6 +567,50 @@ def test_remote_station_validation_checks_fulllist_not_case_root(monkeypatch):
     page_sim_data.PageSimData._validate_data(page)
 
     assert calls == ["/remote/home/.openbench/sim_station_lists/StationCase.csv"]
+    assert infos and infos[0][1] == "Validation OK"
+
+
+def test_remote_grid_validation_lists_each_case_once(monkeypatch):
+    from openbench.remote.storage import RemoteStorage
+
+    calls = []
+    infos = []
+    ssh = SimpleNamespace(is_connected=True)
+    monkeypatch.setattr(page_sim_data, "get_remote_ssh_manager", lambda _controller: ssh)
+    monkeypatch.setattr(page_sim_data, "_remote_find_nc_dir", lambda *_args: "/remote/sim/CaseA")
+
+    def list_files(*_args):
+        calls.append(1)
+        return ["/remote/sim/CaseA/runoff_2001.nc", "/remote/sim/CaseA/heat_2001.nc"]
+
+    monkeypatch.setattr(page_sim_data, "_remote_list_nc_files", list_files)
+    monkeypatch.setattr(page_sim_data.QMessageBox, "information", lambda *args: infos.append(args))
+    monkeypatch.setattr(page_sim_data.QMessageBox, "warning", lambda *_args: None)
+
+    page = SimpleNamespace(
+        controller=SimpleNamespace(
+            storage=RemoteStorage("/remote", ssh),
+            config={"general": {"syear": 2001, "eyear": 2001}},
+            remote_settings=lambda: {},
+        ),
+        get_selected_cases=lambda: [
+            {
+                "label": "CaseA",
+                "nc_dir": "/remote/sim/CaseA",
+                "model": "CoLM2024",
+                "data_type": "grid",
+                "data_groupby": "Year",
+                "variables": {
+                    "Runoff": {"prefix": "runoff_", "suffix": ".nc"},
+                    "Latent_Heat": {"prefix": "heat_", "suffix": ".nc"},
+                },
+            }
+        ],
+    )
+
+    page_sim_data.PageSimData._validate_data(page)
+
+    assert calls == [1]
     assert infos and infos[0][1] == "Validation OK"
 
 

--- a/tests/test_registry/test_scanner_registration.py
+++ b/tests/test_registry/test_scanner_registration.py
@@ -4215,6 +4215,30 @@ def test_parse_merged_station_file_uses_first_non_time_dimension(tmp_path: Path)
     assert [row[0] for row in rows] == ["A", "B"]
 
 
+def test_station_coordinate_values_loads_array_once():
+    import numpy as np
+
+    from openbench.data.registry.scanner import _station_coordinate_value, _station_coordinate_values
+
+    class Coordinate:
+        dims = ("station",)
+        size = 2
+
+        def __init__(self):
+            self.reads = 0
+
+        @property
+        def values(self):
+            self.reads += 1
+            return np.array([10.0, 20.0])
+
+    coordinate = Coordinate()
+    values = _station_coordinate_values({"lat": coordinate}, "lat", "station")
+
+    assert [_station_coordinate_value(values, "lat", i) for i in range(2)] == [10.0, 20.0]
+    assert coordinate.reads == 1
+
+
 def test_build_variables_uses_injected_remote_inspection(tmp_path):
     """Remote-scanned datasets ship NC inspection results computed on the remote host."""
     from openbench.data.registry.scanner import ScannedDataset, _build_variables

--- a/tests/test_registry/test_scanner_tim_res.py
+++ b/tests/test_registry/test_scanner_tim_res.py
@@ -60,6 +60,32 @@ def test_scan_reference_directory_registers_unprofiled_grid_composite(tmp_path: 
     assert variant.file_count == 1
 
 
+def test_scan_reference_directory_accepts_grid_directory(tmp_path: Path):
+    dataset = tmp_path / "ref" / "Grid" / "LowRes" / "Water" / "Runoff" / "Demo"
+    dataset.mkdir(parents=True)
+    (dataset / "demo.nc").write_text("")
+    station = tmp_path / "ref" / "Station" / "Composite" / "Daily"
+    station.mkdir(parents=True)
+    (station / "daily.nc").write_text("")
+
+    groups = scan_reference_directory(tmp_path / "ref" / "Grid")
+
+    assert [group.base_name for group in groups] == ["Demo"]
+
+
+def test_scan_reference_directory_accepts_station_directory(tmp_path: Path):
+    station = tmp_path / "ref" / "Station" / "Water" / "Runoff" / "Gauge"
+    station.mkdir(parents=True)
+    (station / "gauge.nc").write_text("")
+    grid = tmp_path / "ref" / "Grid" / "LowRes" / "Water" / "Runoff" / "Demo"
+    grid.mkdir(parents=True)
+    (grid / "demo.nc").write_text("")
+
+    groups = scan_reference_directory(tmp_path / "ref" / "Station")
+
+    assert [group.base_name for group in groups] == ["Gauge"]
+
+
 def test_scan_reference_directory_registers_multiple_standard_composite_datasets(tmp_path: Path):
     """Composite/<variable>/<dataset> with several datasets is standard layout."""
     import numpy as np

--- a/tests/test_remote_install_worker.py
+++ b/tests/test_remote_install_worker.py
@@ -889,6 +889,8 @@ def test_existing_non_git_directory_is_never_deleted(qapp, monkeypatch):
                 return "/usr/bin/git\n", "", 0
             if command.startswith("test -e /remote/OpenBench/.git"):
                 return "not is_openbench\n", "", 1
+            if command.startswith("first_entry=$(find /remote/OpenBench"):
+                return "", "", 1
             if command.startswith("test -d /remote/OpenBench"):
                 return "exists\n", "", 0
             raise AssertionError(command)
@@ -908,6 +910,43 @@ def test_existing_non_git_directory_is_never_deleted(qapp, monkeypatch):
     assert warnings and "move/remove that directory manually" in warnings[-1]
     assert all("rm -rf" not in command for command, _timeout in widget._ssh_manager.execute_calls)
     assert FakeWorker.created == []
+
+
+def test_existing_empty_directory_can_be_install_target(qapp, monkeypatch):
+    from openbench.gui.widgets import remote_config
+
+    class SSH:
+        is_connected = True
+
+        def __init__(self):
+            self.execute_calls = []
+
+        def execute(self, command, timeout=None):
+            self.execute_calls.append((command, timeout))
+            if command == "which git":
+                return "/usr/bin/git\n", "", 0
+            if command.startswith("test -e /remote/OpenBench/.git"):
+                return "", "", 1
+            if command.startswith("first_entry=$(find /remote/OpenBench"):
+                return "is_empty\n", "", 0
+            if command.startswith("test -d /remote/OpenBench"):
+                return "exists\n", "", 0
+            raise AssertionError(command)
+
+    FakeWorker.created.clear()
+    widget = RemoteConfigWidget()
+    widget._ssh_manager = SSH()
+    widget.openbench_input.setText("/remote/OpenBench")
+
+    monkeypatch.setattr(remote_config, "SshExecuteWorker", FakeWorker, raising=False)
+    monkeypatch.setattr(QDialog, "exec", lambda self: QDialog.Accepted)
+
+    widget._install_openbench()
+
+    assert len(FakeWorker.created) == 1
+    assert FakeWorker.created[0].command.endswith(
+        "git clone --progress git@github.com:zhongwangwei/OpenBench.git /remote/OpenBench 2>&1"
+    )
 
 
 class GuardedInstallSSH:
@@ -1264,6 +1303,7 @@ def test_conda_create_commands_expand_tilde_conda_exe(qapp, monkeypatch):
 
     assert ssh.commands
     assert ssh.commands[0].startswith('"$HOME"/miniconda3/bin/conda create')
+    assert "-c conda-forge" in ssh.commands[0]
     assert "'~/" not in ssh.commands[0]
 
 
@@ -1580,6 +1620,30 @@ def test_parse_ssh_config_splits_multiple_host_aliases(tmp_path, monkeypatch):
     assert {host["hostname"] for host in hosts} == {"login.example.org"}
     assert {host["user"] for host in hosts} == {"alice"}
     assert {host["port"] for host in hosts} == {"2222"}
+
+
+def test_remote_config_recovers_source_root_from_detected_src_package(qapp):
+    widget = RemoteConfigWidget()
+    widget._openbench_source_path = ""
+    widget.openbench_package_input.setText("/tera/OpenBench/src/openbench")
+
+    assert widget.get_config()["openbench_source_path"] == "/tera/OpenBench"
+
+
+def test_host_input_click_emits_with_existing_text(qapp):
+    from PySide6.QtCore import Qt
+    from PySide6.QtTest import QTest
+
+    from openbench.gui.widgets.remote_config import ClickableLineEdit
+
+    line_edit = ClickableLineEdit()
+    clicks = []
+    line_edit.clicked.connect(lambda: clicks.append(True))
+    line_edit.setText("alice@login.example.org")
+
+    QTest.mouseClick(line_edit, Qt.LeftButton)
+
+    assert clicks == [True]
 
 
 def test_primary_server_edit_invalidates_existing_connection(monkeypatch):


### PR DESCRIPTION
## Summary
- fix remote install/update setup: accept empty workspaces, use conda-forge, always show SSH config hosts, display remote output paths, require project confirmation, and recover verified source checkout paths for remote registry imports
- keep Grid/Station scans scoped to the selected branch and accelerate merged station metadata extraction
- preserve successful Simulation scans when progress dialogs close and validate file patterns with one directory listing per case
- render the full OpenBench logo on a white plate

## Local impact
- Grid/Station selection scope, merged-station parsing performance, Simulation validation batching, and mandatory project confirmation also apply locally
- switching back from Remote restores the local workspace output path
- SSH host selection, remote install, and remote registry bootstrap remain Remote-only

## Verification
- `python -m pytest -q`: 2191 passed, 5 skipped
- `python -m ruff check src tests`: passed
- remote Grid scan: 30 groups, 0 Station variants, no Daily group
- remote registry bootstrap: 120 references and 28 models loaded outside the checkout directory
