### PR TITLE
Implement appendix metrics in uncertainty-aware evaluation

### DIFF
--- a/src/openbench/config/adapter.py
+++ b/src/openbench/config/adapter.py
@@ -331,7 +331,7 @@ class RunnerBindings:
             _STAT_DEFAULTS: dict[str, dict[str, Any]] = {
                 "Hellinger_Distance": {"nbins": 25},
                 "Functional_Response": {"nbins": 25},
-                "Mann_Kendall_Trend_Test": {"significance_level": 0.05},
+                "Mann_Kendall_Trend_Test": {"significance_level": 0.05, "max_sen_pairs": 2_000_000},
                 "ANOVA": {"n_jobs": -1, "analysis_type": "oneway"},
                 "Partial_Least_Squares_Regression": {
                     "max_components": 10,

--- a/src/openbench/core/appendix_methods.py
+++ b/src/openbench/core/appendix_methods.py
@@ -1,0 +1,318 @@
+"""Appendix methods whose inputs or outputs do not fit pairwise scalar metrics."""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from scipy import stats
+
+
+def uncertainty_factors(lower, upper, observation, dim="time"):
+    """Return uncertainty-band width (R-factor) and coverage (p-factor)."""
+    lower, upper, observation = xr.align(lower, upper, observation, join="inner")
+    valid = np.isfinite(lower) & np.isfinite(upper) & np.isfinite(observation)
+    valid &= upper >= lower
+    lower = lower.where(valid)
+    upper = upper.where(valid)
+    observation = observation.where(valid)
+    obs_std = observation.std(dim=dim)
+    r_factor = xr.where(obs_std > 0, (upper - lower).mean(dim=dim) / obs_std, np.nan)
+    p_factor = ((observation >= lower) & (observation <= upper)).where(valid).mean(dim=dim)
+    return xr.Dataset({"R_factor": r_factor, "p_factor": p_factor})
+
+
+def ideal_point_error(rmse, r_squared, pbias, dim="candidate"):
+    """Calculate IPE across a fixed candidate-model dimension."""
+    rmse, r_squared, pbias = xr.align(rmse, r_squared, pbias, join="inner")
+    rmse_max = rmse.max(dim=dim)
+    r2_span = 1.0 - r_squared.min(dim=dim)
+    pbias_max = np.abs(pbias).max(dim=dim)
+
+    total = xr.zeros_like(rmse, dtype=float)
+    count = xr.zeros_like(rmse, dtype=float)
+    for value, denominator in (
+        (rmse, rmse_max),
+        (1.0 - r_squared, r2_span),
+        (np.abs(pbias), pbias_max),
+    ):
+        usable = np.isfinite(denominator) & (denominator > 0)
+        total = total + xr.where(usable, (value / denominator) ** 2, 0.0)
+        count = count + xr.where(usable, 1.0, 0.0)
+    return xr.where(count > 0, 1.0 - np.sqrt(total / count), np.nan).rename("IPE")
+
+
+def contingency_scores(forecast, outcome, dim="time"):
+    """Return CSI, HSS, POD, and FAR for already-binarized events."""
+    forecast, outcome = _binary_inputs(forecast, outcome)
+    domain = _binary_domain(forecast, outcome, dim)
+    hit = ((forecast == 1) & (outcome == 1)).sum(dim=dim)
+    false_alarm = ((forecast == 1) & (outcome == 0)).sum(dim=dim)
+    miss = ((forecast == 0) & (outcome == 1)).sum(dim=dim)
+    correct_negative = ((forecast == 0) & (outcome == 0)).sum(dim=dim)
+    csi_denominator = hit + false_alarm + miss
+    pod_denominator = hit + miss
+    far_denominator = hit + false_alarm
+    hss_denominator = (hit + miss) * (miss + correct_negative) + (hit + false_alarm) * (false_alarm + correct_negative)
+    return xr.Dataset(
+        {
+            "CSI": hit / csi_denominator.where(csi_denominator > 0),
+            "HSS": 2.0 * (hit * correct_negative - false_alarm * miss) / hss_denominator.where(hss_denominator > 0),
+            "POD": hit / pod_denominator.where(pod_denominator > 0),
+            "FAR": false_alarm / far_denominator.where(far_denominator > 0),
+        }
+    ).where(domain)
+
+
+def taylor_skill_score(simulation, observation, reference_correlation, dim="time"):
+    """Return the appendix Taylor skill score for an explicit reference correlation."""
+    simulation, observation = xr.align(simulation, observation, join="inner")
+    valid = np.isfinite(simulation) & np.isfinite(observation)
+    simulation = simulation.where(valid)
+    observation = observation.where(valid)
+    correlation = xr.corr(simulation, observation, dim=dim)
+    obs_std = observation.std(dim=dim)
+    std_ratio = xr.where(obs_std > 0, simulation.std(dim=dim) / obs_std, np.nan)
+    denominator = (1.0 + reference_correlation) ** 4 * (std_ratio + 1.0 / std_ratio) ** 2
+    return xr.where(
+        (reference_correlation > -1) & (std_ratio > 0),
+        4.0 * (1.0 + correlation) ** 4 / denominator,
+        np.nan,
+    ).rename("TSS")
+
+
+def brier_score(probability, outcome, dim="time"):
+    """Return the Brier score for binary-event probabilities."""
+    probability, outcome = _probability_inputs(probability, outcome)
+    result = ((probability - outcome) ** 2).mean(dim=dim)
+    return result.where(_probability_domain(probability, outcome, dim)).rename("BS")
+
+
+def brier_decomposition(probability, outcome, dim="time", bins=10):
+    """Return Brier score, reliability, resolution, and uncertainty."""
+    probability, outcome = _probability_inputs(probability, outcome)
+    if bins < 1:
+        raise ValueError("bins must be at least 1")
+    probability, outcome = _single_chunk(probability, outcome, dim=dim)
+
+    def _components(p, y):
+        mask = np.isfinite(p) & np.isfinite(y)
+        p = p[mask]
+        y = y[mask]
+        if p.size == 0:
+            return np.full(5, np.nan)
+        if ((p < 0) | (p > 1)).any() or not np.isin(y, [0, 1]).all():
+            return np.full(5, np.nan)
+        group = np.minimum((p * bins).astype(int), bins - 1)
+        base_rate = y.mean()
+        reliability = 0.0
+        resolution = 0.0
+        for index in range(bins):
+            selected = group == index
+            if not selected.any():
+                continue
+            weight = selected.mean()
+            reliability += weight * (p[selected].mean() - y[selected].mean()) ** 2
+            resolution += weight * (y[selected].mean() - base_rate) ** 2
+        uncertainty = base_rate * (1.0 - base_rate)
+        score = np.mean((p - y) ** 2)
+        residual = score - (reliability - resolution + uncertainty)
+        return np.array([score, reliability, resolution, uncertainty, residual])
+
+    values = xr.apply_ufunc(
+        _components,
+        probability,
+        outcome,
+        input_core_dims=[[dim], [dim]],
+        output_core_dims=[["brier_component"]],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float],
+        dask_gufunc_kwargs={"output_sizes": {"brier_component": 5}},
+    )
+    return xr.Dataset(
+        {
+            "BS": values.isel(brier_component=0, drop=True),
+            "reliability": values.isel(brier_component=1, drop=True),
+            "resolution": values.isel(brier_component=2, drop=True),
+            "uncertainty": values.isel(brier_component=3, drop=True),
+            "binning_residual": values.isel(brier_component=4, drop=True),
+        }
+    )
+
+
+def crps_ensemble(ensemble, observation, member_dim="member", dim="time"):
+    """Return the empirical ensemble CRPS, averaged over *dim*."""
+    if member_dim not in ensemble.dims:
+        raise ValueError(f"ensemble must contain a {member_dim!r} dimension")
+    ensemble, observation = xr.align(ensemble, observation, join="inner", exclude={member_dim})
+    observation = observation.where(np.isfinite(observation))
+    ensemble = ensemble.where(np.isfinite(ensemble) & np.isfinite(observation))
+    first = np.abs(ensemble - observation).mean(dim=member_dim)
+    other_dim = f"{member_dim}_other"
+    pairwise = np.abs(ensemble - ensemble.rename({member_dim: other_dim})).mean(dim=[member_dim, other_dim])
+    result = first - 0.5 * pairwise
+    return result.mean(dim=dim).rename("CRPS") if dim is not None else result.rename("CRPS")
+
+
+def roc_auc(probability, outcome, dim="time"):
+    """Return ROC area under the curve for binary outcomes."""
+    probability, outcome = _probability_inputs(probability, outcome)
+    probability, outcome = _single_chunk(probability, outcome, dim=dim)
+
+    def _auc(p, y):
+        mask = np.isfinite(p) & np.isfinite(y)
+        p = p[mask]
+        y = y[mask]
+        if ((p < 0) | (p > 1)).any() or not np.isin(y, [0, 1]).all():
+            return np.nan
+        y = y.astype(int)
+        positive = y == 1
+        n_positive = positive.sum()
+        n_negative = y.size - n_positive
+        if n_positive == 0 or n_negative == 0:
+            return np.nan
+        ranks = stats.rankdata(p, method="average")
+        return (ranks[positive].sum() - n_positive * (n_positive + 1) / 2) / (n_positive * n_negative)
+
+    return xr.apply_ufunc(
+        _auc,
+        probability,
+        outcome,
+        input_core_dims=[[dim], [dim]],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float],
+    ).rename("AUC")
+
+
+def roc_curve(probability, outcome):
+    """Return an exact ROC curve for one-dimensional probability inputs."""
+    probability, outcome = _probability_inputs(probability, outcome)
+    if probability.ndim != 1 or outcome.ndim != 1:
+        raise ValueError("roc_curve accepts one-dimensional inputs; use roc_auc for gridded data")
+    p = np.asarray(probability)
+    y = np.asarray(outcome)
+    mask = np.isfinite(p) & np.isfinite(y)
+    p = p[mask]
+    y = y[mask]
+    if ((p < 0) | (p > 1)).any():
+        raise ValueError("probabilities must be between 0 and 1")
+    if not np.isin(y, [0, 1]).all():
+        raise ValueError("outcomes must be binary values 0 or 1")
+    y = y.astype(int)
+    positive = np.count_nonzero(y == 1)
+    negative = np.count_nonzero(y == 0)
+    if positive == 0 or negative == 0:
+        raise ValueError("roc_curve requires both positive and negative outcomes")
+    thresholds = np.r_[np.inf, np.unique(p)[::-1]]
+    tpr = np.array([np.count_nonzero((p >= threshold) & (y == 1)) / positive for threshold in thresholds])
+    fpr = np.array([np.count_nonzero((p >= threshold) & (y == 0)) / negative for threshold in thresholds])
+    return xr.Dataset(
+        {"TPR": ("threshold", tpr), "FPR": ("threshold", fpr)},
+        coords={"threshold": thresholds},
+    )
+
+
+def fit_gev(data, dim="time", min_samples=3):
+    """Fit a GEV distribution to block maxima along *dim*."""
+    data = _single_chunk(data, dim=dim)[0]
+
+    def _fit(values):
+        values = values[np.isfinite(values)]
+        if values.size < min_samples or np.ptp(values) == 0:
+            return np.full(3, np.nan)
+        shape_scipy, location, scale = stats.genextreme.fit(values)
+        return np.array([-shape_scipy, location, scale])
+
+    values = _fit_distribution(data, dim, _fit)
+    return xr.Dataset(
+        {
+            "shape": values.isel(distribution_parameter=0, drop=True),
+            "location": values.isel(distribution_parameter=1, drop=True),
+            "scale": values.isel(distribution_parameter=2, drop=True),
+        }
+    )
+
+
+def fit_gpd(data, threshold, dim="time", min_samples=3):
+    """Fit a GPD to threshold excesses along *dim*."""
+    if not isinstance(threshold, xr.DataArray):
+        threshold = xr.DataArray(threshold)
+    data, threshold = xr.align(data, threshold, join="inner", exclude={dim})
+    data = _single_chunk(data, dim=dim)[0]
+
+    def _fit(values, cutoff):
+        values = values[np.isfinite(values)]
+        excess = values[values > cutoff] - cutoff
+        if excess.size < min_samples or np.ptp(excess) == 0:
+            return np.full(2, np.nan)
+        shape, _, scale = stats.genpareto.fit(excess, floc=0.0)
+        return np.array([shape, scale])
+
+    values = xr.apply_ufunc(
+        _fit,
+        data,
+        threshold,
+        input_core_dims=[[dim], []],
+        output_core_dims=[["distribution_parameter"]],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float],
+        dask_gufunc_kwargs={"output_sizes": {"distribution_parameter": 2}},
+    )
+    return xr.Dataset(
+        {
+            "shape": values.isel(distribution_parameter=0, drop=True),
+            "scale": values.isel(distribution_parameter=1, drop=True),
+            "threshold": threshold,
+        }
+    )
+
+
+def _probability_inputs(probability, outcome):
+    probability, outcome = xr.align(probability, outcome, join="inner")
+    valid = np.isfinite(probability) & np.isfinite(outcome)
+    probability = probability.where(valid)
+    outcome = outcome.where(valid)
+    return probability, outcome
+
+
+def _binary_inputs(forecast, outcome):
+    forecast, outcome = xr.align(forecast, outcome, join="inner")
+    valid = np.isfinite(forecast) & np.isfinite(outcome)
+    forecast = forecast.where(valid)
+    outcome = outcome.where(valid)
+    return forecast, outcome
+
+
+def _probability_domain(probability, outcome, dim):
+    valid = probability.notnull() & outcome.notnull()
+    probability_ok = probability.isnull() | ((probability >= 0) & (probability <= 1))
+    outcome_ok = outcome.isnull() | outcome.isin([0, 1])
+    return valid.any(dim=dim) & probability_ok.all(dim=dim) & outcome_ok.all(dim=dim)
+
+
+def _binary_domain(forecast, outcome, dim):
+    valid = forecast.notnull() & outcome.notnull()
+    forecast_ok = forecast.isnull() | forecast.isin([0, 1])
+    outcome_ok = outcome.isnull() | outcome.isin([0, 1])
+    return valid.any(dim=dim) & forecast_ok.all(dim=dim) & outcome_ok.all(dim=dim)
+
+
+def _single_chunk(*arrays, dim):
+    return tuple(
+        array.chunk({dim: -1}) if array.chunks is not None and dim in array.dims else array for array in arrays
+    )
+
+
+def _fit_distribution(data, dim, function):
+    return xr.apply_ufunc(
+        function,
+        data,
+        input_core_dims=[[dim]],
+        output_core_dims=[["distribution_parameter"]],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[float],
+        dask_gufunc_kwargs={"output_sizes": {"distribution_parameter": 3}},
+    )

--- a/src/openbench/core/metrics.py
+++ b/src/openbench/core/metrics.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from collections.abc import Mapping
 
 import numpy as np
 import pandas as pd
@@ -118,6 +119,35 @@ class metrics:
         # Calculate RMSE
         rmse = np.sqrt(((s - o) ** 2).mean(dim="time"))
         return rmse
+
+    def MSE(self, s, o, dim="time"):
+        """Mean square error from the appendix."""
+        s, o = self._validate_inputs(s, o)
+        return ((s - o) ** 2).mean(dim=dim)
+
+    def NRMSE(self, s, o, dim="time"):
+        """RMSE normalized by ``abs(mean(o))`` (appendix NRMSE_mu)."""
+        s, o = self._validate_inputs(s, o)
+        o_mean = o.mean(dim=dim)
+        return xr.where(o_mean != 0, np.sqrt(((s - o) ** 2).mean(dim=dim)) / np.abs(o_mean), np.nan)
+
+    def RSR(self, s, o, dim="time"):
+        """RMSE-observations standard deviation ratio."""
+        s, o = self._validate_inputs(s, o)
+        denom = np.sqrt(((o - o.mean(dim=dim)) ** 2).sum(dim=dim))
+        numer = np.sqrt(((s - o) ** 2).sum(dim=dim))
+        return xr.where(denom != 0, numer / denom, np.nan)
+
+    def RSS(self, s, o, dim="time"):
+        """Residual sum of squares."""
+        s, o = self._validate_inputs(s, o)
+        return ((s - o) ** 2).sum(dim=dim)
+
+    def NMAE(self, s, o, dim="time"):
+        """Normalized mean absolute error using sum(abs(o)) denominator."""
+        s, o = self._validate_inputs(s, o)
+        denom = np.abs(o).sum(dim=dim)
+        return xr.where(denom != 0, np.abs(s - o).sum(dim=dim) / denom, np.nan)
 
     def ubRMSE(self, s, o):
         """
@@ -490,25 +520,252 @@ class metrics:
         safe_o_range = o_range.where((o_range != 0) & o_range.notnull())
         return s_range / safe_o_range - 1.0
 
-    def rSD(self, s, o):
-        # Ratio of standard deviations
-        # also see E. Towler et al.: Benchmarking model simulations of retrospective streamflow in the contiguous US
-        # Indicates if flow variability is being over- or underestimated; calculated from rSD in the hydroGOF R package
-        raise NotImplementedError("rSD metric is not yet implemented")
+    def _chunk_core_dim(self, *arrays, dim="time"):
+        out = []
+        for array in arrays:
+            if hasattr(array, "chunks") and array.chunks is not None and dim in array.dims:
+                array = array.chunk({dim: -1})
+            out.append(array)
+        return out
 
-    def PBIAS_HF(self, s, o):
-        # Percent bias of flows ≥ Q98 (Yilmaz et al., 2008)
-        # also see E. Towler et al.: Benchmarking model simulations of retrospective streamflow in the contiguous US
-        # Characterizes response to large precipitation events; calculated using flows ≥ the 98th percentile flow with pbias in the hydroGOF R package
-        raise NotImplementedError("PBIAS_HF metric is not yet implemented")
+    def _kge_components(self, s, o, dim="time"):
+        s, o = self._validate_inputs(s, o)
+        r = xr.corr(s, o, dim=dim)
+        s_mean = s.mean(dim=dim)
+        o_mean = o.mean(dim=dim)
+        s_std = s.std(dim=dim)
+        o_std = o.std(dim=dim)
+        alpha = xr.where(o_std != 0, s_std / o_std, np.nan)
+        beta = xr.where(o_mean != 0, s_mean / o_mean, np.nan)
+        cv_s = xr.where(s_mean != 0, s_std / s_mean, np.nan)
+        cv_o = xr.where(o_mean != 0, o_std / o_mean, np.nan)
+        gamma = xr.where(cv_o != 0, cv_s / cv_o, np.nan)
+        return r, alpha, beta, gamma
 
-    def PBIAS_LF(self, s, o):
-        # Percent bias of flows ≤ Q30(Yilmaz et al., 2008)
-        # also see E. Towler et al.: Benchmarking model simulations of retrospective streamflow in the contiguous US
-        # Characterizes baseflow; calculated following equations in
-        # Yilmaz et al. (2008) using logged flows ≤ the 30th percentile (zeros are set to the USGS observational threshold
-        # of 0.01 ft3 s−1 (0.000283 m3 s−1))
-        raise NotImplementedError("PBIAS_LF metric is not yet implemented")
+    def rSD(self, s, o, dim="time"):
+        """Ratio of simulated to observed standard deviation."""
+        s, o = self._validate_inputs(s, o)
+        o_std = o.std(dim=dim)
+        return xr.where(o_std != 0, s.std(dim=dim) / o_std, np.nan)
+
+    def PBIAS_HF(self, s, o, quantile=0.98, dim="time"):
+        """Percent bias over observed high-flow samples; default threshold is Q98."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+        threshold = o.quantile(quantile, dim=dim, skipna=True)
+        high = o >= threshold
+        denom = o.where(high).sum(dim=dim)
+        return xr.where(denom != 0, 100.0 * (s - o).where(high).sum(dim=dim) / denom, np.nan)
+
+    def PBIAS_LF(self, s, o, quantile=0.30, dim="time"):
+        """Percent bias over observed low-flow samples; default threshold is Q30."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+        threshold = o.quantile(quantile, dim=dim, skipna=True)
+        low = o <= threshold
+        selected = o.where(low)
+        denom = selected.sum(dim=dim)
+        strictly_positive = ((selected > 0) | selected.isnull()).all(dim=dim) & low.any(dim=dim)
+        return xr.where(
+            strictly_positive & (denom != 0),
+            100.0 * (s - o).where(low).sum(dim=dim) / denom,
+            np.nan,
+        )
+
+    def pbiasfdc(self, s, o, high_quantile=0.66, low_quantile=0.33, dim="time"):
+        """Percent bias in the slope of the midsegment of the flow-duration curve."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+        qs_h = s.quantile(high_quantile, dim=dim, skipna=True)
+        qs_l = s.quantile(low_quantile, dim=dim, skipna=True)
+        qo_h = o.quantile(high_quantile, dim=dim, skipna=True)
+        qo_l = o.quantile(low_quantile, dim=dim, skipna=True)
+        valid = (qs_h > 0) & (qs_l > 0) & (qo_h > 0) & (qo_l > 0)
+        sim_slope = np.log(qs_h) - np.log(qs_l)
+        obs_slope = np.log(qo_h) - np.log(qo_l)
+        return xr.where(valid & (obs_slope != 0), 100.0 * (sim_slope - obs_slope) / obs_slope, np.nan)
+
+    def rSpearman(self, s, o, dim="time"):
+        """Spearman rank correlation using average ranks for ties."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+
+        def _spearman_1d(sim, obs):
+            mask = np.isfinite(sim) & np.isfinite(obs)
+            if mask.sum() < 2:
+                return np.nan
+            sim_rank = pd.Series(sim[mask]).rank(method="average").to_numpy()
+            obs_rank = pd.Series(obs[mask]).rank(method="average").to_numpy()
+            if np.std(sim_rank) == 0 or np.std(obs_rank) == 0:
+                return np.nan
+            return float(np.corrcoef(sim_rank, obs_rank)[0, 1])
+
+        return xr.apply_ufunc(
+            _spearman_1d,
+            s,
+            o,
+            input_core_dims=[[dim], [dim]],
+            vectorize=True,
+            dask="parallelized",
+            output_dtypes=[float],
+        )
+
+    def MIA(self, s, o, dim="time"):
+        """Modified index of agreement."""
+        s, o = self._validate_inputs(s, o)
+        o_mean = o.mean(dim=dim)
+        denom = (np.abs(s - o_mean) + np.abs(o - o_mean)).sum(dim=dim)
+        return xr.where(denom != 0, 1 - np.abs(s - o).sum(dim=dim) / denom, np.nan)
+
+    def RIA(self, s, o, dim="time"):
+        """Relative index of agreement for positive observations."""
+        s, o = self._validate_inputs(s, o)
+        valid_pair = np.isfinite(s) & np.isfinite(o)
+        o_mean = o.mean(dim=dim)
+        positive = ((o > 0) | ~valid_pair).all(dim=dim) & (valid_pair.sum(dim=dim) > 0) & (o_mean > 0)
+        numer = (np.abs(s - o) / o.where(o > 0)).sum(dim=dim)
+        denom = ((np.abs(s - o_mean) + np.abs(o - o_mean)) / o_mean).sum(dim=dim)
+        return xr.where(positive & (denom != 0), 1 - numer / denom, np.nan)
+
+    def valindex(self, s, o, epsilon=0.0, dim="time"):
+        """Fraction of valid pairs with absolute error <= epsilon (default exact match)."""
+        s, o = self._validate_inputs(s, o)
+        n = np.isfinite(s).sum(dim=dim)
+        hits = (np.abs(s - o) <= epsilon).where(np.isfinite(s)).sum(dim=dim)
+        return xr.where(n != 0, hits / n, np.nan)
+
+    def VE(self, s, o, dim="time"):
+        """Volumetric efficiency for non-negative observed volumes/flows."""
+        s, o = self._validate_inputs(s, o)
+        valid_pair = np.isfinite(s) & np.isfinite(o)
+        denom = o.sum(dim=dim)
+        nonnegative = ((o >= 0) | ~valid_pair).all(dim=dim) & (valid_pair.sum(dim=dim) > 0)
+        return xr.where(nonnegative & (denom > 0), 1 - np.abs(s - o).sum(dim=dim) / denom, np.nan)
+
+    def LNSE(self, s, o, dim="time"):
+        """Log Nash-Sutcliffe efficiency for strictly positive pairs."""
+        s, o = self._validate_inputs(s, o)
+        valid_pair = np.isfinite(s) & np.isfinite(o)
+        positive_pair = (s > 0) & (o > 0)
+        valid_domain = (positive_pair | ~valid_pair).all(dim=dim) & (valid_pair.sum(dim=dim) > 0)
+        log_s = np.log(s.where(positive_pair))
+        log_o = np.log(o.where(positive_pair))
+        denom = ((log_o - log_o.mean(dim=dim)) ** 2).sum(dim=dim)
+        numer = ((log_s - log_o) ** 2).sum(dim=dim)
+        return xr.where(valid_domain & (denom != 0), 1 - numer / denom, np.nan)
+
+    def mNSE(self, s, o, dim="time"):
+        """Modified NSE using absolute errors and absolute observed deviations."""
+        s, o = self._validate_inputs(s, o)
+        denom = np.abs(o - o.mean(dim=dim)).sum(dim=dim)
+        return xr.where(denom != 0, 1 - np.abs(s - o).sum(dim=dim) / denom, np.nan)
+
+    def rNSE(self, s, o, dim="time"):
+        """Relative NSE; only defined for non-zero observations and observed mean."""
+        s, o = self._validate_inputs(s, o)
+        valid_pair = np.isfinite(s) & np.isfinite(o)
+        o_mean = o.mean(dim=dim)
+        nonzero = ((o != 0) | ~valid_pair).all(dim=dim) & (valid_pair.sum(dim=dim) > 0) & (o_mean != 0)
+        numer = (((s - o) / o.where(o != 0)) ** 2).sum(dim=dim)
+        denom = (((o - o_mean) / o_mean) ** 2).sum(dim=dim)
+        return xr.where(nonzero & (denom != 0), 1 - numer / denom, np.nan)
+
+    def wNSE(self, s, o, weights, dim="time"):
+        """Weighted NSE using explicit non-negative sample weights."""
+        s, o = self._validate_inputs(s, o)
+        s, o, weights = xr.align(s, o, weights, join="inner")
+        valid_weight_domain = ((weights >= 0) | ~np.isfinite(weights)).all(dim=dim)
+        weights = weights.where(np.isfinite(s) & np.isfinite(o) & np.isfinite(weights) & (weights >= 0))
+        wsum = weights.sum(dim=dim)
+        o_mean = (weights * o).sum(dim=dim) / wsum.where(wsum != 0)
+        denom = (weights * (o - o_mean) ** 2).sum(dim=dim)
+        numer = (weights * (s - o) ** 2).sum(dim=dim)
+        return xr.where(valid_weight_domain & (wsum > 0) & (denom != 0), 1 - numer / denom, np.nan)
+
+    def wsNSE(self, s, o, season_weights, seasons=None, dim="time"):
+        """Weighted seasonal NSE using explicit season weights and labels."""
+        s, o = self._validate_inputs(s, o)
+        if not isinstance(season_weights, Mapping):
+            raise TypeError("wsNSE season_weights must map season labels to weights")
+        if seasons is None:
+            if dim not in o.coords:
+                raise ValueError("wsNSE requires explicit seasons or a datetime coordinate")
+            try:
+                seasons = o[dim].dt.season
+            except (AttributeError, TypeError) as exc:
+                raise ValueError("wsNSE requires explicit seasons for non-datetime coordinates") from exc
+        s, o, seasons = xr.align(s, o, seasons, join="inner")
+        seasons = seasons.rename(seasons.name or "season")
+        labels = np.asarray(seasons)
+        missing = set(np.unique(labels)) - set(season_weights)
+        if missing:
+            raise ValueError(f"Missing wsNSE weights for seasons: {sorted(missing)}")
+        if any(weight < 0 for weight in season_weights.values()):
+            raise ValueError("wsNSE season weights must be non-negative")
+        weights = xr.DataArray(
+            [season_weights[label.item() if hasattr(label, "item") else label] for label in labels],
+            coords={dim: o[dim]},
+            dims=[dim],
+        )
+        season_mean = o.groupby(seasons).mean(dim=dim)
+        centered = o.groupby(seasons) - season_mean
+        denom = (weights * centered**2).sum(dim=dim)
+        numer = (weights * (s - o) ** 2).sum(dim=dim)
+        return xr.where((weights.sum(dim=dim) > 0) & (denom != 0), 1 - numer / denom, np.nan)
+
+    def mKGE(self, s, o, dim="time"):
+        """Modified KGE using coefficient-of-variation ratio gamma."""
+        r, _alpha, beta, gamma = self._kge_components(s, o, dim=dim)
+        return 1 - ((r - 1) ** 2 + (beta - 1) ** 2 + (gamma - 1) ** 2) ** 0.5
+
+    def sKGE(self, s, o, dim="time"):
+        """Split KGE components as [r, beta, gamma]."""
+        r, _alpha, beta, gamma = self._kge_components(s, o, dim=dim)
+        return xr.concat([r, beta, gamma], dim=xr.IndexVariable("component", ["r", "beta", "gamma"]))
+
+    def KGEkm(self, s, o, dim="time"):
+        """Known-moments KGE variant with alpha, beta, and CV-ratio gamma."""
+        r, alpha, beta, gamma = self._kge_components(s, o, dim=dim)
+        return 1 - ((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2 + (gamma - 1) ** 2) ** 0.5
+
+    def KGElf(self, s, o, quantile=0.30, dim="time"):
+        """Low-flow KGE over samples where observed values are <= Q30 by default."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+        threshold = o.quantile(quantile, dim=dim, skipna=True)
+        low = o <= threshold
+        r, alpha, beta, _gamma = self._kge_components(s.where(low), o.where(low), dim=dim)
+        return 1 - ((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2) ** 0.5
+
+    def KGEnp(self, s, o, dim="time"):
+        """Pool et al. non-parametric KGE using normalized flow-duration curves."""
+        s, o = self._validate_inputs(s, o)
+        s, o = self._chunk_core_dim(s, o, dim=dim)
+        rho = self.rSpearman(s, o, dim=dim)
+
+        def _fdc_variability(sim, obs):
+            mask = np.isfinite(sim) & np.isfinite(obs)
+            sim = sim[mask]
+            obs = obs[mask]
+            if sim.size < 2 or sim.mean() == 0 or obs.mean() == 0:
+                return np.nan
+            n = sim.size
+            sim_fdc = np.sort(sim)[::-1] / (n * sim.mean())
+            obs_fdc = np.sort(obs)[::-1] / (n * obs.mean())
+            return 1.0 - 0.5 * np.abs(sim_fdc - obs_fdc).sum()
+
+        alpha_np = xr.apply_ufunc(
+            _fdc_variability,
+            s,
+            o,
+            input_core_dims=[[dim], [dim]],
+            vectorize=True,
+            dask="parallelized",
+            output_dtypes=[float],
+        )
+        o_mean = o.mean(dim=dim)
+        beta = xr.where(o_mean != 0, s.mean(dim=dim) / o_mean, np.nan)
+        return 1 - ((rho - 1) ** 2 + (alpha_np - 1) ** 2 + (beta - 1) ** 2) ** 0.5
 
     def APFB(
         self,

--- a/src/openbench/core/registry.py
+++ b/src/openbench/core/registry.py
@@ -16,7 +16,6 @@ _METRIC_EXCLUDE = {
     "rSD",
     "PBIAS_HF",
     "PBIAS_LF",
-    "index_agreement",
     # SMPI returns (estimate, lower, upper) and belongs to the dedicated
     # comparison workflow, not the single-DataArray evaluation contract.
     "smpi",
@@ -27,6 +26,8 @@ _METRIC_EXCLUDE = {
     "ubKGE",
     "kappa_coeff",
 }
+
+_SCORE_EXCLUDE = {"index_agreement"}
 
 
 def _public_callable_names(cls: type, *, exclude: Iterable[str] = ()) -> list[str]:
@@ -39,7 +40,7 @@ def _public_callable_names(cls: type, *, exclude: Iterable[str] = ()) -> list[st
 
 
 IMPLEMENTED_METRIC_NAMES = tuple(_public_callable_names(metrics, exclude=_METRIC_EXCLUDE))
-IMPLEMENTED_SCORE_NAMES = tuple(_public_callable_names(scores))
+IMPLEMENTED_SCORE_NAMES = tuple(_public_callable_names(scores, exclude=_SCORE_EXCLUDE))
 
 IMPLEMENTED_METRICS = set(IMPLEMENTED_METRIC_NAMES)
 IMPLEMENTED_SCORES = set(IMPLEMENTED_SCORE_NAMES)
@@ -73,10 +74,10 @@ METRIC_LABELS = {
     "MFM_varphi": "Model Fidelity Metric Variability Component (MFM-φ)",
     "MFM_eta": "Model Fidelity Metric Distribution Component (MFM-η)",
     "MFM": "Model Fidelity Metric (MFM)",
+    "index_agreement": "Index of Agreement (IOA)",
 }
 
 SCORE_LABELS = {
-    "index_agreement": "Index of Agreement (IOA)",
     "nBiasScore": "Normalized Bias Score (nBiasScore)",
     "nRMSEScore": "Normalized RMSE Score (nRMSEScore)",
     "nPhaseScore": "Normalized Phase Score (nPhaseScore)",
@@ -120,6 +121,7 @@ METRICS_ITEMS = {
             "KGESS",
             "ubNSE",
             "L",
+            "index_agreement",
         ],
         IMPLEMENTED_METRICS,
     ),

--- a/src/openbench/core/registry.py
+++ b/src/openbench/core/registry.py
@@ -13,9 +13,17 @@ from openbench.core.scores import scores
 # stale hard-coded copy.
 _METRIC_EXCLUDE = {
     "rm_mean",
-    "rSD",
-    "PBIAS_HF",
-    "PBIAS_LF",
+    # These methods are implemented for programmatic use, but the current
+    # evaluation config cannot provide their extra inputs or scalarize their
+    # vector output.
+    "valindex",
+    "wNSE",
+    "wsNSE",
+    "sKGE",
+    # The appendix names quantile-based KGEnp components without fixing their
+    # formulas. Keep the canonical Pool et al. implementation importable, but
+    # do not present one scientific convention as the guide's only definition.
+    "KGEnp",
     # SMPI returns (estimate, lower, upper) and belongs to the dedicated
     # comparison workflow, not the single-DataArray evaluation contract.
     "smpi",
@@ -48,7 +56,12 @@ IMPLEMENTED_SCORES = set(IMPLEMENTED_SCORE_NAMES)
 METRIC_LABELS = {
     "percent_bias": "Percent Bias (PBIAS)",
     "absolute_percent_bias": "Absolute Percent Bias (APB)",
+    "MSE": "Mean Squared Error (MSE)",
     "RMSE": "Root Mean Squared Error (RMSE)",
+    "NRMSE": "Normalized Root Mean Squared Error (NRMSE)",
+    "RSR": "RMSE–Observation Standard Deviation Ratio (RSR)",
+    "RSS": "Residual Sum of Squares (RSS)",
+    "NMAE": "Normalized Mean Absolute Error (NMAE)",
     "ubRMSE": "Unbiased Root Mean Squared Error (ubRMSE)",
     "CRMSD": "Centered Root Mean Square Difference (CRMSD)",
     "mean_absolute_error": "Mean Absolute Error (MAE)",
@@ -60,6 +73,7 @@ METRIC_LABELS = {
     "KGE": "Kling–Gupta Efficiency (KGE)",
     "KGESS": "Kling–Gupta Efficiency Skill Score (KGESS)",
     "rv": "Relative Variability (RV)",
+    "rSD": "Ratio of Standard Deviations (rSD)",
     "ubNSE": "Unbiased Nash–Sutcliffe Efficiency (ubNSE)",
     "ubcorrelation": "Unbiased Correlation Coefficient (ubr)",
     "ubcorrelation_R2": "Unbiased Coefficient of Determination (ubR²)",
@@ -67,9 +81,22 @@ METRIC_LABELS = {
     "pc_min": "Relative Minimum Deviation (PCmin)",
     "pc_ampli": "Relative Amplitude Deviation (PCamp)",
     "APFB": "Annual Peak Flow Bias (APFB)",
+    "PBIAS_HF": "Percent Bias of High Flows (PBIAS-HF)",
+    "PBIAS_LF": "Percent Bias of Low Flows (PBIAS-LF)",
+    "pbiasfdc": "Flow Duration Curve Midsegment Slope Bias (PBIAS-FDC)",
     "br2": "Slope-adjusted Coefficient of Determination (br²)",
     "cp": "Coefficient of Persistence (CP)",
+    "rSpearman": "Spearman Rank Correlation Coefficient (rSpearman)",
+    "MIA": "Modified Index of Agreement (MIA)",
+    "RIA": "Relative Index of Agreement (RIA)",
     "dr": "Refined Index of Agreement (dr)",
+    "VE": "Volumetric Efficiency (VE)",
+    "LNSE": "Log Nash–Sutcliffe Efficiency (LNSE)",
+    "mNSE": "Modified Nash–Sutcliffe Efficiency (mNSE)",
+    "rNSE": "Relative Nash–Sutcliffe Efficiency (rNSE)",
+    "mKGE": "Modified Kling–Gupta Efficiency (mKGE)",
+    "KGEkm": "Known-moments Kling–Gupta Efficiency (KGEkm)",
+    "KGElf": "Low-flow Kling–Gupta Efficiency (KGElf)",
     "MFM_omega": "Model Fidelity Metric Phase Component (MFM-ω)",
     "MFM_varphi": "Model Fidelity Metric Variability Component (MFM-φ)",
     "MFM_eta": "Model Fidelity Metric Distribution Component (MFM-η)",
@@ -99,7 +126,12 @@ METRICS_ITEMS = {
             "percent_bias",
             "absolute_percent_bias",
             "mean_absolute_error",
+            "MSE",
             "RMSE",
+            "NRMSE",
+            "RSR",
+            "RSS",
+            "NMAE",
             "ubRMSE",
             "CRMSD",
         ],
@@ -111,21 +143,32 @@ METRICS_ITEMS = {
             "correlation_R2",
             "ubcorrelation",
             "ubcorrelation_R2",
+            "rSpearman",
         ],
         IMPLEMENTED_METRICS,
     ),
     "Efficiency": _filtered(
         [
             "NSE",
+            "LNSE",
+            "mNSE",
+            "rNSE",
             "KGE",
             "KGESS",
+            "mKGE",
+            "KGEkm",
+            "KGElf",
             "ubNSE",
             "L",
-            "index_agreement",
         ],
         IMPLEMENTED_METRICS,
     ),
-    "Hydrology": _filtered(["br2", "cp", "dr", "APFB"], IMPLEMENTED_METRICS),
+    "Agreement": _filtered(["index_agreement", "MIA", "RIA", "dr"], IMPLEMENTED_METRICS),
+    "Hydrology": _filtered(
+        ["PBIAS_HF", "PBIAS_LF", "pbiasfdc", "APFB", "VE", "br2", "cp"],
+        IMPLEMENTED_METRICS,
+    ),
+    "Variability": _filtered(["rv", "rSD", "pc_max", "pc_min", "pc_ampli"], IMPLEMENTED_METRICS),
     "Other": [],
 }
 

--- a/src/openbench/core/statistics/stat_mann_kendall_trend_test.py
+++ b/src/openbench/core/statistics/stat_mann_kendall_trend_test.py
@@ -18,9 +18,13 @@ def stat_mann_kendall_trend_test(self, data):
         xarray.Dataset: Dataset containing trend test results for each variable and grid point.
     """
     try:
-        significance_level = self.stats_nml["Mann_Kendall_Trend_Test"]["significance_level"]
+        method_config = self.stats_nml["Mann_Kendall_Trend_Test"]
     except (AttributeError, KeyError, TypeError):
-        significance_level = self.compare_nml["Mann_Kendall_Trend_Test"]["significance_level"]
+        method_config = self.compare_nml["Mann_Kendall_Trend_Test"]
+    significance_level = method_config["significance_level"]
+    max_sen_pairs = int(method_config.get("max_sen_pairs", 2_000_000))
+    if max_sen_pairs < 0:
+        raise ValueError("Mann_Kendall_Trend_Test max_sen_pairs must be non-negative")
 
     def _apply_mann_kendall(da, significance_level):
         """
@@ -28,31 +32,70 @@ def stat_mann_kendall_trend_test(self, data):
         """
 
         def mk_test(x):
-            if len(x) < 4 or np.all(np.isnan(x)):
-                return np.array([np.nan, np.nan, np.nan, np.nan])
+            if len(x) < 4 or not np.isfinite(x).any():
+                return np.full(7, np.nan)
 
-            # Remove NaN values
-            x = x[~np.isnan(x)]
+            valid = np.isfinite(x)
+            positions = np.flatnonzero(valid)
+            x = x[valid]
+            n = len(x)
+            if n < 4:
+                return np.full(7, np.nan)
 
-            if len(x) < 4:
-                return np.array([np.nan, np.nan, np.nan, np.nan])
+            _, ranks = np.unique(x, return_inverse=True)
+            tree = np.zeros(ranks.max() + 2, dtype=np.int64)
 
-            # Let SciPy select exact inference only when it is valid. In
-            # particular, tied values cannot use method="exact" and require
-            # the tie-corrected asymptotic path.
-            tau, p_value = stats.kendalltau(np.arange(len(x)), x, method="auto")
+            def _rank_count(rank):
+                count = 0
+                while rank > 0:
+                    count += tree[rank]
+                    rank -= rank & -rank
+                return count
 
-            # Determine trend. Propagate NaN from `p_value` (e.g. exact-method
-            # output for a degenerate constant series) into `significance`
-            # rather than letting `NaN < α` silently fold to False (= "not
-            # significant"), which conflates "no trend" with "undefined".
-            trend = np.sign(tau)
-            if np.isnan(p_value):
-                significance = np.nan
+            s_stat = 0
+            for seen, zero_based_rank in enumerate(ranks):
+                rank = int(zero_based_rank) + 1
+                less = _rank_count(rank - 1)
+                less_or_equal = _rank_count(rank)
+                s_stat += less - (seen - less_or_equal)
+                update = rank
+                while update < tree.size:
+                    tree[update] += 1
+                    update += update & -update
+            s_stat = float(s_stat)
+
+            _, tie_counts = np.unique(x, return_counts=True)
+            tie_term = np.sum(tie_counts * (tie_counts - 1) * (2 * tie_counts + 5))
+            var_s = (n * (n - 1) * (2 * n + 5) - tie_term) / 18.0
+            if var_s > 0:
+                if s_stat > 0:
+                    z_score = (s_stat - 1) / np.sqrt(var_s)
+                elif s_stat < 0:
+                    z_score = (s_stat + 1) / np.sqrt(var_s)
+                else:
+                    z_score = 0.0
+                p_value = float(2 * stats.norm.sf(abs(z_score)))
             else:
-                significance = float(p_value < significance_level)
+                z_score = np.nan
+                p_value = np.nan
 
-            return np.array([trend, significance, p_value, tau])
+            pair_count = n * (n - 1) // 2
+            if pair_count <= max_sen_pairs:
+                pair_slopes = np.concatenate(
+                    [
+                        (x[index + 1 :] - x[index]) / (positions[index + 1 :] - positions[index])
+                        for index in range(n - 1)
+                    ]
+                )
+                sen_slope = float(np.median(pair_slopes))
+            else:
+                sen_slope = np.nan
+            tau, _ = stats.kendalltau(positions, x, method="auto")
+
+            trend = np.sign(s_stat)
+            significance = np.nan if np.isnan(p_value) else float(p_value < significance_level)
+
+            return np.array([trend, significance, p_value, tau, s_stat, z_score, sen_slope])
 
         try:
             # Rechunk time dimension to single chunk for apply_ufunc with dask
@@ -68,7 +111,7 @@ def stat_mann_kendall_trend_test(self, data):
                 vectorize=True,
                 dask="parallelized",
                 output_dtypes=[float],
-                dask_gufunc_kwargs={"output_sizes": {"mk_params": 4}},
+                dask_gufunc_kwargs={"output_sizes": {"mk_params": 7}},
             )
 
             # Create separate variables for each component
@@ -76,9 +119,22 @@ def stat_mann_kendall_trend_test(self, data):
             significance = result.isel(mk_params=1)
             p_value = result.isel(mk_params=2)
             tau = result.isel(mk_params=3)
+            s_statistic = result.isel(mk_params=4)
+            z_score = result.isel(mk_params=5)
+            sen_slope = result.isel(mk_params=6)
 
             # Create a new Dataset with separate variables
-            ds = xr.Dataset({"trend": trend, "significance": significance, "p_value": p_value, "tau": tau})
+            ds = xr.Dataset(
+                {
+                    "trend": trend,
+                    "significance": significance,
+                    "p_value": p_value,
+                    "tau": tau,
+                    "s_statistic": s_statistic,
+                    "z_score": z_score,
+                    "sen_slope": sen_slope,
+                }
+            )
 
             # Add attributes
             ds.trend.attrs["long_name"] = "Mann-Kendall trend"
@@ -91,9 +147,16 @@ def stat_mann_kendall_trend_test(self, data):
             ds.p_value.attrs["description"] = "p-value of the Mann-Kendall trend test"
             ds.tau.attrs["long_name"] = "Kendall's tau statistic"
             ds.tau.attrs["description"] = "Kendall's tau correlation coefficient"
+            ds.s_statistic.attrs["long_name"] = "Mann-Kendall S statistic"
+            ds.s_statistic.attrs["description"] = "Sum of signs over all forward time pairs"
+            ds.z_score.attrs["long_name"] = "Mann-Kendall Z statistic"
+            ds.z_score.attrs["description"] = "Tie-corrected normal Z statistic for the Mann-Kendall S statistic"
+            ds.sen_slope.attrs["long_name"] = "Sen's slope"
+            ds.sen_slope.attrs["description"] = "Median of all pairwise slopes per time step"
 
-            ds.attrs["statistical_test"] = "Mann-Kendall trend test (using Kendall's tau)"
+            ds.attrs["statistical_test"] = "Mann-Kendall trend test with Sen slope"
             ds.attrs["significance_level"] = significance_level
+            ds.attrs["sen_slope_max_exact_pairs"] = max_sen_pairs
 
             # Clean up intermediate result
             del result

--- a/src/openbench/data/climatology.py
+++ b/src/openbench/data/climatology.py
@@ -115,7 +115,18 @@ class ClimatologyProcessor:
             "KGE",  # Kling-Gupta Efficiency
             "KGESS",  # KGE with multiple components
             "mKGE",  # Modified KGE
-            "nKGE",  # Normalized KGE
+            "KGEkm",  # Known-moments KGE
+            "KGElf",  # Low-flow KGE
+            "KGEnp",  # Non-parametric KGE
+            "rSD",  # standard-deviation ratio
+            "RSR",  # RMSE / observed standard deviation
+            "rSpearman",  # rank correlation requires multiple pairs
+            "pbiasfdc",  # flow-duration slope requires a distribution
+            "LNSE",  # log NSE needs observed variance
+            "mNSE",  # modified NSE needs observed absolute deviation
+            "rNSE",  # relative NSE needs observed relative variance
+            "MIA",  # agreement around the observed mean
+            "RIA",  # relative agreement around the observed mean
             "pc_ampli",  # Phase and amplitude require temporal variation
             "CRMSD",  # Centered RMSD uses std(dim='time') and correlation
             "rv",  # Relative variability requires std(dim='time')

--- a/src/openbench/util/netcdf.py
+++ b/src/openbench/util/netcdf.py
@@ -39,8 +39,8 @@ def _distributed_client_active() -> bool:
 
 
 def _needs_local_dask_netcdf_write(data: Any) -> bool:
-    """Keep distributed workers out of the HDF5 store phase."""
-    if not _distributed_client_active() or not isinstance(data, (xr.Dataset, xr.DataArray)):
+    """Keep Dask worker threads out of the HDF5 store phase."""
+    if not isinstance(data, (xr.Dataset, xr.DataArray)):
         return False
 
     try:
@@ -237,7 +237,7 @@ def write_netcdf_atomic(
                         "Cannot write xarray data backed by distributed Futures; "
                         "pass the unpersisted lazy Dataset or DataArray instead."
                     )
-                logger.info("Writing lazy xarray data with local single-threaded NetCDF scheduler")
+                logger.info("Writing lazy xarray data with a single-threaded NetCDF scheduler")
                 # ponytail: serial HDF5 store; use Zarr when parallel output bandwidth becomes the bottleneck.
                 data.to_netcdf(tmp_path, compute=False, **nc_kwargs).compute(
                     scheduler="threads",

--- a/src/openbench/visualization/Fig_toolbox.py
+++ b/src/openbench/visualization/Fig_toolbox.py
@@ -21,7 +21,10 @@ def process_unit(ref_unit, sim_unit, metric):
         "MSE": "Square of input data unit",  # Mean Squared Error
         "ubRMSE": "Same as input data",  # Unbiased Root Mean Squared Error
         "CRMSD": "Same as input data",  # Centered Root Mean Square Difference
-        "nrmse": "Unitless",  # Normalized Root Mean Square Error
+        "NRMSE": "Unitless",  # Normalized Root Mean Square Error
+        "NMAE": "Unitless",  # Normalized Mean Absolute Error
+        "RSR": "Unitless",  # RMSE-observation standard deviation ratio
+        "RSS": "Square of input data unit",  # Residual sum of squares
         "L": "Unitless",  # Likelihood
         "correlation": "Unitless",  # correlation coefficient
         "correlation_R2": "Unitless",  # correlation coefficient R2
@@ -49,16 +52,19 @@ def process_unit(ref_unit, sim_unit, metric):
         "KGEnp": "Unitless",  # Non-parametric version of the Kling-Gupta Efficiency
         "md": "Unitless",  # Modified Index of Agreement
         "mNSE": "Unitless",  # Modified Nash-Sutcliffe efficiency
+        "mKGE": "Unitless",  # Modified Kling-Gupta efficiency
         "pbiasfdc": "%",  # Percent Bias in the Slope of the Midsegment of the Flow Duration Curve
         "pfactor": "%",  # the percent of observations that are within the given uncertainty bounds.
         "rd": "Unitless",  # Relative Index of Agreement
+        "MIA": "Unitless",  # Modified Index of Agreement
+        "RIA": "Unitless",  # Relative Index of Agreement
         "rfactor": "Unitless",
         # the average width of the given uncertainty bounds divided by the standard deviation of the observations.
         "rNSE": "Unitless",  # Relative Nash-Sutcliffe efficiency
         "rSpearman": "Unitless",  # Spearman's rank correlation coefficient
-        "rsr": "Unitless",  # Ratio of RMSE to the standard deviation of the observations
+        "rsr": "Unitless",  # Legacy spelling for RSR
         "sKGE": "Unitless",  # Split Kling-Gupta Efficiency
-        "ssq": "Square of input data unit",  # Sum of the Squared Residuals
+        "ssq": "Square of input data unit",  # Legacy spelling for RSS
         "valindex": "Unitless",  # Valid Indexes
         "ve": "Unitless",  # Volumetric Efficiency
         "wNSE": "Unitless",  # Weighted Nash-Sutcliffe efficiency

--- a/tests/test_cli_stubs.py
+++ b/tests/test_cli_stubs.py
@@ -4371,11 +4371,11 @@ def test_init_metric_and_score_options_are_implemented():
 
     missing_metrics = [name for name in init_module.METRIC_OPTIONS if not hasattr(metrics, name)]
     missing_scores = [name for name in init_module.SCORE_OPTIONS if not hasattr(scores, name)]
-    disabled_metrics = {"rSD", "PBIAS_HF", "PBIAS_LF"} & set(init_module.METRIC_OPTIONS)
+    restored_metrics = {"rSD", "PBIAS_HF", "PBIAS_LF"} & set(init_module.METRIC_OPTIONS)
 
     assert missing_metrics == []
     assert missing_scores == []
-    assert disabled_metrics == set()
+    assert restored_metrics == {"rSD", "PBIAS_HF", "PBIAS_LF"}
 
 
 def test_run_basic_comparison_uses_basic_figure_options(tmp_path, monkeypatch):

--- a/tests/test_core/test_appendix_methods.py
+++ b/tests/test_core/test_appendix_methods.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from openbench.core.appendix_methods import (
+    brier_decomposition,
+    brier_score,
+    contingency_scores,
+    crps_ensemble,
+    fit_gev,
+    fit_gpd,
+    ideal_point_error,
+    roc_auc,
+    roc_curve,
+    taylor_skill_score,
+    uncertainty_factors,
+)
+
+
+def da(values, dim="time"):
+    return xr.DataArray(values, dims=dim)
+
+
+def test_uncertainty_factors_use_band_width_and_coverage():
+    result = uncertainty_factors(da([0.0, 1.0, 2.0]), da([2.0, 3.0, 4.0]), da([1.0, 4.0, 3.0]))
+
+    np.testing.assert_allclose(result.R_factor, 2.0 / np.std([1.0, 4.0, 3.0]))
+    np.testing.assert_allclose(result.p_factor, 2.0 / 3.0)
+
+
+def test_ipe_drops_degenerate_components():
+    candidate = {"candidate": ["a", "b"]}
+    result = ideal_point_error(
+        xr.DataArray([0.0, 2.0], coords=candidate, dims="candidate"),
+        xr.DataArray([1.0, 1.0], coords=candidate, dims="candidate"),
+        xr.DataArray([0.0, 4.0], coords=candidate, dims="candidate"),
+    )
+
+    np.testing.assert_allclose(result, [1.0, 0.0])
+
+
+def test_brier_score_and_decomposition_identity():
+    probability = da([0.25, 0.25, 0.75, 0.75])
+    outcome = da([0.0, 0.0, 1.0, 1.0])
+    score = brier_score(probability, outcome)
+    decomposition = brier_decomposition(probability, outcome, bins=2)
+
+    np.testing.assert_allclose(score, 0.0625)
+    np.testing.assert_allclose(
+        decomposition.BS,
+        decomposition.reliability
+        - decomposition.resolution
+        + decomposition.uncertainty
+        + decomposition.binning_residual,
+    )
+
+
+def test_binary_event_scores_use_the_contingency_table():
+    result = contingency_scores(da([1, 1, 0, 0]), da([1, 0, 1, 0]))
+
+    np.testing.assert_allclose(result.CSI, 1.0 / 3.0)
+    np.testing.assert_allclose(result.HSS, 0.0)
+    np.testing.assert_allclose(result.POD, 0.5)
+    np.testing.assert_allclose(result.FAR, 0.5)
+
+
+def test_taylor_skill_requires_explicit_reference_correlation():
+    result = taylor_skill_score(da([1.0, 2.0, 3.0]), da([1.0, 2.0, 3.0]), reference_correlation=1.0)
+
+    np.testing.assert_allclose(result, 1.0)
+
+
+def test_crps_empirical_ensemble_formula():
+    ensemble = xr.DataArray([[0.0, 2.0], [1.0, 3.0]], dims=["time", "member"])
+    observation = da([1.0, 2.0])
+
+    np.testing.assert_allclose(crps_ensemble(ensemble, observation), 0.5)
+
+
+def test_roc_curve_and_auc_handle_tied_probabilities():
+    probability = da([0.1, 0.4, 0.4, 0.9])
+    outcome = da([0, 0, 1, 1])
+
+    np.testing.assert_allclose(roc_auc(probability, outcome), 0.875)
+    curve = roc_curve(probability, outcome)
+    np.testing.assert_allclose(curve.TPR.values[[0, -1]], [0.0, 1.0])
+    np.testing.assert_allclose(curve.FPR.values[[0, -1]], [0.0, 1.0])
+
+
+def test_probability_and_binary_domains_fail_without_eager_grid_validation():
+    probability = da([0.2, 1.2]).chunk({"time": 1})
+    outcome = da([0, 1]).chunk({"time": 1})
+    forecast = da([0, 2]).chunk({"time": 1})
+
+    assert np.isnan(float(brier_score(probability, outcome).compute()))
+    assert np.isnan(float(brier_decomposition(probability, outcome).BS.compute()))
+    assert np.isnan(float(roc_auc(probability, outcome).compute()))
+    assert np.isnan(float(contingency_scores(forecast, outcome).CSI.compute()))
+    with pytest.raises(ValueError, match="probabilities"):
+        roc_curve(probability.compute(), outcome.compute())
+
+
+def test_extreme_value_fits_return_finite_parameters():
+    rng = np.random.default_rng(4)
+    gev = fit_gev(da(rng.gumbel(size=200)))
+    gpd = fit_gpd(da(rng.exponential(size=400)), threshold=0.5)
+
+    assert np.isfinite(gev.to_array()).all()
+    assert np.isfinite(gpd[["shape", "scale"]].to_array()).all()
+    assert float(gev.scale) > 0
+    assert float(gpd.scale) > 0

--- a/tests/test_core/test_appendix_metrics.py
+++ b/tests/test_core/test_appendix_metrics.py
@@ -1,0 +1,196 @@
+"""Appendix metric formulas not covered by the legacy metric tests."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from openbench.core.metrics import metrics
+
+
+def da(values):
+    return xr.DataArray(
+        values,
+        coords={"time": pd.date_range("2001-01-01", periods=len(values), freq="D")},
+        dims=["time"],
+    )
+
+
+def assert_close(actual, expected):
+    assert np.isclose(float(actual), expected, rtol=1e-10, atol=1e-10)
+
+
+def test_appendix_error_and_variability_metrics():
+    m = metrics()
+    obs = da([1.0, 2.0, 3.0, 4.0])
+    sim = da([2.0, 2.0, 4.0, 4.0])
+
+    mse = np.mean((sim.values - obs.values) ** 2)
+    rss = np.sum((sim.values - obs.values) ** 2)
+    rmse = np.sqrt(mse)
+    obs_mean = obs.values.mean()
+    obs_std_sum = np.sqrt(np.sum((obs.values - obs_mean) ** 2))
+
+    assert_close(m.MSE(sim, obs), mse)
+    assert_close(m.RSS(sim, obs), rss)
+    assert_close(m.NRMSE(sim, obs), rmse / abs(obs_mean))
+    assert_close(m.RSR(sim, obs), np.sqrt(rss) / obs_std_sum)
+    assert_close(m.NMAE(sim, obs), np.sum(abs(sim.values - obs.values)) / np.sum(abs(obs.values)))
+    assert_close(m.rSD(sim, obs), np.std(sim.values) / np.std(obs.values))
+
+
+def test_appendix_flow_bias_metrics_use_observed_thresholds():
+    m = metrics()
+    obs = da([1.0, 2.0, 3.0, 4.0, 100.0])
+    sim = da([1.0, 3.0, 3.0, 5.0, 120.0])
+
+    assert_close(m.PBIAS_HF(sim, obs, quantile=0.8), 20.0)
+    assert_close(m.PBIAS_LF(sim, obs, quantile=0.2), 0.0)
+
+    qs_h, qs_l = np.quantile(sim.values, [0.66, 0.33])
+    qo_h, qo_l = np.quantile(obs.values, [0.66, 0.33])
+    expected = 100.0 * ((np.log(qs_h) - np.log(qs_l)) - (np.log(qo_h) - np.log(qo_l))) / (np.log(qo_h) - np.log(qo_l))
+    assert_close(m.pbiasfdc(sim, obs), expected)
+
+
+def test_low_flow_percent_bias_rejects_zero_in_selected_observations():
+    obs = da([0.0, 1.0, 2.0, 3.0])
+    sim = da([1.0, 2.0, 2.0, 3.0])
+
+    assert np.isnan(float(metrics().PBIAS_LF(sim, obs, quantile=0.5)))
+
+
+def test_appendix_agreement_and_efficiency_metrics():
+    m = metrics()
+    obs = da([1.0, 2.0, 4.0, 8.0])
+    sim = da([1.0, 3.0, 5.0, 7.0])
+    obs_mean = obs.values.mean()
+
+    mia_den = np.sum(abs(sim.values - obs_mean) + abs(obs.values - obs_mean))
+    assert_close(m.MIA(sim, obs), 1 - np.sum(abs(sim.values - obs.values)) / mia_den)
+
+    ria_num = np.sum(abs(sim.values - obs.values) / obs.values)
+    ria_den = np.sum((abs(sim.values - obs_mean) + abs(obs.values - obs_mean)) / obs_mean)
+    assert_close(m.RIA(sim, obs), 1 - ria_num / ria_den)
+
+    assert_close(m.valindex(sim, obs, epsilon=1.0), 1.0)
+    assert_close(m.VE(sim, obs), 1 - np.sum(abs(sim.values - obs.values)) / np.sum(obs.values))
+
+    log_obs = np.log(obs.values)
+    log_sim = np.log(sim.values)
+    assert_close(m.LNSE(sim, obs), 1 - np.sum((log_sim - log_obs) ** 2) / np.sum((log_obs - log_obs.mean()) ** 2))
+    assert_close(m.mNSE(sim, obs), 1 - np.sum(abs(sim.values - obs.values)) / np.sum(abs(obs.values - obs_mean)))
+    assert_close(
+        m.rNSE(sim, obs),
+        1 - np.sum(((sim.values - obs.values) / obs.values) ** 2) / np.sum(((obs.values - obs_mean) / obs_mean) ** 2),
+    )
+
+
+def test_appendix_kge_variants_and_spearman_components():
+    m = metrics()
+    obs = da([1.0, 2.0, 3.0, 4.0])
+    sim = da([1.0, 2.0, 2.0, 8.0])
+
+    r = np.corrcoef(sim.values, obs.values)[0, 1]
+    alpha = np.std(sim.values) / np.std(obs.values)
+    beta = np.mean(sim.values) / np.mean(obs.values)
+    gamma = (np.std(sim.values) / np.mean(sim.values)) / (np.std(obs.values) / np.mean(obs.values))
+
+    assert_close(m.rSpearman(sim, obs), pd.Series(sim.values).rank().corr(pd.Series(obs.values).rank()))
+    assert_close(m.mKGE(sim, obs), 1 - np.sqrt((r - 1) ** 2 + (beta - 1) ** 2 + (gamma - 1) ** 2))
+    assert_close(m.KGEkm(sim, obs), 1 - np.sqrt((r - 1) ** 2 + (alpha - 1) ** 2 + (beta - 1) ** 2 + (gamma - 1) ** 2))
+
+    split = m.sKGE(sim, obs)
+    assert list(split.component.values) == ["r", "beta", "gamma"]
+    np.testing.assert_allclose(split.values, [r, beta, gamma])
+
+    low = obs <= obs.quantile(0.5)
+    assert_close(m.KGElf(sim, obs, quantile=0.5), m.KGE(sim.where(low), obs.where(low)))
+
+    n = sim.size
+    alpha_np = 1 - 0.5 * np.sum(
+        np.abs(
+            np.sort(sim.values)[::-1] / (n * np.mean(sim.values))
+            - np.sort(obs.values)[::-1] / (n * np.mean(obs.values))
+        )
+    )
+    expected_np = 1 - np.sqrt(
+        (float(m.rSpearman(sim, obs)) - 1) ** 2
+        + (alpha_np - 1) ** 2
+        + (np.mean(sim.values) / np.mean(obs.values) - 1) ** 2
+    )
+    assert_close(m.KGEnp(sim, obs), expected_np)
+
+
+def test_appendix_metrics_return_nan_outside_domain_and_do_not_mutate_inputs():
+    m = metrics()
+    obs = da([0.0, 0.0, 0.0])
+    sim = da([1.0, 2.0, 3.0])
+    obs_before = obs.copy(deep=True)
+    sim_before = sim.copy(deep=True)
+
+    for name in ["NRMSE", "RSR", "rSD", "PBIAS_LF", "RIA", "VE", "LNSE", "mNSE", "rNSE"]:
+        assert np.isnan(float(getattr(m, name)(sim, obs)))
+
+    xr.testing.assert_identical(obs, obs_before)
+    xr.testing.assert_identical(sim, sim_before)
+
+
+def test_appendix_metrics_vectorize_over_non_time_dimensions():
+    m = metrics()
+    obs = xr.DataArray([[1.0, 2.0], [2.0, 4.0], [3.0, 6.0]], dims=["time", "site"])
+    sim = xr.DataArray([[1.0, 3.0], [2.0, 5.0], [4.0, 7.0]], dims=["time", "site"])
+
+    assert m.MSE(sim, obs).dims == ("site",)
+    np.testing.assert_allclose(m.MSE(sim, obs), [1.0 / 3.0, 1.0])
+    assert m.rSpearman(sim, obs).dims == ("site",)
+    np.testing.assert_allclose(m.rSpearman(sim, obs), [1.0, 1.0])
+
+
+def test_appendix_weighted_metrics_reject_negative_weights():
+    m = metrics()
+    obs = da([1.0, 2.0, 3.0, 4.0])
+    sim = da([1.0, 3.0, 2.0, 6.0])
+    weights = da([1.0, 1.0, 2.0, 2.0])
+
+    weighted_mean = np.sum(weights.values * obs.values) / np.sum(weights.values)
+    expected = 1 - np.sum(weights.values * (sim.values - obs.values) ** 2) / np.sum(
+        weights.values * (obs.values - weighted_mean) ** 2
+    )
+    assert_close(m.wNSE(sim, obs, weights=weights), expected)
+
+    bad_weights = da([1.0, -10.0, np.nan, 2.0])
+    assert np.isnan(float(m.wNSE(sim, obs, weights=bad_weights)))
+
+
+def test_appendix_weighted_seasonal_nse_matches_monthly_formula():
+    m = metrics()
+    times = pd.to_datetime(["2001-01-01", "2001-01-02", "2001-07-01", "2001-07-02"])
+    obs = xr.DataArray([1.0, 3.0, 2.0, 6.0], coords={"time": times}, dims=["time"])
+    sim = xr.DataArray([1.0, 5.0, 4.0, 6.0], coords={"time": times}, dims=["time"])
+    season_weights = {"DJF": 2.0, "JJA": 1.0}
+    weights = np.array([2.0, 2.0, 1.0, 1.0])
+    month_means = np.array([2.0, 2.0, 4.0, 4.0])
+    expected = 1 - np.sum(weights * (sim.values - obs.values) ** 2) / np.sum(weights * (obs.values - month_means) ** 2)
+
+    assert_close(m.wsNSE(sim, obs, season_weights=season_weights), expected)
+
+
+def test_domain_guards_ignore_invalid_pairs_not_entire_series():
+    m = metrics()
+    obs = da([1.0, 2.0, np.nan, 4.0])
+    sim = da([1.0, 3.0, 9.0, 5.0])
+    obs_drop = da([1.0, 2.0, 4.0])
+    sim_drop = da([1.0, 3.0, 5.0])
+
+    for name in ["RIA", "VE", "LNSE", "rNSE"]:
+        assert_close(getattr(m, name)(sim, obs), getattr(m, name)(sim_drop, obs_drop))
+
+
+def test_wsNSE_requires_explicit_seasons_for_numeric_time_coords():
+    m = metrics()
+    obs = xr.DataArray([1.0, 2.0, 3.0], coords={"time": [0, 1, 2]}, dims=["time"])
+    sim = xr.DataArray([1.0, 3.0, 2.0], coords={"time": [0, 1, 2]}, dims=["time"])
+
+    with pytest.raises(ValueError, match="explicit seasons"):
+        m.wsNSE(sim, obs, season_weights={"all": 1.0})

--- a/tests/test_core/test_appendix_registry.py
+++ b/tests/test_core/test_appendix_registry.py
@@ -1,0 +1,38 @@
+from openbench.core.registry import IMPLEMENTED_METRICS, METRIC_LABELS, METRICS_ITEMS
+
+
+def test_appendix_scalar_metrics_are_selectable_and_labeled():
+    expected = {
+        "MSE",
+        "NRMSE",
+        "RSR",
+        "RSS",
+        "NMAE",
+        "rSD",
+        "PBIAS_HF",
+        "PBIAS_LF",
+        "pbiasfdc",
+        "rSpearman",
+        "MIA",
+        "RIA",
+        "VE",
+        "LNSE",
+        "mNSE",
+        "rNSE",
+        "mKGE",
+        "KGEkm",
+        "KGElf",
+    }
+    gui_metrics = {name for values in METRICS_ITEMS.values() for name in values}
+
+    assert expected <= IMPLEMENTED_METRICS
+    assert expected <= gui_metrics
+    assert expected <= METRIC_LABELS.keys()
+
+
+def test_appendix_methods_requiring_extra_inputs_are_not_pairwise_gui_metrics():
+    gui_metrics = {name for values in METRICS_ITEMS.values() for name in values}
+
+    special = {"valindex", "wNSE", "wsNSE", "sKGE", "KGEnp"}
+    assert special.isdisjoint(IMPLEMENTED_METRICS)
+    assert special.isdisjoint(gui_metrics)

--- a/tests/test_core/test_appendix_trend.py
+++ b/tests/test_core/test_appendix_trend.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from openbench.core.statistics import statistics_calculate
+
+
+def _stats(max_sen_pairs=2_000_000):
+    return statistics_calculate(
+        {
+            "stats_nml": {
+                "Mann_Kendall_Trend_Test": {
+                    "significance_level": 0.05,
+                    "max_sen_pairs": max_sen_pairs,
+                }
+            }
+        }
+    )
+
+
+def _da(values):
+    times = pd.date_range("2000-01-01", periods=len(values), freq="D")
+    return xr.DataArray(values, coords={"time": times}, dims=["time"])
+
+
+def test_mann_kendall_exports_existing_and_appendix_outputs_for_increase():
+    result = _stats().stat_mann_kendall_trend_test(_da([1, 2, 3, 4, 5]))
+
+    assert {"trend", "significance", "p_value", "tau"}.issubset(result.data_vars)
+    assert {"s_statistic", "z_score", "sen_slope"}.issubset(result.data_vars)
+    assert float(result.trend) == 1.0
+    assert float(result.significance) == 1.0
+    np.testing.assert_allclose(float(result.tau), 1.0)
+    assert float(result.s_statistic) == 10.0
+    np.testing.assert_allclose(float(result.z_score), 9 / np.sqrt(50 / 3))
+    assert float(result.sen_slope) == 1.0
+
+
+def test_mann_kendall_decrease_has_negative_s_and_sen_slope():
+    result = _stats().stat_mann_kendall_trend_test(_da([5, 4, 3, 2, 1]))
+
+    assert float(result.trend) == -1.0
+    assert float(result.significance) == 1.0
+    np.testing.assert_allclose(float(result.tau), -1.0)
+    assert float(result.s_statistic) == -10.0
+    np.testing.assert_allclose(float(result.z_score), -9 / np.sqrt(50 / 3))
+    assert float(result.sen_slope) == -1.0
+
+
+def test_mann_kendall_ties_use_tie_corrected_z_and_average_slope():
+    result = _stats().stat_mann_kendall_trend_test(_da([1, 1, 2, 3, 4]))
+
+    assert np.isfinite(float(result.p_value))
+    assert np.isfinite(float(result.tau))
+    assert float(result.s_statistic) == 9.0
+    np.testing.assert_allclose(float(result.z_score), 8 / np.sqrt(47 / 3))
+    assert float(result.sen_slope) == 1.0
+
+
+def test_mann_kendall_constant_series_keeps_undefined_p_but_zero_slope():
+    result = _stats().stat_mann_kendall_trend_test(_da([2, 2, 2, 2, 2]))
+
+    assert float(result.trend) == 0.0
+    assert np.isnan(float(result.significance))
+    assert np.isnan(float(result.p_value))
+    assert np.isnan(float(result.tau))
+    assert float(result.s_statistic) == 0.0
+    assert np.isnan(float(result.z_score))
+    assert float(result.sen_slope) == 0.0
+
+
+def test_mann_kendall_ignores_nans_before_statistics():
+    result = _stats().stat_mann_kendall_trend_test(_da([1, np.nan, 3, 4, 5]))
+
+    assert float(result.trend) == 1.0
+    assert float(result.s_statistic) == 6.0
+    assert float(result.sen_slope) == 1.0
+
+
+def test_mann_kendall_keeps_linear_memory_when_exact_sen_limit_is_exceeded():
+    result = _stats(max_sen_pairs=3).stat_mann_kendall_trend_test(_da([1, 2, 3, 4, 5]))
+
+    assert float(result.s_statistic) == 10.0
+    assert np.isnan(float(result.sen_slope))
+    assert result.attrs["sen_slope_max_exact_pairs"] == 3

--- a/tests/test_gui_legacy_cleanup.py
+++ b/tests/test_gui_legacy_cleanup.py
@@ -59,8 +59,10 @@ def test_gui_metric_and_score_options_come_from_core_registry():
     assert gui_metrics <= IMPLEMENTED_METRICS
     assert gui_scores <= IMPLEMENTED_SCORES
     assert {"dr", "APFB", "br2", "cp"} <= gui_metrics
-    assert {"smpi", "SMPI", "MSE", "LNSE", "The_Ideal_Point_score"} & (gui_metrics | gui_scores) == set()
-    assert "index_agreement" in METRICS_ITEMS["Efficiency"]
+    assert {"smpi", "SMPI", "The_Ideal_Point_score"} & (gui_metrics | gui_scores) == set()
+    assert {"MSE", "LNSE", "rSD", "PBIAS_HF", "PBIAS_LF"} <= gui_metrics
+    assert "KGEnp" not in gui_metrics
+    assert "index_agreement" in METRICS_ITEMS["Agreement"]
     assert "index_agreement" not in gui_scores
     assert "nSeasonalityScore" in gui_scores
 

--- a/tests/test_gui_legacy_cleanup.py
+++ b/tests/test_gui_legacy_cleanup.py
@@ -60,7 +60,9 @@ def test_gui_metric_and_score_options_come_from_core_registry():
     assert gui_scores <= IMPLEMENTED_SCORES
     assert {"dr", "APFB", "br2", "cp"} <= gui_metrics
     assert {"smpi", "SMPI", "MSE", "LNSE", "The_Ideal_Point_score"} & (gui_metrics | gui_scores) == set()
-    assert {"index_agreement", "nSeasonalityScore"} <= gui_scores
+    assert "index_agreement" in METRICS_ITEMS["Efficiency"]
+    assert "index_agreement" not in gui_scores
+    assert "nSeasonalityScore" in gui_scores
 
 
 def test_metric_and_score_labels_use_full_name_with_abbreviation(qapp):

--- a/tests/test_netcdf_lifecycle_atomic.py
+++ b/tests/test_netcdf_lifecycle_atomic.py
@@ -248,7 +248,8 @@ def test_netcdf_compression_is_opt_in_by_environment(tmp_path, monkeypatch):
 
 
 @pytest.mark.parametrize("kind", ["dataset", "dataarray"])
-def test_distributed_netcdf_write_uses_local_serial_scheduler_for_lazy_data(tmp_path, monkeypatch, kind):
+@pytest.mark.parametrize("distributed", [False, True])
+def test_lazy_netcdf_write_uses_local_serial_scheduler(tmp_path, monkeypatch, kind, distributed):
     import openbench.util.netcdf as netcdf
 
     array = xr.DataArray(
@@ -269,7 +270,7 @@ def test_distributed_netcdf_write_uses_local_serial_scheduler_for_lazy_data(tmp_
         captured["lazy"] = hasattr(self["metric"].data if isinstance(self, xr.Dataset) else self.data, "compute")
         return FakeDelayed()
 
-    monkeypatch.setattr(netcdf, "_distributed_client_active", lambda: True)
+    monkeypatch.setattr(netcdf, "_distributed_client_active", lambda: distributed)
     monkeypatch.setattr(type(lazy), "to_netcdf", fake_to_netcdf)
 
     netcdf.write_netcdf_atomic(lazy, tmp_path / "out.nc")


### PR DESCRIPTION
## Summary
- move Index of Agreement back to Metrics for branch parity
- implement missing appendix pairwise and special-input methods
- extend Mann–Kendall with S, Z, and bounded exact Sen slope
- serialize lazy NetCDF HDF5 stores to prevent intermittent stalls

## Validation
- `python -m pytest -q` → 2207 passed, 10 skipped
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`