### PR TITLE
Restore Ruff formatting after remote workflow merge

### DIFF
--- a/src/openbench/data/registry/scanner.py
+++ b/src/openbench/data/registry/scanner.py
@@ -3374,7 +3374,9 @@ def _parse_merged_station_file(nc_file: Path, dataset_dir: Path) -> list:
             lon_var = _find_var(ds, LON_NAMES)
             lat_values = _station_coordinate_values(ds, lat_var, stn_dim)
             lon_values = _station_coordinate_values(ds, lon_var, stn_dim)
-            id_values = [(name, ds[name].values) for name in ("station_id", "site_id", "station_name", "site") if name in ds]
+            id_values = [
+                (name, ds[name].values) for name in ("station_id", "site_id", "station_name", "site") if name in ds
+            ]
             station_values = ds[stn_dim].values if stn_dim in ds.coords else None
 
             # Time range (case-insensitive dim name)

--- a/src/openbench/gui/widgets/remote_config.py
+++ b/src/openbench/gui/widgets/remote_config.py
@@ -2209,7 +2209,7 @@ if spec is not None:
                     ssh_manager,
                     (
                         f"first_entry=$(find {quoted_install_path} -mindepth 1 -maxdepth 1 -print -quit "
-                        f"2>/dev/null) && test -z \"$first_entry\" && test -w {quoted_install_path} && echo is_empty"
+                        f'2>/dev/null) && test -z "$first_entry" && test -w {quoted_install_path} && echo is_empty'
                     ),
                     timeout=10,
                 )


### PR DESCRIPTION
## Summary
- apply the exact Ruff formatting required by CI to the two files changed in #174

## Verification
- `python -m ruff check src tests`: passed
- `python -m ruff format --check src tests`: 381 files already formatted
- targeted tests: 209 passed
