### PR TITLE
Release OpenBench 3.0.0b16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [3.0.0b16] - 2026-08-31
+
+Beta release over 3.0.0b15 for remote workflow reliability, expanded evaluation
+methods, and complete output packaging.
+
+### Added
+- Evaluation-guide appendix metrics and methods, including deterministic,
+  categorical, uncertainty, trend, and distribution diagnostics.
+- Live remote CPU and memory monitoring tied to the active OpenBench process.
+
+### Changed
+- Index of Agreement is available through the metric workflow.
+- Generated figures are published under the advertised top-level `figures/`
+  directory while existing metric, comparison, and report paths remain valid.
+
+### Fixed
+- Remote installation, Conda environment creation, SSH host selection, output
+  paths, project confirmation, and local/remote dataset discovery.
+- Remote progress now waits for the real evaluation process across jump hosts
+  instead of reporting premature success or completion.
+- Legacy flat reference layouts, CLM multi-stream file prefixes, and simulation
+  data scanning now preserve the files selected by the user.
+- Appendix NetCDF execution, GUI/Qt CI stability, and repository formatting.
+
 ## [3.0.0b15] - 2026-08-26
 
 Beta release over 3.0.0b14 for GUI/runtime reliability, truthful reporting,

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ conda install -c conda-forge colm-openbench
 mamba install -c conda-forge colm-openbench   # or the faster mamba
 ```
 
-> **Note:** the current release is a Beta pre-release (`3.0.0b15`) and is **not on
+> **Note:** the current release is a Beta pre-release (`3.0.0b16`) and is **not on
 > conda-forge yet**. Until it is, use one of the two paths below.
 
 If your platform does not have wheels for geospatial dependencies such as

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b15" %}
+{% set version = "3.0.0b16" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: 3b40f83f4dddab4f0b678be7b877a7e2c2434c00acd69a8d12c1080d241538ef
+  sha256: bd1f78abe46e0e7598c6f58184bdbec1a3359551a8a4682d6f9f597fa02a0eb9
 
 build:
   noarch: python

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b15"
+__version__ = "3.0.0b16"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"


### PR DESCRIPTION
## Summary
- bump OpenBench to `3.0.0b16`
- document remote workflow, evaluation-method, scanner, and figure-output fixes
- update the conda recipe to the verified b16 sdist checksum

## Verification
- 2212 passed, 5 skipped
- Ruff check and format check passed
- wheel and sdist built successfully
- Twine and build-artifact checks passed
- wheel SHA-256: `8228686ebe87148f1a93240f42f3e3b388db976e18ca53adcb5b7e768c5c2207`
- sdist SHA-256: `bd1f78abe46e0e7598c6f58184bdbec1a3359551a8a4682d6f9f597fa02a0eb9`
