### PR TITLE
Restore Index of Agreement to Metrics

### DIFF
--- a/src/openbench/core/registry.py
+++ b/src/openbench/core/registry.py
@@ -16,7 +16,6 @@ _METRIC_EXCLUDE = {
     "rSD",
     "PBIAS_HF",
     "PBIAS_LF",
-    "index_agreement",
     # SMPI returns (estimate, lower, upper) and belongs to the dedicated
     # comparison workflow, not the single-DataArray evaluation contract.
     "smpi",
@@ -27,6 +26,8 @@ _METRIC_EXCLUDE = {
     "ubKGE",
     "kappa_coeff",
 }
+
+_SCORE_EXCLUDE = {"index_agreement"}
 
 
 def _public_callable_names(cls: type, *, exclude: Iterable[str] = ()) -> list[str]:
@@ -39,7 +40,7 @@ def _public_callable_names(cls: type, *, exclude: Iterable[str] = ()) -> list[st
 
 
 IMPLEMENTED_METRIC_NAMES = tuple(_public_callable_names(metrics, exclude=_METRIC_EXCLUDE))
-IMPLEMENTED_SCORE_NAMES = tuple(_public_callable_names(scores))
+IMPLEMENTED_SCORE_NAMES = tuple(_public_callable_names(scores, exclude=_SCORE_EXCLUDE))
 
 IMPLEMENTED_METRICS = set(IMPLEMENTED_METRIC_NAMES)
 IMPLEMENTED_SCORES = set(IMPLEMENTED_SCORE_NAMES)
@@ -73,10 +74,10 @@ METRIC_LABELS = {
     "MFM_varphi": "Model Fidelity Metric Variability Component (MFM-φ)",
     "MFM_eta": "Model Fidelity Metric Distribution Component (MFM-η)",
     "MFM": "Model Fidelity Metric (MFM)",
+    "index_agreement": "Index of Agreement (IOA)",
 }
 
 SCORE_LABELS = {
-    "index_agreement": "Index of Agreement (IOA)",
     "nBiasScore": "Normalized Bias Score (nBiasScore)",
     "nRMSEScore": "Normalized RMSE Score (nRMSEScore)",
     "nPhaseScore": "Normalized Phase Score (nPhaseScore)",
@@ -120,6 +121,7 @@ METRICS_ITEMS = {
             "KGESS",
             "ubNSE",
             "L",
+            "index_agreement",
         ],
         IMPLEMENTED_METRICS,
     ),

--- a/tests/test_gui_legacy_cleanup.py
+++ b/tests/test_gui_legacy_cleanup.py
@@ -60,7 +60,9 @@ def test_gui_metric_and_score_options_come_from_core_registry():
     assert gui_scores <= IMPLEMENTED_SCORES
     assert {"dr", "APFB", "br2", "cp"} <= gui_metrics
     assert {"smpi", "SMPI", "MSE", "LNSE", "The_Ideal_Point_score"} & (gui_metrics | gui_scores) == set()
-    assert {"index_agreement", "nSeasonalityScore"} <= gui_scores
+    assert "index_agreement" in METRICS_ITEMS["Efficiency"]
+    assert "index_agreement" not in gui_scores
+    assert "nSeasonalityScore" in gui_scores
 
 
 def test_metric_and_score_labels_use_full_name_with_abbreviation(qapp):


### PR DESCRIPTION
## Summary
- classify `index_agreement` as a metric again
- show it in the Metrics **Efficiency** group
- remove it from selectable Scores while retaining the compatibility method

## Verification
- `ruff format --check ...`
- `ruff check ...`
- `pytest -q tests/test_gui_legacy_cleanup.py tests/test_metric_score_core_regressions.py tests/test_core/test_scores.py` (51 passed)