### PR TITLE
Preserve uncertainty CLM file stream

### DIFF
--- a/src/openbench/cli/sim.py
+++ b/src/openbench/cli/sim.py
@@ -683,8 +683,10 @@ def _case_prefix_is_safe_to_write(case) -> bool:
     for override in overrides.values():
         if not isinstance(override, dict):
             continue
-        seen_prefixes.add(override.get("prefix", case_prefix) or "")
-        seen_suffixes.add(override.get("suffix", case_suffix) or "")
+        if override.get("prefix"):
+            seen_prefixes.add(override["prefix"])
+        if override.get("suffix"):
+            seen_suffixes.add(override["suffix"])
     return len(seen_prefixes) <= 1 and len(seen_suffixes) <= 1
 
 

--- a/src/openbench/gui/pages/page_sim_data.py
+++ b/src/openbench/gui/pages/page_sim_data.py
@@ -117,8 +117,10 @@ def _case_prefix_is_safe(prefix: str, suffix: str, overrides: Dict[str, Any]) ->
     for override in overrides.values():
         if not isinstance(override, dict):
             continue
-        seen_prefixes.add(override.get("prefix", prefix) or "")
-        seen_suffixes.add(override.get("suffix", suffix) or "")
+        if override.get("prefix"):
+            seen_prefixes.add(override["prefix"])
+        if override.get("suffix"):
+            seen_suffixes.add(override["suffix"])
     return len(seen_prefixes) <= 1 and len(seen_suffixes) <= 1
 
 

--- a/tests/test_cli_sim_scan.py
+++ b/tests/test_cli_sim_scan.py
@@ -714,6 +714,20 @@ def test_infer_tim_res_from_time_coverage_preserves_subdaily_labels():
     assert _infer_tim_res_from_time_coverage({"time_count": 3, "time_span_seconds": 12 * 3600}) == "6Hour"
 
 
+def test_blank_compute_override_does_not_hide_case_file_prefix():
+    from types import SimpleNamespace
+
+    from openbench.cli.sim import _case_prefix_is_safe_to_write
+
+    case = SimpleNamespace(
+        prefix="case.clm2.h0.",
+        suffix="",
+        variable_overrides={"Surface_Albedo": {"prefix": "", "suffix": ""}},
+    )
+
+    assert _case_prefix_is_safe_to_write(case) is True
+
+
 def test_rebase_station_artifacts_updates_fulllist_and_case_paths(tmp_path):
     from types import SimpleNamespace
 

--- a/tests/test_gui_scan_alignment_fixes.py
+++ b/tests/test_gui_scan_alignment_fixes.py
@@ -536,6 +536,24 @@ def test_get_selected_cases_keeps_prefix_for_single_stream():
     assert selected["variables"] == {}
 
 
+def test_get_selected_cases_keeps_prefix_with_blank_compute_overrides():
+    case = {
+        "checkbox": _FakeCheck(),
+        "model_combo": _FakeCombo("CLM5"),
+        "label": "CLM5",
+        "nc_dir": "/sims/CLM5",
+        "auto_prefix": "case.clm2.h0.",
+        "auto_suffix": "",
+        "variable_overrides": {"Surface_Albedo": {"prefix": "", "suffix": ""}},
+        "multi_stream": True,
+    }
+
+    (selected,) = _selected_cases(case)
+
+    assert selected["prefix"] == "case.clm2.h0."
+    assert selected["variables"]["Surface_Albedo"] == {"prefix": "", "suffix": ""}
+
+
 def test_get_selected_cases_uses_per_case_pattern_edits():
     case = {
         "checkbox": _FakeCheck(),


### PR DESCRIPTION
## Summary
- port the CLM h0 prefix preservation fix to the uncertainty branch
- keep blank compute-variable patterns from suppressing the concrete case stream

## Verification
- 73 targeted tests passed
- Ruff passed
