### PR TITLE
Release stable OpenBench 3.0.0 with validated Conda installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [Unreleased] — 3.0 release preparation
+## [3.0.0] - 2026-09-11
+
+First stable 3.0 release, including the main-branch fixes validated across Linux,
+macOS and Windows on Python 3.10–3.12. The opt-in uncertainty-aware pipeline
+remains on its separate development branch.
 
 ### Fixed
 - Shared grid preprocessing no longer depends on which reference is evaluated
@@ -17,6 +21,10 @@
   credential handling without removing public compatibility entry points.
 - Share wheel/sdist resource checks between CI and publishing, require explicitly
   selected artifacts to exist, and document fresh-build release verification.
+- Remove redundant comments and duplicate test scaffolding while retaining
+  meaningful scientific documentation and deterministic regression coverage.
+- Align the Conda recipe with the stable PyPI version and verify its dependency,
+  command-line and bundled-data installation contracts.
 
 ## [3.0.0b16] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Open Source Land Surface Model Benchmarking System
 
-[![PyPI version](https://img.shields.io/pypi/v/colm-openbench?include_prereleases)](https://pypi.org/project/colm-openbench/)
+[![PyPI version](https://img.shields.io/pypi/v/colm-openbench)](https://pypi.org/project/colm-openbench/)
 [![Python versions](https://img.shields.io/pypi/pyversions/colm-openbench)](https://pypi.org/project/colm-openbench/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![User's Guide](https://img.shields.io/badge/docs-User's%20Guide%20(PDF)-blue)](docs/manual/OpenBench_UsersGuide_EN.pdf)
@@ -126,37 +126,44 @@ Using `uv`:
 uv pip install "colm-openbench[all]"
 ```
 
-### conda / conda-forge
+### Conda / Mamba
 
-OpenBench ships a conda-forge recipe (`conda/meta.yaml`, `noarch`: sourced from
-PyPI, with Cartopy/NetCDF/PROJ resolved by conda). Once published to
-conda-forge, a single command installs everything (no local compilation):
-
-```bash
-conda install -c conda-forge colm-openbench
-mamba install -c conda-forge colm-openbench   # or the faster mamba
-```
-
-> **Note:** the current release is a Beta pre-release (`3.0.0b16`) and is **not on
-> conda-forge yet**. Until it is, use one of the two paths below.
-
-If your platform does not have wheels for geospatial dependencies such as
-Cartopy, install the scientific stack from conda-forge first, then install
-OpenBench with pip:
+OpenBench **3.0.0** can be installed in an isolated Conda environment. A
+`colm-openbench` package is not currently published on conda-forge, so do not use
+`conda install -c conda-forge colm-openbench` yet. Install the native scientific
+libraries from conda-forge first, then OpenBench from PyPI:
 
 ```bash
-mamba create -n openbench -c conda-forge python=3.12 cartopy netcdf4
-mamba activate openbench
-pip install colm-openbench
+conda create -n openbench --override-channels -c conda-forge python=3.12 pip cartopy netcdf4 scipy pandas xarray matplotlib-base
+conda activate openbench
+python -m pip install "colm-openbench==3.0.0"
+python -m pip check
+openbench --version
+openbench smoke-test
 ```
 
-Or build a local conda package straight from the bundled recipe:
+For the graphical wizard and SSH controls, use
+`python -m pip install "colm-openbench[gui]==3.0.0"` in that environment.
+Mamba can replace `conda create`. Install Conda dependencies before pip packages;
+when changing the native stack later, recreate the environment instead of mixing
+Conda updates into an existing pip installation. Avoid installing into `base`.
+
+#### Build a native Conda package locally
+
+The versioned recipe in `conda/meta.yaml` builds a `noarch: python` CLI package
+from the checksummed PyPI source archive. This is a local build, not a claim of
+conda-forge publication. From a checkout of the matching release:
 
 ```bash
-conda install -n base conda-build
-conda build conda/
-conda install -c local colm-openbench
+conda create -n openbench-build --override-channels -c conda-forge python=3.12 conda-build
+conda run -n openbench-build conda build conda/ --python 3.12 --override-channels -c conda-forge --no-anaconda-upload --output-folder ./dist/conda
+conda create -n openbench-conda --override-channels -c ./dist/conda -c conda-forge colm-openbench=3.0.0
+conda run -n openbench-conda openbench smoke-test
 ```
+
+The recipe installs dependencies through Conda rather than downloading them
+inside pip, then checks imports, dependency consistency, the CLI and bundled
+sample data. GUI/SSH and PDF extras remain optional, as with the PyPI install.
 
 Install from a GitHub checkout for development or local testing:
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "colm-openbench" %}
 {% set dist_name = name|replace("-", "_") %}
-{% set version = "3.0.0b16" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,12 +8,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: bd1f78abe46e0e7598c6f58184bdbec1a3359551a8a4682d6f9f597fa02a0eb9
+  sha256: 0c4238fc5841dff92a4b7a6d476bde9080dce324fd4b0bfdb0d140ef8dff3ea8
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - openbench = openbench.cli.main:cli
 
@@ -48,10 +48,17 @@ requirements:
     - f90nml >=1.4.4
 
 test:
+  requires:
+    - pip
   imports:
     - openbench
+    - openbench.config
+    - openbench.data.registry
   commands:
+    - python -m pip check
     - openbench --version
+    - openbench model list
+    - openbench smoke-test
 
 about:
   home: https://github.com/CoLM-SYSU/OpenBench

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ dist_name }}-{{ version }}.tar.gz
-  sha256: 0c4238fc5841dff92a4b7a6d476bde9080dce324fd4b0bfdb0d140ef8dff3ea8
+  sha256: 9774243ae91ca72d52f79e1aa0887a2507d157f3fe7fae336074284740b72bff
 
 build:
   noarch: python

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,7 @@
 # Releasing OpenBench 3.0
 
 This is a preparation checklist, not a record of publication or a version change.
-Do not upload a rebuilt beta over the existing release, or reuse old local `dist/`
-artifacts.
+Do not overwrite an existing release or reuse old local `dist/` artifacts.
 
 ## 1. Finalize the release inputs
 
@@ -72,6 +71,21 @@ it is an installed-wheel check, not proof of a clean dependency resolution.
 ## 5. Publish deliberately
 
 Only after review and CI pass: use the approved release/tag and upload process.
+Upload the exact verified wheel and sdist with `python -m twine upload`, using the
+configured credential store rather than putting tokens in commands or logs.
+Verify PyPI's version-specific JSON metadata and download hashes after upload.
 The manual publish workflow runs the same artifact gate before uploading and
 requires separately configured PyPI/TestPyPI environments. No local cleanup or
 build command should trigger publication.
+
+## 6. Validate Conda installation
+
+The README documents both Conda-plus-PyPI installation and a native local Conda
+build. Test in a fresh environment, not `base`. The recipe's pip step must not
+resolve runtime dependencies or fetch build tools outside Conda's host environment.
+
+Before publishing, a temporary copy of the recipe may point to the verified local
+sdist for build/testing; the committed recipe must retain its PyPI URL and the
+same SHA-256. After PyPI publication, verify that URL resolves to the same archive.
+Run the recipe's dependency, CLI and bundled-data smoke checks. Do not claim a
+conda-forge release until the feedstock and channel package actually exist.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,6 +33,7 @@ headless tests do not prove real SSH/HPC connectivity or every optional backend.
 ## 3. Build and inspect fresh artifacts
 
 Install the build tools in the release environment (`build`, `twine`, `pytest`).
+Use a clean checkout of the release commit, not a working tree with local files.
 The following shell commands use a new directory and leave existing `dist/` alone:
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ authors = [
 ]
 keywords = ["land surface model", "benchmarking", "evaluation", "climate", "earth science"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ exclude = [
 # By default sdist would pick up everything in the working tree —
 # including any output/cache directories created by ad-hoc test runs
 # (the previous sdist artifact was 13 GB for exactly this reason).
-include = [
+only-include = [
     "src/openbench",
     "tests",
     "README.md",

--- a/src/openbench/__init__.py
+++ b/src/openbench/__init__.py
@@ -1,6 +1,6 @@
 """OpenBench: Open Source Land Surface Model Benchmarking System."""
 
-__version__ = "3.0.0b16"
+__version__ = "3.0.0"
 __author__ = "Zhongwang Wei, CoLM-SYSU"
 __title__ = "OpenBench"
 __description__ = "Land Surface Model Benchmarking System"

--- a/tests/test_build_artifacts.py
+++ b/tests/test_build_artifacts.py
@@ -170,6 +170,15 @@ def test_sdist_has_no_forbidden_files() -> None:
     )
 
 
+def test_sdist_contains_only_release_inputs() -> None:
+    root_files = {"README.md", "LICENSE", "pyproject.toml", "CHANGELOG.md", "PKG-INFO", ".gitignore"}
+    paths = [member.split("/", 1)[1] for member in _sdist_members()]
+    unexpected = [
+        path for path in paths if path not in root_files and not path.startswith(("src/openbench/", "tests/"))
+    ]
+    assert not unexpected, f"Sdist contains files outside the release inputs: {unexpected}"
+
+
 @pytest.mark.parametrize("archive_members", [_wheel_members, _sdist_members], ids=["wheel", "sdist"])
 def test_archives_contain_required_data_files(archive_members) -> None:
     """Sanity: the registry YAML files MUST ship in the wheel."""

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,57 @@
+"""Keep PyPI and Conda release metadata aligned."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from jinja2 import Environment, StrictUndefined
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+from openbench import __version__
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def metadata():
+    recipe_path = ROOT / "conda/meta.yaml"
+    if not recipe_path.is_file():
+        pytest.skip("Conda recipe is a repository-only release input")
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+    template = Environment(undefined=StrictUndefined).from_string(recipe_path.read_text(encoding="utf-8"))
+    recipe = yaml.safe_load(template.render(PYTHON=sys.executable))
+    return project, recipe
+
+
+def test_pypi_and_conda_versions_and_release_status_agree(metadata):
+    project, recipe = metadata
+    assert recipe["package"] == {"name": project["name"], "version": __version__}
+    status = "4 - Beta" if Version(__version__).is_prerelease else "5 - Production/Stable"
+    assert f"Development Status :: {status}" in project["classifiers"]
+    assert recipe["source"]["url"].endswith(f"/colm_openbench-{__version__}.tar.gz")
+    assert len(recipe["source"]["sha256"]) == 64
+
+
+def test_conda_installs_the_declared_runtime_without_pip_dependency_resolution(metadata):
+    project, recipe = metadata
+    requirements = dict(item.lower().split(maxsplit=1) for item in recipe["requirements"]["run"])
+    assert requirements.pop("python") == project["requires-python"]
+    aliases = {"matplotlib": "matplotlib-base"}
+    for item in project["dependencies"]:
+        dependency = Requirement(item)
+        name = aliases.get(dependency.name.lower(), dependency.name.lower())
+        assert requirements.pop(name) == str(dependency.specifier)
+        if dependency.name == "dask" and "distributed" in dependency.extras:
+            assert requirements.pop("distributed") == str(dependency.specifier)
+    assert not requirements
+    assert "--no-deps" in recipe["build"]["script"]
+    assert "--no-build-isolation" in recipe["build"]["script"]
+    assert recipe["build"]["entry_points"] == [f"openbench = {project['scripts']['openbench']}"]
+    assert {"python -m pip check", "openbench --version", "openbench smoke-test"} <= set(recipe["test"]["commands"])


### PR DESCRIPTION
## Purpose
Release the audited **main** branch as stable **3.0.0**, with matching PyPI and Conda metadata. The uncertainty development branch is intentionally separate.

## Changes
- Set package version to 3.0.0 and Production/Stable; finalize the changelog.
- Document an isolated Conda scientific-stack + PyPI install and a native local Conda build, without claiming a nonexistent conda-forge publication.
- Pin the recipe to the verified sdist SHA-256; avoid pip dependency resolution during Conda builds and exercise installed CLI/resources.
- Add regression checks for version, classifier, dependency and entry-point parity.
- Restrict source archives to explicit release inputs: the regression failed on a nested local README and passes after the Hatch selection fix.

## Verification
- Full local suite: **2381 passed, 5 skipped** (unavailable external data).
- Fresh isolated sdist/wheel: **22 artifact checks passed**, `twine check` passed.
- Ruff lint/format and `git diff --check` passed.
- Native Conda package build, recipe tests, and full evaluation in a fresh Python 3.12 install passed.
- Fresh Python 3.12 Conda + pip environment: dependency check and full bundled evaluation passed.
- A clean committed-tree build reproduces the exact validated wheel/sdist hashes.
- Independent review found no release blockers. Fresh GitHub CI: all **11 checks passed**, including Linux/macOS/Windows × Python 3.10/3.11/3.12.

`Openbench-with-Uncertainty-task/` remains local-only and is absent from Git and both package archives. No PyPI package has been uploaded yet.
