### PR TITLE
Prevent leaked Qt test state from destabilizing GUI CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,27 @@ import pytest
 
 @pytest.fixture
 def qapp():
-    """Process-wide QApplication for GUI tests (offscreen platform)."""
+    """Reuse QApplication, but do not leak widgets or event filters across tests."""
     pytest.importorskip("PySide6")
+    from PySide6.QtCore import QCoreApplication, QEvent
     from PySide6.QtWidgets import QApplication
 
-    return QApplication.instance() or QApplication([])
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+    manager = getattr(app, "_openbench_language_manager", None)
+    if manager is not None:
+        app.removeEventFilter(manager)
+        del app._openbench_language_manager
+    for widget in app.topLevelWidgets():
+        # Do not invoke closeEvent: it can open confirmation dialogs in teardown.
+        widget.hide()
+        widget.deleteLater()
+    if manager is not None:
+        manager.deleteLater()
+    # processEvents() alone does not deliver deferred QObject deletions.
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    app.processEvents()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_gui_qapp_lifecycle.py
+++ b/tests/test_gui_qapp_lifecycle.py
@@ -1,0 +1,53 @@
+"""Exercise fixture teardown in a separate process, not the suite's QApplication."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def test_qapp_cleans_widgets_and_language_filter_between_tests(tmp_path):
+    pytest.importorskip("PySide6")
+    test_file = tmp_path / "test_qapp_isolation.py"
+    test_file.write_text(
+        textwrap.dedent("""\
+        from PySide6.QtWidgets import QWidget
+        from shiboken6 import isValid
+        from openbench.gui.localization import LanguageManager
+
+        retained = {}
+
+        def test_create_widgets(qapp):
+            retained["app"] = qapp
+            retained["window"] = QWidget()
+            retained["child"] = QWidget(retained["window"])
+            retained["pending"] = QWidget()
+            retained["pending"].deleteLater()
+            manager = LanguageManager(qapp, persist=False)
+            retained["manager"] = manager
+            qapp._openbench_language_manager = manager
+            qapp.installEventFilter(manager)
+
+        def test_previous_widgets_are_destroyed(qapp):
+            assert qapp is retained["app"]
+            for name in ("window", "child", "pending", "manager"):
+                assert not isValid(retained[name]), name
+            assert not qapp.topLevelWidgets()
+            assert getattr(qapp, "_openbench_language_manager", None) is None
+        """),
+        encoding="utf-8",
+    )
+    repo = Path(__file__).resolve().parents[1]
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join((str(repo / "src"), str(repo))))
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--noconftest", "-p", "tests.conftest", str(test_file)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Why
The merged main CI run 34121630256 hit native Qt crashes on Ubuntu and Windows with Python 3.11. GUI tests currently share a QApplication without cleaning up their widgets or application-wide language filter; earlier dialogs remain alive when later tests construct MainWindow.

## Fix
- Keep the shared QApplication, but dispose of each test's top-level widgets and language manager.
- Explicitly deliver Qt DeferredDelete events; processEvents alone does not guarantee deletion.
- Avoid closeEvent during teardown so cleanup cannot open confirmation dialogs.
- Add an isolated two-test regression that retains Python references and verifies native widgets, children, pending deletion, and language manager are destroyed before the next test.

No application behavior, dependencies, test exclusions, or CI matrix changes.

## Verification
- Regression fails before the fixture fix and passes after it.
- Python 3.11 / PySide6 6.11.2: 8 targeted tests passed with coverage.
- Full Ruff lint and formatting passed.
- Read-only review approved; git diff --check passed.
- Full local suites with coverage: Python 3.11 / PySide6 6.11.2 and Python 3.12 / PySide6 6.10.1 each passed 2245 tests with 10 existing skips. Python 3.11 emitted one NumPy binary-compatibility warning.
- [GitHub CI run 34129993430](https://github.com/zhongwangwei/OpenBench/actions/runs/34129993430): all 11 jobs passed, including all 9 OS/Python combinations and both previously crashing Python 3.11 jobs.
- The native crash was not reproduced on macOS; cross-platform CI is the verification of the reported failure. The retained-object regression was verified red before the fix and green afterward.
