### PR TITLE
Keep remote progress and resources tied to the actual run

### DIFF
--- a/src/openbench/gui/pages/page_run_monitor.py
+++ b/src/openbench/gui/pages/page_run_monitor.py
@@ -316,7 +316,6 @@ class PageRunMonitor(BasePage):
         num_statistics = len([k for k, v in statistics.items() if v])
 
         if is_remote:
-            self.dashboard.show_resource_unavailable("Resources (remote not monitored)")
             # Remote execution mode
             self._runner = self._create_remote_runner(config_path, general)
             if self._runner is None:
@@ -324,6 +323,7 @@ class PageRunMonitor(BasePage):
                 self.dashboard.stop_monitoring()
                 self._refresh_parent_navigation()
                 return
+            self.dashboard.monitor_remote_resources()
         else:
             # Local execution mode (default)
             python_path = general.get("python_path", "")
@@ -355,6 +355,8 @@ class PageRunMonitor(BasePage):
         # Connect signals - same interface for both runners
         self._runner.progress_updated.connect(self._on_progress)
         self._runner.log_message.connect(self._on_log)
+        if is_remote:
+            self._runner.resource_updated.connect(self.dashboard.update_remote_resource_usage)
         self._runner.finished_signal.connect(self._on_finished)
         self._runner.finished.connect(self._refresh_parent_navigation)
         self._runner.start()

--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -23,6 +23,10 @@ from openbench.gui.runner import RunnerStatus, RunnerProgress, _looks_like_parti
 
 
 _REMOTE_PGID_PREFIX = "__OPENBENCH_PGID__="
+_REMOTE_PHASE_PREFIX = "__OPENBENCH_PHASE__="
+_REMOTE_CHECK_STARTED = "check_started"
+_REMOTE_RUN_STARTED = "run_started"
+_REMOTE_RUN_COMPLETED = "run_completed"
 
 
 def build_remote_run_command(python_path: str, openbench_path: str, config_path: str, conda_env: str) -> str:
@@ -38,7 +42,16 @@ def build_remote_run_command(python_path: str, openbench_path: str, config_path:
     q_openbench = quote_remote_path(openbench_path)
     q_config = quote_remote_path(config_path)
     prefix = f"PYTHONUNBUFFERED=1 OPENBENCH_GUI_PROGRESS=1 {q_python} -u -m openbench"
-    invocation = f"{prefix} check {q_config} && {prefix} run {q_config}"
+    marker = lambda phase: f"printf '%s\\n' {shlex.quote(_REMOTE_PHASE_PREFIX + phase)}"
+    invocation = " && ".join(
+        (
+            marker(_REMOTE_CHECK_STARTED),
+            f"{prefix} check {q_config}",
+            marker(_REMOTE_RUN_STARTED),
+            f"{prefix} run {q_config}",
+            marker(_REMOTE_RUN_COMPLETED),
+        )
+    )
     return wrap_with_conda_env(
         f"cd {q_openbench} && {invocation}",
         python_path=python_path,
@@ -82,6 +95,7 @@ class RemoteRunner(QThread):
     # Signals - same interface as EvaluationRunner
     progress_updated = Signal(object)  # RunnerProgress
     log_message = Signal(str)
+    resource_updated = Signal(float, float)  # normalized CPU %, host memory %
     finished_signal = Signal(bool, str)  # success, message
 
     def __init__(
@@ -113,6 +127,8 @@ class RemoteRunner(QThread):
         self._config_already_remote = config_already_remote
         self._stop_requested = False
         self._stop_lock = threading.Lock()
+        self._resource_stop = threading.Event()
+        self._resource_thread: threading.Thread | None = None
 
         # Remote paths
         self._remote_temp_dir = ""
@@ -257,6 +273,7 @@ class RemoteRunner(QThread):
             self.finished_signal.emit(False, error_msg)
 
         finally:
+            self._stop_resource_monitor()
             # Cleanup remote temp directory
             self._cleanup_remote()
 
@@ -473,6 +490,8 @@ path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encod
             progress = self.PROGRESS_INIT
             output_tail = deque(maxlen=5)
             saw_partial_completion = False
+            saw_run_started = False
+            saw_run_completed = False
 
             # `execute_stream` yields output lines and `return`s the exit
             # code. We need to capture the StopIteration.value to know
@@ -501,7 +520,19 @@ path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encod
                             value = line[len(_REMOTE_PGID_PREFIX) :].strip()
                             if value.isdigit() and int(value) > 1:
                                 self._remote_process_group = int(value)
+                                self._start_resource_monitor()
                                 continue
+                        if line.startswith(_REMOTE_PHASE_PREFIX):
+                            phase = line[len(_REMOTE_PHASE_PREFIX) :].strip()
+                            if phase == _REMOTE_CHECK_STARTED:
+                                self.log_message.emit("Validating remote configuration...")
+                            elif phase == _REMOTE_RUN_STARTED:
+                                saw_run_started = True
+                                self.log_message.emit("Remote configuration valid. Evaluation started.")
+                            elif phase == _REMOTE_RUN_COMPLETED:
+                                saw_run_completed = True
+                                self.log_message.emit("Remote evaluation process completed.")
+                            continue
                         output_tail.append(line)
                         saw_partial_completion = saw_partial_completion or _looks_like_partial_completion([line])
                         self.log_message.emit(line)
@@ -528,6 +559,10 @@ path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encod
             if stopped_by_user:
                 return (False, "Stopped by user")
             if exit_code == 0:
+                if not saw_run_started:
+                    return (False, "Remote command exited before the OpenBench evaluation started")
+                if not saw_run_completed:
+                    return (False, "Remote command exited before OpenBench reported evaluation completion")
                 return (True, "Completed")
             message = self._format_remote_failure(f"Remote OpenBench exited with code {exit_code}", output_tail)
             if saw_partial_completion and not _looks_like_partial_completion([message]):
@@ -541,6 +576,59 @@ path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encod
             return (False, self._format_command_context(f"SSH error while running remote command: {e}", cmd))
         except Exception as e:
             return (False, self._format_command_context(f"Execution error while running remote command: {e}", cmd))
+        finally:
+            self._stop_resource_monitor()
+
+    def _start_resource_monitor(self) -> None:
+        """Poll the captured remote process group without blocking the GUI thread."""
+        if self._resource_thread is not None and self._resource_thread.is_alive():
+            return
+        self._resource_stop.clear()
+
+        def monitor():
+            while not self._resource_stop.is_set():
+                self._sample_remote_resources()
+                self._resource_stop.wait(2.0)
+
+        self._resource_thread = threading.Thread(target=monitor, name="openbench-remote-resources", daemon=True)
+        self._resource_thread.start()
+
+    def _stop_resource_monitor(self) -> None:
+        self._resource_stop.set()
+        thread = self._resource_thread
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=3.0)
+        self._resource_thread = None
+
+    def _sample_remote_resources(self) -> bool:
+        """Emit CPU-capacity and host-memory usage for this run's process group."""
+        pgid = self._remote_process_group
+        if pgid is None:
+            return False
+        command = (
+            "mem_total=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || true); "
+            "ps -eo pgid=,pcpu=,rss= | "
+            f'awk -v target={pgid} -v total="${{mem_total:-0}}" \''
+            "$1 == target {cpu += $2; rss += $3; found=1} "
+            "END {if (!found) exit 1; mem=(total > 0 ? 100 * rss / total : 0); "
+            'printf "%.6f %.6f\\n", cpu, mem}'
+        )
+        try:
+            stdout, _stderr, exit_code = self._ssh_manager.execute(command, timeout=2)
+            if exit_code != 0:
+                return False
+            aggregate_cpu, memory_percent = map(float, stdout.split()[-2:])
+            try:
+                configured_cores = max(1, int(self._remote_config.get("num_cores") or 1))
+            except (TypeError, ValueError):
+                configured_cores = 1
+            self.resource_updated.emit(
+                max(0.0, min(100.0, aggregate_cpu / configured_cores)),
+                max(0.0, min(100.0, memory_percent)),
+            )
+            return True
+        except Exception:
+            return False
 
     def _kill_remote_process(self):
         """Attempt to kill the remote OpenBench process."""

--- a/src/openbench/gui/widgets/progress_dashboard.py
+++ b/src/openbench/gui/widgets/progress_dashboard.py
@@ -237,6 +237,25 @@ class ProgressDashboard(QWidget):
         self.resource_group.setTitle(title)
         self._set_resource_labels_unavailable()
 
+    def monitor_remote_resources(self):
+        """Accept resource samples emitted by the remote runner."""
+        self._resource_mode = "remote"
+        self._resource_pid_provider = None
+        self._resource_processes.clear()
+        self.resource_group.setTitle("Resources (OpenBench remote)")
+        self._set_resource_labels_unavailable()
+
+    def update_remote_resource_usage(self, cpu_percent: float, mem_percent: float):
+        """Display one remote process-group resource sample."""
+        if self._resource_mode != "remote":
+            return
+        cpu_value = max(0, min(100, int(round(cpu_percent))))
+        mem_value = max(0, min(100, int(round(mem_percent))))
+        self.cpu_bar.setValue(cpu_value)
+        self.mem_bar.setValue(mem_value)
+        self.cpu_label.setText(f"{cpu_value}%")
+        self.mem_label.setText(f"{mem_percent:.1f}%" if 0 < mem_percent < 1 else f"{mem_value}%")
+
     def _set_resource_labels_unavailable(self):
         self.cpu_bar.setValue(0)
         self.mem_bar.setValue(0)
@@ -306,6 +325,8 @@ class ProgressDashboard(QWidget):
         """Update resource usage display."""
         if self._resource_mode == "unavailable":
             self._set_resource_labels_unavailable()
+            return
+        if self._resource_mode == "remote":
             return
         try:
             import psutil

--- a/tests/test_gui_remote_scanner_workflow.py
+++ b/tests/test_gui_remote_scanner_workflow.py
@@ -326,10 +326,9 @@ def test_remote_run_command_expands_tilde_paths():
     assert 'cd "$HOME"/OpenBench && ' in cmd
     assert "OPENBENCH_GUI_PROGRESS=1" in cmd
     assert '"$HOME"/miniconda3/envs/ob/bin/python -u -m openbench check' in cmd
-    assert (
-        "&& PYTHONUNBUFFERED=1 OPENBENCH_GUI_PROGRESS=1 "
-        '"$HOME"/miniconda3/envs/ob/bin/python -u -m openbench run' in cmd
-    )
+    assert '"$HOME"/miniconda3/envs/ob/bin/python -u -m openbench run' in cmd
+    assert "__OPENBENCH_PHASE__=run_started" in cmd
+    assert "__OPENBENCH_PHASE__=run_completed" in cmd
     assert "'~/" not in cmd
 
 

--- a/tests/test_progress_dashboard.py
+++ b/tests/test_progress_dashboard.py
@@ -140,20 +140,21 @@ def test_process_cpu_sampler_is_reused_after_psutil_priming(qapp, monkeypatch):
     assert dashboard.mem_label.text() == "0.4%"
 
 
-def test_remote_resource_mode_is_explicitly_unavailable(qapp, monkeypatch):
+def test_remote_resource_samples_are_not_overwritten_by_local_psutil(qapp, monkeypatch):
     fake_psutil = SimpleNamespace(
         cpu_percent=lambda: 99,
         virtual_memory=lambda: SimpleNamespace(percent=99),
     )
     monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
     dashboard = ProgressDashboard()
-    dashboard.show_resource_unavailable("Resources (remote not monitored)")
+    dashboard.monitor_remote_resources()
+    dashboard.update_remote_resource_usage(25, 0.4)
 
     dashboard._update_resource_usage()
 
-    assert dashboard.resource_group.title() == "Resources (remote not monitored)"
-    assert dashboard.cpu_label.text() == "N/A"
-    assert dashboard.mem_label.text() == "N/A"
+    assert dashboard.resource_group.title() == "Resources (OpenBench remote)"
+    assert dashboard.cpu_label.text() == "25%"
+    assert dashboard.mem_label.text() == "0.4%"
 
 
 def test_resource_usage_shows_unavailable_when_psutil_is_missing(qapp, monkeypatch):

--- a/tests/test_remote_runner.py
+++ b/tests/test_remote_runner.py
@@ -331,7 +331,14 @@ def test_execute_remote_openbench_nonzero_exit_includes_log_tail(tmp_path):
 def test_execute_remote_openbench_passes_should_abort_to_stream(tmp_path):
     config = tmp_path / "main.yaml"
     config.write_text("x: 1\n", encoding="utf-8")
-    ssh = StreamSSH(lines=["running\n"], exit_code=0)
+    ssh = StreamSSH(
+        lines=[
+            "__OPENBENCH_PHASE__=run_started\n",
+            "running\n",
+            "__OPENBENCH_PHASE__=run_completed\n",
+        ],
+        exit_code=0,
+    )
     runner = _runner(config, ssh)
     runner._remote_config_path = "/remote/main.yaml"
 
@@ -344,7 +351,16 @@ def test_execute_remote_openbench_passes_should_abort_to_stream(tmp_path):
 def test_execute_remote_openbench_captures_hidden_process_group_marker(tmp_path):
     config = tmp_path / "main.yaml"
     config.write_text("x: 1\n", encoding="utf-8")
-    ssh = StreamSSH(lines=["login banner\n", "__OPENBENCH_PGID__=4321\n", "running\n"], exit_code=0)
+    ssh = StreamSSH(
+        lines=[
+            "login banner\n",
+            "__OPENBENCH_PGID__=4321\n",
+            "__OPENBENCH_PHASE__=run_started\n",
+            "running\n",
+            "__OPENBENCH_PHASE__=run_completed\n",
+        ],
+        exit_code=0,
+    )
     runner = _runner(config, ssh)
     runner._remote_config_path = "/remote/main.yaml"
     logs = []
@@ -354,10 +370,45 @@ def test_execute_remote_openbench_captures_hidden_process_group_marker(tmp_path)
 
     assert success is True
     assert runner._remote_process_group == 4321
-    assert logs[-1] == "running"
+    assert "running" in logs
+    assert logs[-1] == "Remote evaluation process completed."
     assert "login banner" in logs
     assert all("__OPENBENCH_PGID__" not in line for line in logs)
     assert "setsid" in ssh.stream_command
+
+
+def test_execute_remote_openbench_rejects_unconfirmed_zero_exit(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    ssh = StreamSSH(lines=["Config valid. Ready to run.\n"], exit_code=0)
+    runner = _runner(config, ssh)
+    runner._remote_config_path = "/remote/main.yaml"
+
+    success, message = runner._execute_remote_openbench()
+
+    assert success is False
+    assert message == "Remote command exited before the OpenBench evaluation started"
+
+
+def test_remote_resource_sample_is_normalized_to_configured_cores(tmp_path):
+    config = tmp_path / "main.yaml"
+    config.write_text("x: 1\n", encoding="utf-8")
+    ssh = ExecuteSSH(("240.0 1.5\n", "", 0))
+    runner = RemoteRunner(
+        str(config),
+        ssh,
+        {"python_path": "python3", "openbench_path": "/remote/openbench", "num_cores": 12},
+        config_already_remote=True,
+    )
+    runner._remote_process_group = 4321
+    samples = []
+    runner.resource_updated.connect(lambda cpu, memory: samples.append((cpu, memory)))
+
+    assert runner._sample_remote_resources() is True
+
+    assert samples == [(20.0, 1.5)]
+    assert "ps -eo pgid=,pcpu=,rss=" in ssh.commands[-1]
+    assert "target=4321" in ssh.commands[-1]
 
 
 def test_execute_remote_openbench_preserves_partial_marker_outside_tail(tmp_path):


### PR DESCRIPTION
## Summary
- require explicit remote run-start and run-complete markers before showing 100%
- fail visibly when SSH exits before the evaluation phase is confirmed
- monitor CPU and memory for the captured remote OpenBench process group
- keep remote resource samples separate from local host psutil values

## Validation
- `python -m pytest -q` → 2205 passed, 10 skipped
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`