### PR TITLE
Keep jump-host remote runs attached

### DIFF
--- a/src/openbench/gui/remote_runner.py
+++ b/src/openbench/gui/remote_runner.py
@@ -476,12 +476,13 @@ path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encod
 
         # Run the CLI in its own process group when `setsid` is available so
         # Stop can terminate ProcessPool/Dask descendants, not only the parent
-        # `python -m openbench` process. The foreground wrapper preserves the
-        # SSH channel's normal exit-code and streaming behavior.
+        # `python -m openbench` process. `setsid -w` is required because some
+        # SSH channels make setsid fork; without wait mode the channel reports
+        # success as soon as the short-lived parent exits.
         grouped_inner = f"printf '{_REMOTE_PGID_PREFIX}%s\\n' \"$$\"; exec sh -c {shlex.quote(cmd)}"
         stream_cmd = (
-            "if command -v setsid >/dev/null 2>&1; then "
-            f"exec setsid sh -c {shlex.quote(grouped_inner)}; "
+            "if command -v setsid >/dev/null 2>&1 && setsid -w true >/dev/null 2>&1; then "
+            f"exec setsid -w sh -c {shlex.quote(grouped_inner)}; "
             f"else exec sh -c {shlex.quote(cmd)}; fi"
         )
 

--- a/tests/test_remote_runner.py
+++ b/tests/test_remote_runner.py
@@ -374,7 +374,7 @@ def test_execute_remote_openbench_captures_hidden_process_group_marker(tmp_path)
     assert logs[-1] == "Remote evaluation process completed."
     assert "login banner" in logs
     assert all("__OPENBENCH_PGID__" not in line for line in logs)
-    assert "setsid" in ssh.stream_command
+    assert "setsid -w" in ssh.stream_command
 
 
 def test_execute_remote_openbench_rejects_unconfirmed_zero_exit(tmp_path):


### PR DESCRIPTION
## Summary
- make `setsid` wait for the OpenBench child process before SSH reports completion
- fall back to the existing foreground shell when wait mode is unavailable
- lock the wrapper behavior with a regression assertion

## Verification
- `python -m pytest tests/test_remote_runner.py -q`
- `python -m ruff check src/openbench/gui/remote_runner.py tests/test_remote_runner.py`
- `python -m ruff format --check src/openbench/gui/remote_runner.py tests/test_remote_runner.py`
- reproduced and verified against the configured Paramiko jump-host path to `tms17`
