### PR TITLE
Support legacy flat Grid reference layouts

### DIFF
--- a/src/openbench/data/registry/scanner.py
+++ b/src/openbench/data/registry/scanner.py
@@ -783,6 +783,25 @@ def _resolution_label(name: str) -> str | None:
     return None
 
 
+def _grid_resolution_roots(grid_dir: Path) -> list[tuple[str | None, Path]]:
+    """Return named resolution roots, or the legacy flat Grid root."""
+    roots = [
+        (res_name, res_dir)
+        for res_name in RESOLUTION_MAP
+        if (res_dir := _child_dir_case_insensitive(grid_dir, res_name)).is_dir()
+    ]
+    return roots or [(None, grid_dir)]
+
+
+def _resolution_from_grid_res(grid_res) -> str:
+    """Map native NetCDF spacing to the closest registry resolution bucket."""
+    try:
+        value = float(grid_res)
+    except (TypeError, ValueError):
+        return "MidRes"
+    return min(RESOLUTION_MAP, key=lambda name: abs(value - RESOLUTION_MAP[name]["typical_grid_res"]))
+
+
 def _profile_scan_specs():
     """Yield reference profiles that opt into scan-time layout handling."""
     for profile_name, profile in _load_reference_profiles().items():
@@ -1310,8 +1329,7 @@ def _reference_dataset_dirs(
     directories = []
     if selected_scope != "station":
         grid_dir = _child_dir_case_insensitive(ref_root, "Grid")
-        for res_name in ("LowRes", "MidRes", "HigRes"):
-            res_dir = _child_dir_case_insensitive(grid_dir, res_name)
+        for _res_name, res_dir in _grid_resolution_roots(grid_dir):
             for category_dir in _iter_dirs(res_dir):
                 for var_dir in _iter_dirs(category_dir):
                     if not _is_profile_consumed(var_dir, consumed_dirs):
@@ -1386,7 +1404,7 @@ def scan_reference_directory(
         max_workers=max_workers,
     )
 
-    # Scan grid data: Grid/{Res}/<Category>/<Variable>/<Dataset>/*.nc
+    # Scan grid data: Grid/[{Res}/]<Category>/<Variable>/<Dataset>/*.nc
     # Walk 3 levels of directories. Composite category is scanned too:
     #   - Composite/<Dataset>/{dataset,data}/*.nc → profile-friendly dataset root
     #   - Composite/<Variable>/<Dataset>/*.nc     → normal grid registration
@@ -1394,13 +1412,9 @@ def scan_reference_directory(
     # If not but its children do → dataset with sub-dirs (depth 4).
     grid_dir = _child_dir_case_insensitive(ref_root, "Grid")
     if selected_scope != "station" and grid_dir.exists():
-        for res_name in ["LowRes", "MidRes", "HigRes"]:
-            res_dir = _child_dir_case_insensitive(grid_dir, res_name)
-            if not res_dir.exists():
-                continue
-
+        for declared_res_name, res_dir in _grid_resolution_roots(grid_dir):
             if on_progress:
-                on_progress(f"Scanning Grid/{res_name}...")
+                on_progress(f"Scanning Grid/{declared_res_name or ''}...")
 
             for category_dir in _iter_dirs(res_dir):
                 cat_name = category_dir.name
@@ -1412,7 +1426,7 @@ def scan_reference_directory(
 
                     var_name = var_dir.name
                     if on_progress:
-                        on_progress(f"  {res_name}/{cat_name}/{var_name}")
+                        on_progress(f"  {declared_res_name or 'auto'}/{cat_name}/{var_name}")
 
                     if cat_name.casefold() == "composite":
                         nc_dir, nc_count, status = _find_grid_composite_nc_dir(var_dir)
@@ -1439,6 +1453,10 @@ def scan_reference_directory(
                         if status == "found":
                             dataset_name = var_name
                             tim_res = _detect_tim_res(nc_dir)
+                            inspection = _inspect_nc_file(nc_dir) if declared_res_name is None else {}
+                            res_name = declared_res_name or _resolution_from_grid_res(
+                                inspection.get("detected_grid_res")
+                            )
                             if dataset_name not in groups:
                                 groups[dataset_name] = DatasetGroup(base_name=dataset_name)
 
@@ -1456,6 +1474,8 @@ def scan_reference_directory(
                             if dataset_name not in scanned.variables:
                                 scanned.variables[dataset_name] = ""
                                 scanned.file_count += nc_count
+                                if inspection:
+                                    scanned.nc_inspections[dataset_name] = inspection
                             continue
 
                     for dataset_dir in _iter_dirs(var_dir):
@@ -1514,6 +1534,8 @@ def scan_reference_directory(
 
                         # Detect tim_res and record sub_dir from the actual NC location
                         tim_res = _detect_tim_res(nc_dir)
+                        inspection = _inspect_nc_file(nc_dir) if declared_res_name is None else {}
+                        res_name = declared_res_name or _resolution_from_grid_res(inspection.get("detected_grid_res"))
                         sub_dir = nc_dir.relative_to(res_dir).as_posix()
 
                         if dataset_name not in groups:
@@ -1533,6 +1555,8 @@ def scan_reference_directory(
                         if var_name not in scanned.variables:
                             scanned.variables[var_name] = sub_dir
                             scanned.file_count += nc_count
+                            if inspection:
+                                scanned.nc_inspections[var_name] = inspection
 
     # Scan station data: Station/<category>/<variable>/<dataset>/
     # Also handles Composite layout: Station/Composite/<dataset>/dataset/*.nc

--- a/tests/test_registry/test_scanner_registration.py
+++ b/tests/test_registry/test_scanner_registration.py
@@ -1321,6 +1321,30 @@ def test_scan_uses_child_dir_when_nc_files_one_level_deep(tmp_path: Path):
     assert variant.tim_res == "Day", f"Expected 'Day', got: {variant.tim_res!r}"
 
 
+def test_scan_supports_flat_grid_without_resolution_directories(tmp_path: Path):
+    """Legacy Grid/<category>/<variable>/<dataset> roots infer the bucket from NC spacing."""
+    import numpy as np
+    import xarray as xr
+
+    from openbench.data.registry.scanner import scan_reference_directory
+
+    grid_dir = tmp_path / "Reference" / "Grid"
+    nc_dir = grid_dir / "Water" / "Runoff" / "FlatDemo"
+    nc_dir.mkdir(parents=True)
+    xr.Dataset(
+        {"runoff": (["lat", "lon"], np.zeros((3, 3), dtype=np.float32))},
+        coords={"lat": [0.0, 0.25, 0.5], "lon": [0.0, 0.25, 0.5]},
+    ).to_netcdf(nc_dir / "runoff.nc")
+
+    groups = scan_reference_directory(grid_dir)
+
+    assert [group.base_name for group in groups] == ["FlatDemo"]
+    variant = groups[0].variants["MidRes"]
+    assert Path(variant.root_dir) == grid_dir
+    assert variant.variables == {"Runoff": "Water/Runoff/FlatDemo"}
+    assert variant.nc_inspections["Runoff"]["detected_grid_res"] == 0.25
+
+
 def test_scan_skips_dataset_with_multiple_nc_bearing_children(tmp_path: Path, caplog):
     """When dataset_dir/<multi>/*.nc has multiple NC-bearing children
     (composite/multi-variant), the scanner must skip with a warning rather


### PR DESCRIPTION
## Summary
- scan `Grid/<category>/<variable>/<dataset>` when no named resolution folders exist
- infer LowRes/MidRes/HigRes from native NetCDF spacing
- preserve precomputed inspection metadata and existing named-layout behavior

## Verification
- `ruff format --check ...`
- `ruff check ...`
- `pytest -q tests/test_registry/test_scanner_registration.py` (120 passed)
- `/Volumes/work/Reference`: 29 groups / 29 variants discovered